### PR TITLE
Document pnpm dlx path

### DIFF
--- a/docs/cli/dlx.md
+++ b/docs/cli/dlx.md
@@ -14,13 +14,19 @@ needing to install it under another project, you can run:
 pnpm dlx create-react-app ./my-app
 ```
 
-This will fetch `create-react-app` from the registry and run it with the given arguments.
+This will fetch `create-react-app` from the registry, download it to a temporary location (see below) and run it with the given arguments.
 
 You may also specify which exact version of the package you'd like to use:
 
 ```
 pnpm dlx create-react-app@next ./my-app
 ```
+
+The temporary location of the downloaded files is:
+
+* On Windows: **~/AppData/Local/pnpm/dlx**
+* On macOS: **~/Library/Caches/pnpm/dlx**
+* On Linux: **~/.cache/pnpm/dlx**
 
 ## Options
 

--- a/docs/npmrc.md
+++ b/docs/npmrc.md
@@ -238,7 +238,7 @@ After executing a dlx command, pnpm keeps a cache that omits the installation st
   * On Linux: **~/.local/share/pnpm/store**
 * Type: **path**
 
-The location where all the packages are saved on the disk.
+The location where all the packages are saved on the disk (exception: [`pnpm dlx`](./cli/dlx.md)).
 
 The store should be always on the same disk on which installation is happening,
 so there will be one store per disk. If there is a home directory on the current


### PR DESCRIPTION
I was having trouble finding the location of packages such as `create-playwright` when running any of these commands:

```bash
pnp dlx create-playwright

pnpx create-playwright

pnpm create playwright
```

Not 100% sure I have the right paths on Windows and Linux

cc @KSXGitHub I think this may have been implemented in https://github.com/pnpm/pnpm/pull/7835