### PR TITLE
Fix CircleCI caching config

### DIFF
--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -212,6 +212,7 @@ jobs:
           command: |
             corepack enable
             corepack prepare pnpm@latest-8 --activate
+            pnpm config set store-dir .pnpm-store
       - run:
           name: Install Dependencies
           command: |
@@ -220,7 +221,7 @@ jobs:
           name: Save pnpm Package Cache
           key: pnpm-packages-{{ checksum "pnpm-lock.yaml" }}
           paths:
-            - node_modules
+            - .pnpm-store
 ```
 
 ## Jenkins


### PR DESCRIPTION
My understanding of how pnpm caching works means that the pnpm store should get cached, not `node_modules`.

This brings the CircleCI config inline with the other examples.