### PR TITLE
Update using-changesets.md

### DIFF
--- a/docs/using-changesets.md
+++ b/docs/using-changesets.md
@@ -58,7 +58,8 @@ It will publish to the registry once the PR is opened by `changeset version`.
 ```json
 {
    "scripts": {
-      "ci:publish": "pnpm publish -r"
+      "ci:publish": "pnpm changeset version",
+      "ci:publish": "pnpm publish -r --no-git-checks"
    },
    ...
 }


### PR DESCRIPTION
i found an inconsistency between the action and the proposed changes to package.json. the action expects there to be a script called ci:version as well so i put it in. 

there is another thing but its more of an issue. i'm litterally writing this as i find a fix. the other change im talking about is after i ran the action, it works but it also commited the entirety of .pnpm-store/ into the root. which i think is the cache.

thats one big .git/ dir