### PR TITLE
make it clearer that `packageExtensions` can only be set at root package

### DIFF
--- a/docs/package_json.md
+++ b/docs/package_json.md
@@ -220,11 +220,15 @@ For example:
 
 ## pnpm.overrides
 
+:::note
+
+If you are using workspace, `overrides` can only be set at the root package.
+
+:::
+
 This field allows you to instruct pnpm to override any dependency in the
 dependency graph. This is useful to enforce all your packages to use a single
 version of a dependency, backport a fix, or replace a dependency with a fork.
-
-Note that the overrides field can only be set at the root of the project.
 
 An example of the `"pnpm"."overrides"` field:
 
@@ -274,6 +278,12 @@ The referenced package does not need to match the overridden one:
 ```
 
 ## pnpm.packageExtensions
+
+:::note
+
+If you are using workspace, `packageExtensions` can only be set at the root package.
+
+:::
 
 The `packageExtensions` fields offer a way to extend the existing package definitions with additional information. For example, if `react-redux` should have `react-dom` in its `peerDependencies` but it has not, it is possible to patch `react-redux` using `packageExtensions`:
 


### PR DESCRIPTION
# Context

I spent quite a bit of time debugging my package.json, until I found this comment https://github.com/pnpm/pnpm/issues/4097#issuecomment-1044454589

I think this caveat should be made clearer in the documentation.

