### PR TITLE
Add --dir option to run.md

### DIFF
--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -102,6 +102,11 @@ will run:
 webpack --watch --no-color
 ```
 
+### --dir, -C &lt;dir&gt;
+
+Run the command from the directory &lt;dir&gt;.  
+Default is the current directory.
+
 ### --recursive, -r
 
 This runs an arbitrary command from each package's "scripts" object.


### PR DESCRIPTION
We can see that some options are only available in CLI `--help` command but not in the documentation.  
I noticed that the `--dir` is usefull so I wanted to add it.  

Maybe there are other options that should be added ?