### PR TITLE
docs: correct pkg env usage for exec cli

### DIFF
--- a/docs/cli/exec.md
+++ b/docs/cli/exec.md
@@ -56,7 +56,7 @@ pnpm -r exec rm -rf node_modules
 View package information for all packages. This should be used with the `--shell-mode` (or `-c`) option for the environment variable to work.
 
 ```
-pnpm -rc exec pnpm view $PNPM_PACKAGE_NAME
+pnpm -rc exec pnpm view \$PNPM_PACKAGE_NAME
 ```
 
 ### --resume-from &lt;package_name\>

--- a/versioned_docs/version-7.x/cli/exec.md
+++ b/versioned_docs/version-7.x/cli/exec.md
@@ -56,7 +56,7 @@ pnpm -r exec rm -rf node_modules
 View package information for all packages. This should be used with the `--shell-mode` (or `-c`) option for the environment variable to work.
 
 ```
-pnpm -rc exec pnpm view $PNPM_PACKAGE_NAME
+pnpm -rc exec pnpm view \$PNPM_PACKAGE_NAME
 ```
 
 ### --resume-from &lt;package_name\>

--- a/versioned_docs_archived/version-2.x/cli/recursive.md
+++ b/versioned_docs_archived/version-2.x/cli/recursive.md
@@ -103,7 +103,7 @@ Examples:
 # prune node_modules installations for all packages
 pnpm -r exec -- rm -rf node_modules
 # view package information for all packages
-pnpm -r exec -- pnpm view $PNPM_PACKAGE_NAME
+pnpm -r exec -- pnpm view \$PNPM_PACKAGE_NAME
 ```
 
 ### --filter &lt;package_selector\>

--- a/versioned_docs_archived/version-2.x/pnpm-recursive.md
+++ b/versioned_docs_archived/version-2.x/pnpm-recursive.md
@@ -342,5 +342,5 @@ Usage examples:
 
 ```sh
 pnpm recursive exec -- rm -rf node_modules
-pnpm recursive exec -- pnpm view $PNPM_PACKAGE_NAME
+pnpm recursive exec -- pnpm view \$PNPM_PACKAGE_NAME
 ```

--- a/versioned_docs_archived/version-3.x/cli/recursive.md
+++ b/versioned_docs_archived/version-3.x/cli/recursive.md
@@ -77,5 +77,5 @@ Usage examples:
 
 ```sh
 pnpm recursive exec -- rm -rf node_modules
-pnpm recursive exec -- pnpm view $PNPM_PACKAGE_NAME
+pnpm recursive exec -- pnpm view \$PNPM_PACKAGE_NAME
 ```

--- a/versioned_docs_archived/version-3.x/pnpm-recursive.md
+++ b/versioned_docs_archived/version-3.x/pnpm-recursive.md
@@ -347,5 +347,5 @@ Usage examples:
 
 ```sh
 pnpm recursive exec -- rm -rf node_modules
-pnpm recursive exec -- pnpm view $PNPM_PACKAGE_NAME
+pnpm recursive exec -- pnpm view \$PNPM_PACKAGE_NAME
 ```

--- a/versioned_docs_archived/version-4.x/cli/recursive.md
+++ b/versioned_docs_archived/version-4.x/cli/recursive.md
@@ -77,5 +77,5 @@ Usage examples:
 
 ```sh
 pnpm recursive exec -- rm -rf node_modules
-pnpm recursive exec -- pnpm view $PNPM_PACKAGE_NAME
+pnpm recursive exec -- pnpm view \$PNPM_PACKAGE_NAME
 ```

--- a/versioned_docs_archived/version-4.x/pnpm-recursive.md
+++ b/versioned_docs_archived/version-4.x/pnpm-recursive.md
@@ -347,5 +347,5 @@ Usage examples:
 
 ```sh
 pnpm recursive exec -- rm -rf node_modules
-pnpm recursive exec -- pnpm view $PNPM_PACKAGE_NAME
+pnpm recursive exec -- pnpm view \$PNPM_PACKAGE_NAME
 ```

--- a/versioned_docs_archived/version-5.x/cli/recursive.md
+++ b/versioned_docs_archived/version-5.x/cli/recursive.md
@@ -103,7 +103,7 @@ Examples:
 # prune node_modules installations for all packages
 pnpm -r exec -- rm -rf node_modules
 # view package information for all packages
-pnpm -r exec -- pnpm view $PNPM_PACKAGE_NAME
+pnpm -r exec -- pnpm view \$PNPM_PACKAGE_NAME
 ```
 
 ### --filter &lt;package_selector\>

--- a/versioned_docs_archived/version-6.x/cli/exec.md
+++ b/versioned_docs_archived/version-6.x/cli/exec.md
@@ -58,7 +58,7 @@ pnpm -r exec rm -rf node_modules
 View package information for all packages. This should be used with the `--shell-mode` (or `-c`) option for the environment variable to work.
 
 ```
-pnpm -rc exec pnpm view $PNPM_PACKAGE_NAME
+pnpm -rc exec pnpm view \$PNPM_PACKAGE_NAME
 ```
 
 ### --parallel


### PR DESCRIPTION
## Description

Correct `$PNPM_PACKAGE_NAME` usage for `exec` cli documentation, because `$PNPM_PACKAGE_NAME` still empty when we execute `pnpm -rc exec pnpm view $PNPM_PACKAGE_NAME`, this command equivalent to `pnpm -rc exec pnpm view `.

So we should to escape it, to save the original token for execute the real command we expect.

Another question, why `pnpm -rc exec pnpm view $PNPM_PACKAGE_NAME` looks work? Because even if there are no cli argument, `pnpm view` can also works in package directory.