### PR TITLE
Update exec.md

### DIFF
--- a/docs/cli/exec.md
+++ b/docs/cli/exec.md
@@ -3,7 +3,8 @@ id: exec
 title: pnpm exec
 ---
 
-Execute a shell command in scope of a project.
+Execute a shell command in scope of a project, which means that it will always treat the project root as the current working directory,
+may lead to confusion when you run a command after changing to a subdirectory.
 
 `node_modules/.bin` is added to the `PATH`, so `pnpm exec` allows executing commands of dependencies.
 


### PR DESCRIPTION
For example, if you changed to a subdirectory called "foo/" which has a "bar.css" under it, and then you execute "pnpm exec postcss bar.css", it won't work, postcss won't find bar.css, but if you execute "pnpm exec postcss foo/bar.css", postcss will find bar.css as foo/bar.css, it is weird.