### PR TITLE
Docs: For pnpm run -r, remove inaccurate mention of the command failing when script is not defined in any package. 

### DIFF
--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -106,7 +106,6 @@ webpack --watch --no-color
 
 This runs an arbitrary command from each package's "scripts" object.
 If a package doesn't have the command, it is skipped.
-If none of the packages have the command, the command fails.
 
 ### --if-present
 


### PR DESCRIPTION
In the [current docs](https://pnpm.io/cli/run#--recursive--r) for `pnpm run --recursive`:
```
If none of the packages have the command, the command fails.
```
However, the command still exits with `0` for this case, so saying "the command fails" seems misleading. An error message is printed, but to consider the command as truly failed I'd typically expect it to also have a non-zero exit status (likely `1`).  This PR just removes that line from the description.

Example of current behavior (`0` status is logged at the end):
<img width="461" alt="image" src="https://github.com/pnpm/pnpm.io/assets/12928449/930d35c9-dd6a-4c12-a0a0-f96395d776d6">

As an alternative to changing this doc (or as a future consideration), I think there's an argument for changing `pnpm run -r` to exit 1 for this case (as well as for the similar case with `-F`), consistent with the current `pnpm run` behavior without those flags. As an example scenario where that would be preferable, my original catalyst for opening this was having the command unexpectedly not fail the CI pipeline when there was a typo in the script name. `--if-present` would still be available to override this if needed, but it could be less surprising to fail by default.

@zkochan I saw your comment here a few months ago about not proceeding with that change at the time: https://github.com/pnpm/pnpm/pull/6852#issuecomment-1650693358, but is there any interest in reopening that discussion? If so I'd be happy to make a PR to consider. Thanks!
