### PR TITLE
Update catalogs.md to include pnpm pack

### DIFF
--- a/docs/catalogs.md
+++ b/docs/catalogs.md
@@ -126,7 +126,7 @@ catalogs:
 
 ## Publishing
 
-The `catalog:` protocol is removed when running `pnpm publish`. This is similar to the [`workspace:` protocol](./workspaces.md#workspace-protocol-workspace), which is [also replaced on publish](./workspaces.md#publishing-workspace-packages).
+The `catalog:` protocol is removed when running `pnpm publish` or `pnpm pack`. This is similar to the [`workspace:` protocol](./workspaces.md#workspace-protocol-workspace), which is [also replaced on publish](./workspaces.md#publishing-workspace-packages).
 
 For example,
 


### PR DESCRIPTION
`pnpm pack` also removes the `catalog` protocol. I had to debug this locally to be sure but the documentation should be updated to clearly explain this.