### PR TITLE
add --reporter-hide-prefix

### DIFF
--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -198,6 +198,7 @@ An example of a `pnpm-exec-summary.json` file:
 Possible values of `status` are: 'passed', 'queued', 'running'.
 
 ### --reporter-hide-prefix
+
 Hide workspace prefix from output from child processes that are run in parallel, and only print the raw output. This can be useful if you are running on CI and the output must be in a specific format without any prefixes (e.g. [GitHub Actions annotations](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message)). Only `--reporter=append-only` is supported.
 
 ### --filter &lt;package_selector\>

--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -199,6 +199,8 @@ Possible values of `status` are: 'passed', 'queued', 'running'.
 
 ### --reporter-hide-prefix
 
+Added in: v8.8.0
+
 Hide workspace prefix from output from child processes that are run in parallel, and only print the raw output. This can be useful if you are running on CI and the output must be in a specific format without any prefixes (e.g. [GitHub Actions annotations](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message)). Only `--reporter=append-only` is supported.
 
 ### --filter &lt;package_selector\>

--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -197,6 +197,9 @@ An example of a `pnpm-exec-summary.json` file:
 
 Possible values of `status` are: 'passed', 'queued', 'running'.
 
+### --reporter-hide-prefix
+Hide workspace prefix from output from child processes that are run in parallel, and only print the raw output. This can be useful if you are running on CI and the output must be in a specific format without any prefixes (e.g. [GitHub Actions annotations](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message)). Only `--reporter=append-only` is supported.
+
 ### --filter &lt;package_selector\>
 
 [Read more about filtering.](../filtering.md)


### PR DESCRIPTION
See https://github.com/pnpm/pnpm/issues/7061

On a sidenote: the option `--reporter=<name>` is only documented on the [install command](http://localhost:3000/cli/install#--reportername), even though it's also valid for the [run command](http://localhost:3000/cli/run#--aggregate-output) and mentioned in there. If you want, I could copy the reporter block over to run.

Let me know what you think.