### PR TITLE
Improve font fmaily

### DIFF
--- a/src/css/customTheme.css
+++ b/src/css/customTheme.css
@@ -6,6 +6,7 @@
   --ifm-color-primary-dark: #F0850A;
   --ifm-color-primary-darker: #E37D09;
   --ifm-color-primary-darkest: #BB6708;
+  --ifm-font-family-base: -apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,Noto Sans,sans-serif,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
 }
 
 .header-github-link::before {


### PR DESCRIPTION
The default font-family in tailwind is very Mac-centric and lacks consideration for Windows environments, especially CJK Windows environments.(Note: https://infinnie.github.io/blog/2017/systemui.html)

Currently, tailwind's font-family for sans serif is preceded by system-ui, which results in rendering Malgun Gothic instead of Segoe UI in Korean window environments. Malgun Gothic's readability in English is horrendously bad. This PR fixes that issue.

![screenshot 2023-08-20 163545](https://github.com/pnpm/pnpm.io/assets/56965274/d78f3639-90bb-4554-97a2-018ee7e0a1cd)
This is a screenshot of the at-proto site in a Korean Windows environment. You can see that the English is not very readable.

![screenshot 2023-08-20 163557](https://github.com/pnpm/pnpm.io/assets/56965274/564bda40-ed94-4cad-b370-2cde181d8f63)
This is a screenshot taken after removing system-ui from the font-family. You can see that the Segoe ui is rendered and is more readable.