### PR TITLE
Suggestion to re-title the .npmrc Configuration

### DIFF
--- a/docs/npmrc.md
+++ b/docs/npmrc.md
@@ -1,6 +1,6 @@
 ---
 id: npmrc
-title: ".npmrc"
+title: ".npmrc Main Configuration"
 ---
 
 pnpm gets its configuration from the command line, environment variables, and

--- a/docs/npmrc.md
+++ b/docs/npmrc.md
@@ -1,6 +1,6 @@
 ---
 id: npmrc
-title: ".npmrc Main Configuration"
+title: "Settings (.npmrc)"
 ---
 
 pnpm gets its configuration from the command line, environment variables, and


### PR DESCRIPTION
I had a rough time to figure out which page on the docs would tell me how to change the main directory on where packages get installed at and etc. until I figured out that the .npmrc page is the Main Configuration for the pnpm CLI.