### PR TITLE
docs: add `peerDependencies` as a supported `catalog:` protocol field

### DIFF
--- a/docs/catalogs.md
+++ b/docs/catalogs.md
@@ -51,6 +51,7 @@ You may use the `catalog:` protocol in the next fields of your `package.json`:
 
 * `dependencies`
 * `devDependencies`
+* `peerDependencies`
 * `optionalDependencies`
 * `pnpm.overrides`
 


### PR DESCRIPTION
The `peerDependencies` field in the package.json file works with the `catalog:` protocol but is not documented yet.

My package.json and pnpm-workspace.yaml look like this for example:
<img width="367" alt="image" src="https://github.com/user-attachments/assets/a745d4f8-0e42-4ec0-a3f8-bfe2a2a7fea9">

When I inspect the package.json file inside the tarball created by `pnpm pack` it got replaced as expected:
<img width="323" alt="image" src="https://github.com/user-attachments/assets/7dc32dbc-0eca-49f9-8a85-539056feef1c">
