### PR TITLE
docs: improve explanation of --prod flag

### DIFF
--- a/docs/cli/install.md
+++ b/docs/cli/install.md
@@ -60,7 +60,7 @@ determining the environment.
 
 If `true`, pnpm will not install any package listed in `devDependencies` and will remove 
 those insofar they were already installed.
-If `false`, pnpm will install all packages listed in `devDependencies` and `dependencies`
+If `false`, pnpm will install all packages listed in `devDependencies` and `dependencies`.
 
 ### --dev, -D
 

--- a/docs/cli/install.md
+++ b/docs/cli/install.md
@@ -50,10 +50,17 @@ will be requested from the server. To force full offline mode, use `--offline`.
 
 ### --prod, -P
 
-pnpm will not install any package listed in `devDependencies` and will remove 
-those insofar they were already installed, if the `NODE_ENV` environment variable 
-is set to production. Use this flag to instruct pnpm to ignore `NODE_ENV` and take
-its production status from this flag instead.
+* Default:
+  * If `NODE_ENV` is `production`: `true`
+  * If `NODE_ENV` is **not** `production`: `false`
+* Type: Boolean
+
+If set, pnpm will ignore `NODE_ENV` and instead use this boolean value for
+determining the environment.
+
+If `true`, pnpm will not install any package listed in `devDependencies` and will remove 
+those insofar they were already installed.
+If `false`, pnpm will install all packages listed in `devDependencies` and `dependencies`
 
 ### --dev, -D
 


### PR DESCRIPTION
The `--prod` flag for the `pnpm install` command is not well displayed as a boolean value.
It is unclear that one can use the flag like this `pnpm install --prod=false` to use a "development" install in a production environment. This has already happened to some people: https://github.com/pnpm/pnpm/issues/6254 

This PR tries to explain the option a bit better, so its use-case is a bit more clear, and aims to make the docs page more consistent.

I took inspiration from how the `--frozen-lockfile` option works: https://pnpm.io/cli/install#--frozen-lockfile

