### PR TITLE
Replace /dev path with /usr/src/app in docker example

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -107,8 +107,8 @@ ENV PATH="$PNPM_HOME:$PATH"
 RUN corepack enable
 
 FROM base AS build
-COPY . /dev
-WORKDIR /dev
+COPY . /usr/src/app
+WORKDIR /usr/src/app
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
 RUN pnpm run -r build
 RUN pnpm deploy --filter=app1 --prod /prod/app1


### PR DESCRIPTION
/dev is a reserved path on linux for hardware mount points, the example as it stands currently will not work, as COPY . /dev does not actually copy files and the install command afterwards fails