### PR TITLE
chore(deploy): Add some clarrification for deploy packlist generation

### DIFF
--- a/docs/cli/deploy.md
+++ b/docs/cli/deploy.md
@@ -55,5 +55,8 @@ Packages in `devDependencies` won't be installed.
 
 ## Files included in the deployed project
 
-By default, all the files of the project are copied during deployment. The project's `package.json` may contain a "files" field to list the files and directories that should be copied.
+By default, all the files of the project are copied during deployment but this can be modified in _one_ of the following ways which are resolved in order:
 
+1. The project's `package.json` may contain a "files" field to list the files and directories that should be copied.
+2. If there is an `.npmignore` file in the application directory then any files listed here are ignored.
+3. If there is a `.gitignore` file in the application directory then any files listed here are ignored.


### PR DESCRIPTION
Closes https://github.com/pnpm/pnpm/issues//7286

The packlist generation used by pnpm deploy is significantly more complex than the docs currently suggest which resulted in a few lost hours for me figuring out why my `dist` directory was missing (it was .gitignored).

I believe the rules come from https://www.npmjs.com/package/npm-packlist or at least mimic the rules from that package but I couldn't follow the src in the time I had available to be honest.

Instead I made a test repo to check the behaviour described in this PR, it's over here if you want to check my work https://github.com/antiBaconMachine/pnpm-deploy-packlist-examples/tree/main.

If someone could confirm that deploy does indeed use npm-packlist then it might be better to just link straight to that more complete documentation, because there are almost certainly other cases I haven't covered here.

Thanks.