### PR TITLE
chore: add documentation for use-node-version

### DIFF
--- a/docs/cli/env.md
+++ b/docs/cli/env.md
@@ -106,3 +106,10 @@ pnpm env list --remote 16
 
 The changes are made systemwide.
 
+## Managing Versions
+
+Add a `use-node-version` directive to `.npmrc` to make pnpm default to that node version when running scripts in your project:
+
+```
+use-node-version=18.17.1
+```


### PR DESCRIPTION
I'm a long time user of pnpm but only noticed this information today when watching the youtube video, it would be nice to have support for `engines` in package.json or `.node-version`, but that's a separate issue