### PR TITLE
Docs: Fix git-branch-lockfile property name

### DIFF
--- a/docs/git_branch_lockfiles.md
+++ b/docs/git_branch_lockfiles.md
@@ -10,7 +10,7 @@ Git branch lockfiles allows you to totally avoid lockfile merge conflicts and so
 You can turn on this feature by configuring the `.npmrc` file.
 
 ```ini
-git-branch-lockfiles=true
+git-branch-lockfile=true
 ```
 
 By doing this, lockfile name will be generated based on the current branch name.


### PR DESCRIPTION
The .npmrc config page includes the correct property name, which is singular, not plural.