### PR TITLE
Document `pnpm install`'s `--no-lockfile` option

### DIFF
--- a/docs/cli/install.md
+++ b/docs/cli/install.md
@@ -66,10 +66,7 @@ were already installed, regardless of the `NODE_ENV`.
 
 ### --no-lockfile
 
-* Default: **false**
-* Type: **Boolean**
-
-If `true`, pnpm doesn't read or generate a `pnpm-lock.yaml` file.
+Don't read or generate a `pnpm-lock.yaml` file.
 
 ### --lockfile-only
 

--- a/docs/cli/install.md
+++ b/docs/cli/install.md
@@ -64,6 +64,13 @@ were already installed, regardless of the `NODE_ENV`.
 
 `optionalDependencies` are not installed.
 
+### --no-lockfile
+
+* Default: **false**
+* Type: **Boolean**
+
+If `true`, pnpm doesn't read or generate a `pnpm-lock.yaml` file.
+
 ### --lockfile-only
 
 * Default: **false**


### PR DESCRIPTION
https://pnpm.io/cli/install doesn't currently list this option.

References:
- [pnpm/pnpm/pkg-manager/plugin-commands-installation/src/install.ts#L122-L125](https://github.com/pnpm/pnpm/blob/002f6febe489ffefb004110ee5c83c8c2ff80fd2/pkg-manager/plugin-commands-installation/src/install.ts#L122-L125)
- [pnpm/pnpm/pnpm/test/install/misc.ts#L50-L58](https://github.com/pnpm/pnpm/blob/002f6febe489ffefb004110ee5c83c8c2ff80fd2/pnpm/test/install/misc.ts#L50-L58)