### PR TITLE
docs: add Material UI to the showcase

### DIFF
--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -138,6 +138,7 @@ Here are a few of the most popular open source projects that use the workspace f
 | Project | Stars | Migration date | Migration commit |
 | --      | --    | --             | --               |
 | [Next.js](https://github.com/vercel/next.js) | ![](https://img.shields.io/github/stars/vercel/next.js) | 2022-05-29 | `f7b81316aea4fc9962e5e54981a6d559004231aa` |
+| [Material UI](https://github.com/mui/material-ui) | ![](https://img.shields.io/github/stars/mui/material-ui) | 2024-01-03 | `a1263e3e5ef8d840252b4857f85b33caa99f471d` |
 | [Vite](https://github.com/vitejs/vite) | ![](https://img.shields.io/github/stars/vitejs/vite) | 2021-09-26 | `3e1cce01d01493d33e50966d0d0fd39a86d229f9` |
 | [Nuxt](https://github.com/nuxt/nuxt) | ![](https://img.shields.io/github/stars/nuxt/nuxt) | 2022-10-17 | `74a90c566c936164018c086030c7de65b26a5cb6` |
 | [Vue 3.0](https://github.com/vuejs/vue-next) | ![](https://img.shields.io/github/stars/vuejs/vue-next) | 2021-10-09 | `61c5fbd3e35152f5f32e95bf04d3ee083414cecb` |


### PR DESCRIPTION
I added Material UI in the same sort DESC stars order. The PR in question: https://github.com/mui/material-ui/pull/36287.

The page: https://pnpm.io/workspaces#usage-examples.

Hopefully, this will further help convince developers that pnpm is now a better choice than yarn. I mean, I think that developers who are considering pnpm should see this list, this looks like a very powerful marketing tool to me, maybe to make it easier to discover from the homepage. 