### PR TITLE
Update changesets instructions to use install command with --no-frozen-lockfile flag

### DIFF
--- a/docs/using-changesets.md
+++ b/docs/using-changesets.md
@@ -36,7 +36,7 @@ to the repository.
 1. Run `pnpm changeset version`. This will bump the versions of the packages
    previously specified with `pnpm changeset` (and any dependents of those) and
    update the changelog files.
-2. Run `pnpm install`. This will update the lockfile and rebuild packages.
+2. Run `pnpm install --no-frozen-lockfile`. This will update the lockfile and rebuild packages.
 3. Commit the changes.
 4. Run `pnpm publish -r`. This command will publish all packages that have
    bumped versions not yet present in the registry.


### PR DESCRIPTION
When running `pnpm install` in CI environments after running `pnpm changeset tag`, install fails because it's attempting to use a frozen lockfile and that frozen lockfile is now out of date with the bumped dependencies. Edit docs to specifically use `pnpm install --no-frozen-lockfile`, so that the lockfile is updated after packages are bumped.