### PR TITLE
docs: improve working with cache doc

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -136,7 +136,7 @@ docker build . --target app2 --tag app2:latest
 
 ### Example 3: Build on CI/CD
 
-On CI or CD environments, the BuildKit cache mounts might now be available, because the VM or container is ephemeral and only normal docker cache will work.
+On CI or CD environments, the BuildKit cache mounts might not be available, because the VM or container is ephemeral and only normal docker cache will work.
 
 So an alternative is to use a typical Dockerfile with layers that are built incrementally, for this scenario, `pnpm fetch` is the best option, as it only needs the `pnpm-lock.yaml` file and the layer cache will only be lost when you change the dependencies.
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -138,7 +138,7 @@ docker build . --target app2 --tag app2:latest
 
 On CI or CD environments, the BuildKit cache mounts might now be available, because the VM or container is ephemeral and only normal docker cache will work.
 
-So an alternative is to use a typical Dockerfile with layers that are built incrementally.
+So an alternative is to use a typical Dockerfile with layers that are built incrementally, for this scenario, `pnpm fetch` is the best option, as it only needs the `pnpm-lock.yaml` file and the layer cache will only be lost when you change the dependencies.
 
 ```dockerfile title="Dockerfile"
 FROM node:20-slim AS base


### PR DESCRIPTION
On the docker documentation, most of the docker examples use BuildKit cache mounts, which are a great option locally or when building the image on only one machine, but when you're using a CI/CD pipeline, this kind of cache might not be available, and only normal docker cache will suffice (eg: Kaniko).

So I added an example for this scenario.