### PR TITLE
Fix to documentation for `git-branch-lockfile`.

### DIFF
--- a/versioned_docs/version-7.x/git_branch_lockfiles.md
+++ b/versioned_docs/version-7.x/git_branch_lockfiles.md
@@ -12,7 +12,7 @@ Git branch lockfiles allows you to totally avoid lockfile merge conflicts and so
 You can turn on this feature by configuring the `.npmrc` file.
 
 ```ini
-git-branch-lockfiles=true
+git-branch-lockfile=true
 ```
 
 By doing this, lockfile name will be generated based on the current branch name.


### PR DESCRIPTION
Changes incorrect `git-branch-lockfiles` config option to `git-branch-lockfile` in v7 docs. The correct name is already used in the v8 docs.