### PR TITLE
Fix placeholder in header

### DIFF
--- a/docs/filtering.md
+++ b/docs/filtering.md
@@ -181,7 +181,7 @@ source code of the package, tests will run in the dependent packages as well:
 pnpm --filter="...[origin/master]" --test-pattern="test/*" test
 ```
 
-## --changed-files-ignore-pattern &ltglob>
+## --changed-files-ignore-pattern &lt;glob>
 
 Allows to ignore changed files by glob patterns when filtering for changed projects since the specified commit/branch.
 


### PR DESCRIPTION
Due to the missing semicolon, this was rendering as `&ltglob>` instead of the intended `<glob>`

<img alt="Screenshot of the docs site showing the incorrectly rendered headline" width="749" src="https://github.com/pnpm/pnpm.io/assets/520420/3f5f4124-8601-4382-898a-a9d2d83431a2" />
