### PR TITLE
Updated link to npm's peer dependency documentation

### DIFF
--- a/docs/how-peers-are-resolved.md
+++ b/docs/how-peers-are-resolved.md
@@ -7,7 +7,7 @@ One of the best features of pnpm is that in one project, a specific version of a
 package will always have one set of dependencies. There is one exception from
 this rule, though - packages with [peer dependencies].
 
-[peer dependencies]: https://docs.npmjs.com/files/package.json#peerdependencies
+[peer dependencies]: https://docs.npmjs.com/cli/v10/configuring-npm/package-json#peerdependencies
 
 Peer dependencies are resolved from dependencies installed higher in the
 dependency graph, since they share the same version as their parent. That means


### PR DESCRIPTION
The page that the old link points to appears to have moved. The old link still leads to the correct page, due to redirecting on NPM's side, but the link to the #peerdependencies id no longer appears to work.