### PR TITLE
docs(completion): added completion command for fish shell

### DIFF
--- a/docs/completion.md
+++ b/docs/completion.md
@@ -21,6 +21,12 @@ pnpm completion bash > ~/completion-for-pnpm.bash
 echo 'source ~/completion-for-pnpm.bash' >> ~/.bashrc
 ```
 
+To setup autocompletion for Fish, run:
+
+```text
+pnpm completion fish > ~/.config/fish/completions/pnpm.fish
+```
+
 ## g-plane/pnpm-shell-completion
 
 [pnpm-shell-completion] is a shell plugin maintained by Pig Fang on Github.


### PR DESCRIPTION
## Added Fish Shell Completion Command to Documentation

This PR adds the command for generating pnpm autocompletions in the Fish shell to the completion documentation on [pnpm.io/completion](https://pnpm.io/completion), aligning it with the existing instructions for Bash.

```
pnpm completion fish > ~/.config/fish/completions/pnpm.fish
```
Local preview of the PR:

![image](https://github.com/user-attachments/assets/f70d33bc-e728-4f75-863e-71063f2dcbbf)
