### PR TITLE
Add `--workspace-concurrency` to `run` docs

### DIFF
--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -121,6 +121,16 @@ immediately in all matching packages with prefixed streaming output. This is the
 preferred flag for long-running processes over many packages, for instance, a
 lengthy build process.
 
+### --workspace-concurrency
+
+* Default: **4**
+* Type: **Number**
+
+Set the maximum number of tasks to run simultaneously. For unlimited concurrency
+use `Infinity`.
+
+You can set the `workpace-concurrency` as `<= 0` and it will use amount of cores of the host as: `max(1, (number of cores) - abs(workspace-concurrency))`
+
 ### --stream
 
 Stream output from child processes immediately, prefixed with the originating


### PR DESCRIPTION
This has been a point of confusion for me for a while. I almost never use `-r` and instead use `--filter` to run my scripts. I've used:

`pnpm -F packageA -F packageB -F packageC --workspace-concurrency=1 scriptName`

Quite a bit and it works. I've always wondered why `--workspace-concurrency` was only buried in the recursive docs. The command above I believe is really just syntactic sugar for:

`pnpm -F packageA -F packageB -F packageC --workspace-concurrency=1 run scriptName`

So I think this is the right place for this to be documented? Or is It more of a global option? I assuming using `--filter` has nothing to do with recursive mode? It seems like it can be used to have a similar effect but is completely different tool.