### PR TITLE
docs(exec): correct examples section

### DIFF
--- a/docs/cli/exec.md
+++ b/docs/cli/exec.md
@@ -45,10 +45,6 @@ Execute the shell command in every project of the workspace.
 The name of the current package is available through the environment variable
 `PNPM_PACKAGE_NAME`.
 
-### --no-reporter-hide-prefix
-
-Do not hide prefix when running commands in parallel.
-
 #### Examples
 
 Prune `node_modules` installations for all packages:
@@ -62,6 +58,10 @@ View package information for all packages. This should be used with the `--shell
 ```
 pnpm -rc exec pnpm view \$PNPM_PACKAGE_NAME
 ```
+
+### --no-reporter-hide-prefix
+
+Do not hide prefix when running commands in parallel.
 
 ### --resume-from &lt;package_name\>
 


### PR DESCRIPTION
I just noticed that mistakenly I inserted `--no-reporter-hide-prefix` section into between the `--recursive, -r` section.