### PR TITLE
docs: Bump `actions/setup-node` from v3 to v4

### DIFF
--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -95,7 +95,7 @@ jobs:
       with:
         version: 8
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'pnpm'


### PR DESCRIPTION
Bumps the version for the `actions/setup-node` GitHub Action from v3 to v4. 

v4 has been around since October of last year. You can see the release notes here: https://github.com/actions/setup-node/releases/tag/v4.0.0

Only real change was bumping the Node version and the version of a few dependencies. The interface for providing `cache: 'pnpm'` does not change.
