### PR TITLE
docs: list `pnpx` as alias for `pnpm dlx`

### DIFF
--- a/docs/cli/dlx.md
+++ b/docs/cli/dlx.md
@@ -3,6 +3,8 @@ id: dlx
 title: "pnpm dlx"
 ---
 
+Aliases: `pnpx` is an alias for `pnpm dlx`
+
 Fetches a package from the registry without installing it as a dependency, hotloads it, and runs whatever default command binary it exposes.
 
 For example, to use `create-react-app` anywhere to bootstrap a react app without


### PR DESCRIPTION
Other docs have aliases listed. E.g. https://pnpm.io/cli/update has `up` and `upgrade`

I wrote this one out in a bit longer format so that no one would think you should run `pnpm pnpx`