### PR TITLE
Change title of installation script "In Alpine Linux" to "In docker container"

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -31,7 +31,7 @@ If you don't have curl installed, you would like to use wget:
 wget -qO- https://get.pnpm.io/install.sh | sh -
 ```
 
-### On Alpine Linux
+### In docker container
 
 ```sh
 # bash


### PR DESCRIPTION
Because the POXIS script that can install pnpm on Mac and Linux doesn't work in all docker containers, not just doesn't work in Alpine.

Fix #477 
