### PR TITLE
clarify link example

### DIFF
--- a/docs/cli/link.md
+++ b/docs/cli/link.md
@@ -26,7 +26,7 @@ Changes the link location to `<dir>`.
 
 Links package from `<dir>` folder to node_modules of package from where you're executing this command or specified via `--dir` option.
 
-> For example, if you are inside `~/projects/foo` and you execute `pnpm link --dir ../bar`, then `foo` will be linked to `bar/node_modules/foo`.
+> For example, if you are inside `~/projects/foo` and you execute `pnpm link ../bar`, then a link to `bar` will be created in `foo/node_modules/bar`.
 
 ### `pnpm link --global`
 


### PR DESCRIPTION
I switched the example to be about the `link <dir>` case instead of the `link --dir <dir>` case, and made the text more readable.

Other examples in the same doc page use `foo` as the dependent and `bar` as the dependency, therefore it's easier to understand the example if that convention is kept.

Also, the case without `--dir` seems to be the "basic case" that is used more often, so for a beginner who's first reading about all of this it makes more sense to introduce that one first. The title of the section also suggests that we're primarily talking about the case without `--dir`.

When I first read the documentation, I misread the command and didn't notice the `--dir` argument, and then misunderstood how the command works, i.e. I first thought the roles of the packages would be reversed to what they actually are.

I hope you find the updated example clearer as well, and if not feel free to close 🙂