### PR TITLE
docs: fix json for pnpm-publish-summary.json example

### DIFF
--- a/docs/cli/publish.md
+++ b/docs/cli/publish.md
@@ -85,8 +85,8 @@ An example of a `pnpm-publish-summary.json` file:
       "name": "bar",
       "version": "2.0.0"
     }
-  }
-]
+  ]
+}
 ```
 
 ### --dry-run


### PR DESCRIPTION
As the title suggests, the JSON example had a typo. 