### PR TITLE
docs(continuous-integration.md): use corepack install instead of prepare

### DIFF
--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -23,7 +23,7 @@ cache:
     - "~/.pnpm-store"
 before_install:
   - corepack enable
-  - corepack prepare pnpm@latest-9 --activate
+  - corepack install pnpm@latest-9 --activate
   - pnpm config set store-dir ~/.pnpm-store
 install:
   - pnpm install
@@ -50,7 +50,7 @@ blocks:
         - name: pnpm install
           commands:
             - corepack enable
-            - corepack prepare pnpm@latest-9 --activate
+            - corepack install pnpm@latest-9 --activate
             - checkout
             - cache restore node-$(checksum pnpm-lock.yaml)
             - pnpm install
@@ -68,7 +68,7 @@ to your `appveyor.yml`:
 install:
   - ps: Install-Product node $env:nodejs_version
   - corepack enable
-  - corepack prepare pnpm@latest-9 --activate
+  - corepack install pnpm@latest-9 --activate
   - pnpm install
 ```
 
@@ -125,7 +125,7 @@ build:
   image: node:18.17.1
   before_script:
     - corepack enable
-    - corepack prepare pnpm@latest-9 --activate
+    - corepack install pnpm@latest-9 --activate
     - pnpm config set store-dir .pnpm-store
   script:
     - pnpm install # install dependencies
@@ -154,7 +154,7 @@ pipelines:
           image: node:18.17.1
           script:
             - corepack enable
-            - corepack prepare pnpm@latest-9 --activate
+            - corepack install pnpm@latest-9 --activate
             - pnpm install
             - pnpm run build # Replace with your build/test…etc. commands
           caches:
@@ -178,7 +178,7 @@ steps:
 
   - script: |
       corepack enable
-      corepack prepare pnpm@latest-9 --activate
+      corepack install pnpm@latest-9 --activate
       pnpm config set store-dir $(pnpm_config_cache)
     displayName: "Setup pnpm"
 
@@ -213,7 +213,7 @@ jobs:
           name: Install pnpm package manager
           command: |
             corepack enable
-            corepack prepare pnpm@latest-9 --activate
+            corepack install pnpm@latest-9 --activate
             pnpm config set store-dir .pnpm-store
       - run:
           name: Install Dependencies
@@ -242,7 +242,7 @@ pipeline {
         stage('Build') { 
             steps {
                 sh 'corepack enable'
-                sh 'corepack prepare pnpm@latest-9 --activate'
+                sh 'corepack install pnpm@latest-9 --activate'
                 sh 'pnpm install'
             }
         }


### PR DESCRIPTION
- [Closes #8380](https://github.com/pnpm/pnpm/issues/8380)