### PR TITLE
docs: add a missing comma to an example of publishConfig.linkDirectory

### DIFF
--- a/docs/package_json.md
+++ b/docs/package_json.md
@@ -217,7 +217,7 @@ For example:
   "name": "foo",
   "version": "1.0.0",
   "publishConfig": {
-    "directory": "dist"
+    "directory": "dist",
     "linkDirectory": true
   }
 }


### PR DESCRIPTION
An example in docs was m.issing comma and I couldn't leave it like that.

Here is a [link to docs](https://pnpm.io/package_json#publishconfiglinkdirectory)