### PR TITLE
Patch `react-dom` and suppress NUL in non-English docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,5 +40,10 @@
     "@types/node": "^20.12.2",
     "shx": "^0.3.4",
     "ts-node": "10.9.2"
+  },
+  "pnpm": {
+    "patchedDependencies": {
+      "react-dom@18.3.1": "patches/react-dom@18.3.1.patch"
+    }
   }
 }

--- a/patches/react-dom@18.3.1.patch
+++ b/patches/react-dom@18.3.1.patch
@@ -1,0 +1,26 @@
+diff --git a/cjs/react-dom-server.node.development.js b/cjs/react-dom-server.node.development.js
+index de58cde782d8aa60f61062613cb9210c56137d3b..8671f5e542213990892e5f92404473deef3068e7 100644
+--- a/cjs/react-dom-server.node.development.js
++++ b/cjs/react-dom-server.node.development.js
+@@ -126,7 +126,7 @@ function writeStringChunk(destination, stringChunk) {
+   writtenBytes += written;
+ 
+   if (read < stringChunk.length) {
+-    writeToDestination(destination, currentView);
++    writeToDestination(destination, currentView.subarray(0, writtenBytes));
+     currentView = new Uint8Array(VIEW_SIZE);
+     writtenBytes = textEncoder.encodeInto(stringChunk.slice(read), currentView).written;
+   }
+diff --git a/cjs/react-dom-server.node.production.min.js b/cjs/react-dom-server.node.production.min.js
+index 9cc6d69a5038580440f939beaf159d09bf6c98e7..412a837868dc3425362fe5ad4ceabeddc048f452 100644
+--- a/cjs/react-dom-server.node.production.min.js
++++ b/cjs/react-dom-server.node.production.min.js
+@@ -8,7 +8,7 @@
+  * LICENSE file in the root directory of this source tree.
+  */
+ 'use strict';var aa=require("util"),ba=require("react"),k=null,l=0,q=!0;
+-function r(a,b){if("string"===typeof b){if(0!==b.length)if(2048<3*b.length)0<l&&(t(a,k.subarray(0,l)),k=new Uint8Array(2048),l=0),t(a,u.encode(b));else{var c=k;0<l&&(c=k.subarray(l));c=u.encodeInto(b,c);var d=c.read;l+=c.written;d<b.length&&(t(a,k),k=new Uint8Array(2048),l=u.encodeInto(b.slice(d),k).written);2048===l&&(t(a,k),k=new Uint8Array(2048),l=0)}}else 0!==b.byteLength&&(2048<b.byteLength?(0<l&&(t(a,k.subarray(0,l)),k=new Uint8Array(2048),l=0),t(a,b)):(c=k.length-l,c<b.byteLength&&(0===c?t(a,
++function r(a,b){if("string"===typeof b){if(0!==b.length)if(2048<3*b.length)0<l&&(t(a,k.subarray(0,l)),k=new Uint8Array(2048),l=0),t(a,u.encode(b));else{var c=k;0<l&&(c=k.subarray(l));c=u.encodeInto(b,c);var d=c.read;l+=c.written;d<b.length&&(t(a,k.subarray(0,l)),k=new Uint8Array(2048),l=u.encodeInto(b.slice(d),k).written);2048===l&&(t(a,k),k=new Uint8Array(2048),l=0)}}else 0!==b.byteLength&&(2048<b.byteLength?(0<l&&(t(a,k.subarray(0,l)),k=new Uint8Array(2048),l=0),t(a,b)):(c=k.length-l,c<b.byteLength&&(0===c?t(a,
+ k):(k.set(b.subarray(0,c),l),l+=c,t(a,k),b=b.subarray(c)),k=new Uint8Array(2048),l=0),k.set(b,l),l+=b.byteLength,2048===l&&(t(a,k),k=new Uint8Array(2048),l=0)))}function t(a,b){a=a.write(b);q=q&&a}function w(a,b){r(a,b);return q}function ca(a){k&&0<l&&a.write(k.subarray(0,l));k=null;l=0;q=!0}var u=new aa.TextEncoder;function x(a){return u.encode(a)}
+ var y=Object.prototype.hasOwnProperty,da=/^[:A-Z_a-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD][:A-Z_a-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD\-.0-9\u00B7\u0300-\u036F\u203F-\u2040]*$/,ea={},fa={};
+ function ha(a){if(y.call(fa,a))return!0;if(y.call(ea,a))return!1;if(da.test(a))return fa[a]=!0;ea[a]=!0;return!1}function z(a,b,c,d,f,e,g){this.acceptsBooleans=2===b||3===b||4===b;this.attributeName=d;this.attributeNamespace=f;this.mustUseProperty=c;this.propertyName=a;this.type=b;this.sanitizeURL=e;this.removeEmptyString=g}var A={};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,11 @@ settings:
 
 pnpmfileChecksum: thdeoz74yvtjgossx7s52d4gtm
 
+patchedDependencies:
+  react-dom@18.3.1:
+    hash: 5dkn6a7gqm2p47xd5rmlr75cgy
+    path: patches/react-dom@18.3.1.patch
+
 importers:
 
   .:
@@ -18,16 +23,16 @@ importers:
         version: 3.19.1
       '@docusaurus/core':
         specifier: 3.4.0
-        version: 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
+        version: 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
       '@docusaurus/plugin-client-redirects':
         specifier: 3.4.0
-        version: 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
+        version: 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
       '@docusaurus/plugin-content-docs':
         specifier: 3.4.0
-        version: 3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
+        version: 3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
       '@docusaurus/preset-classic':
         specifier: 3.4.0
-        version: 3.4.0(@algolia/client-search@4.24.0)(@types/react@17.0.80)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.15.0)(typescript@5.5.3)
+        version: 3.4.0(@algolia/client-search@4.24.0)(@types/react@17.0.80)(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)(search-insights@2.15.0)(typescript@5.5.3)
       '@types/react':
         specifier: ^17.0.49
         version: 17.0.80
@@ -42,7 +47,7 @@ importers:
         version: 18.3.1
       react-dom:
         specifier: ^18.2.0
-        version: 18.3.1(react@18.3.1)
+        version: 18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1)
       typescript:
         specifier: ^5.4.5
         version: 5.5.3
@@ -5709,7 +5714,7 @@ snapshots:
 
   '@docsearch/css@3.6.1': {}
 
-  '@docsearch/react@3.6.1(@algolia/client-search@4.24.0)(@types/react@17.0.80)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.15.0)':
+  '@docsearch/react@3.6.1(@algolia/client-search@4.24.0)(@types/react@17.0.80)(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)(search-insights@2.15.0)':
     dependencies:
       '@algolia/autocomplete-core': 1.9.3(@algolia/client-search@4.24.0)(algoliasearch@4.24.0)(search-insights@2.15.0)
       '@algolia/autocomplete-preset-algolia': 1.9.3(@algolia/client-search@4.24.0)(algoliasearch@4.24.0)
@@ -5718,12 +5723,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 17.0.80
       react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      react-dom: 18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1)
       search-insights: 2.15.0
     transitivePeerDependencies:
       - '@algolia/client-search'
 
-  '@docusaurus/core@3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)':
+  '@docusaurus/core@3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)(typescript@5.5.3)':
     dependencies:
       '@babel/core': 7.24.9
       '@babel/generator': 7.24.10
@@ -5737,10 +5742,10 @@ snapshots:
       '@babel/traverse': 7.24.8
       '@docusaurus/cssnano-preset': 3.4.0
       '@docusaurus/logger': 3.4.0
-      '@docusaurus/mdx-loader': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
-      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.5.3)
-      '@docusaurus/utils-common': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.5.3)
+      '@docusaurus/mdx-loader': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
+      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1))(typescript@5.5.3)
+      '@docusaurus/utils-common': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1))
+      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1))(typescript@5.5.3)
       autoprefixer: 10.4.19(postcss@8.4.39)
       babel-loader: 9.1.3(@babel/core@7.24.9)(webpack@5.93.0)
       babel-plugin-dynamic-import-node: 2.3.3
@@ -5776,8 +5781,8 @@ snapshots:
       prompts: 2.4.2
       react: 18.3.1
       react-dev-utils: 12.0.1(typescript@5.5.3)(webpack@5.93.0)
-      react-dom: 18.3.1(react@18.3.1)
-      react-helmet-async: 1.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-dom: 18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1)
+      react-helmet-async: 1.3.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)
       react-loadable: '@docusaurus/react-loadable@6.0.0(react@18.3.1)'
       react-loadable-ssr-addon-v5-slorber: 1.0.1(@docusaurus/react-loadable@6.0.0(react@18.3.1))(webpack@5.93.0)
       react-router: 5.3.4(react@18.3.1)
@@ -5827,11 +5832,11 @@ snapshots:
       chalk: 4.1.2
       tslib: 2.6.3
 
-  '@docusaurus/mdx-loader@3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)':
+  '@docusaurus/mdx-loader@3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)(typescript@5.5.3)':
     dependencies:
       '@docusaurus/logger': 3.4.0
-      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.5.3)
-      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.5.3)
+      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1))(typescript@5.5.3)
+      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1))(typescript@5.5.3)
       '@mdx-js/mdx': 3.0.1
       '@slorber/remark-comment': 1.0.0
       escape-html: 1.0.3
@@ -5842,7 +5847,7 @@ snapshots:
       mdast-util-mdx: 3.0.0
       mdast-util-to-string: 4.0.0
       react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      react-dom: 18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1)
       rehype-raw: 7.0.0
       remark-directive: 3.0.0
       remark-emoji: 4.0.1
@@ -5864,15 +5869,15 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/module-type-aliases@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@docusaurus/module-type-aliases@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@docusaurus/types': 3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/types': 3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)
       '@types/history': 4.7.11
       '@types/react': 17.0.80
       '@types/react-router-config': 5.0.11
       '@types/react-router-dom': 5.3.3
       react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      react-dom: 18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1)
       react-helmet-async: 2.0.5(react@18.3.1)
       react-loadable: '@docusaurus/react-loadable@6.0.0(react@18.3.1)'
     transitivePeerDependencies:
@@ -5882,18 +5887,18 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/plugin-client-redirects@3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)':
+  '@docusaurus/plugin-client-redirects@3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)(typescript@5.5.3)':
     dependencies:
-      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
+      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
       '@docusaurus/logger': 3.4.0
-      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.5.3)
-      '@docusaurus/utils-common': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.5.3)
+      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1))(typescript@5.5.3)
+      '@docusaurus/utils-common': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1))
+      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1))(typescript@5.5.3)
       eta: 2.2.0
       fs-extra: 11.2.0
       lodash: 4.17.21
       react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      react-dom: 18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1)
       tslib: 2.6.3
     transitivePeerDependencies:
       - '@docusaurus/types'
@@ -5914,21 +5919,21 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-content-blog@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)':
+  '@docusaurus/plugin-content-blog@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)(typescript@5.5.3)':
     dependencies:
-      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
+      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
       '@docusaurus/logger': 3.4.0
-      '@docusaurus/mdx-loader': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
-      '@docusaurus/types': 3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.5.3)
-      '@docusaurus/utils-common': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.5.3)
+      '@docusaurus/mdx-loader': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
+      '@docusaurus/types': 3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1))(typescript@5.5.3)
+      '@docusaurus/utils-common': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1))
+      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1))(typescript@5.5.3)
       cheerio: 1.0.0-rc.12
       feed: 4.2.2
       fs-extra: 11.2.0
       lodash: 4.17.21
       react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      react-dom: 18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1)
       reading-time: 1.5.0
       srcset: 4.0.0
       tslib: 2.6.3
@@ -5953,23 +5958,23 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-content-docs@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)':
+  '@docusaurus/plugin-content-docs@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)(typescript@5.5.3)':
     dependencies:
-      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
+      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
       '@docusaurus/logger': 3.4.0
-      '@docusaurus/mdx-loader': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
-      '@docusaurus/module-type-aliases': 3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/types': 3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.5.3)
-      '@docusaurus/utils-common': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.5.3)
+      '@docusaurus/mdx-loader': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
+      '@docusaurus/module-type-aliases': 3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)
+      '@docusaurus/types': 3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1))(typescript@5.5.3)
+      '@docusaurus/utils-common': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1))
+      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1))(typescript@5.5.3)
       '@types/react-router-config': 5.0.11
       combine-promises: 1.2.0
       fs-extra: 11.2.0
       js-yaml: 4.1.0
       lodash: 4.17.21
       react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      react-dom: 18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1)
       tslib: 2.6.3
       utility-types: 3.11.0
       webpack: 5.93.0
@@ -5991,16 +5996,16 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-content-pages@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)':
+  '@docusaurus/plugin-content-pages@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)(typescript@5.5.3)':
     dependencies:
-      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
-      '@docusaurus/mdx-loader': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
-      '@docusaurus/types': 3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.5.3)
-      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.5.3)
+      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
+      '@docusaurus/mdx-loader': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
+      '@docusaurus/types': 3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1))(typescript@5.5.3)
+      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1))(typescript@5.5.3)
       fs-extra: 11.2.0
       react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      react-dom: 18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1)
       tslib: 2.6.3
       webpack: 5.93.0
     transitivePeerDependencies:
@@ -6021,14 +6026,14 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-debug@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)':
+  '@docusaurus/plugin-debug@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)(typescript@5.5.3)':
     dependencies:
-      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
-      '@docusaurus/types': 3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.5.3)
+      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
+      '@docusaurus/types': 3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1))(typescript@5.5.3)
       fs-extra: 11.2.0
       react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      react-dom: 18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1)
       react-json-view-lite: 1.4.0(react@18.3.1)
       tslib: 2.6.3
     transitivePeerDependencies:
@@ -6049,13 +6054,13 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-google-analytics@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)':
+  '@docusaurus/plugin-google-analytics@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)(typescript@5.5.3)':
     dependencies:
-      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
-      '@docusaurus/types': 3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.5.3)
+      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
+      '@docusaurus/types': 3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1))(typescript@5.5.3)
       react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      react-dom: 18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1)
       tslib: 2.6.3
     transitivePeerDependencies:
       - '@parcel/css'
@@ -6075,14 +6080,14 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-google-gtag@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)':
+  '@docusaurus/plugin-google-gtag@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)(typescript@5.5.3)':
     dependencies:
-      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
-      '@docusaurus/types': 3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.5.3)
+      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
+      '@docusaurus/types': 3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1))(typescript@5.5.3)
       '@types/gtag.js': 0.0.12
       react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      react-dom: 18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1)
       tslib: 2.6.3
     transitivePeerDependencies:
       - '@parcel/css'
@@ -6102,13 +6107,13 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-google-tag-manager@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)':
+  '@docusaurus/plugin-google-tag-manager@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)(typescript@5.5.3)':
     dependencies:
-      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
-      '@docusaurus/types': 3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.5.3)
+      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
+      '@docusaurus/types': 3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1))(typescript@5.5.3)
       react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      react-dom: 18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1)
       tslib: 2.6.3
     transitivePeerDependencies:
       - '@parcel/css'
@@ -6128,17 +6133,17 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-sitemap@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)':
+  '@docusaurus/plugin-sitemap@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)(typescript@5.5.3)':
     dependencies:
-      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
+      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
       '@docusaurus/logger': 3.4.0
-      '@docusaurus/types': 3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.5.3)
-      '@docusaurus/utils-common': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.5.3)
+      '@docusaurus/types': 3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1))(typescript@5.5.3)
+      '@docusaurus/utils-common': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1))
+      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1))(typescript@5.5.3)
       fs-extra: 11.2.0
       react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      react-dom: 18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1)
       sitemap: 7.1.2
       tslib: 2.6.3
     transitivePeerDependencies:
@@ -6159,23 +6164,23 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/preset-classic@3.4.0(@algolia/client-search@4.24.0)(@types/react@17.0.80)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.15.0)(typescript@5.5.3)':
+  '@docusaurus/preset-classic@3.4.0(@algolia/client-search@4.24.0)(@types/react@17.0.80)(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)(search-insights@2.15.0)(typescript@5.5.3)':
     dependencies:
-      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
-      '@docusaurus/plugin-content-blog': 3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
-      '@docusaurus/plugin-content-docs': 3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
-      '@docusaurus/plugin-content-pages': 3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
-      '@docusaurus/plugin-debug': 3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
-      '@docusaurus/plugin-google-analytics': 3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
-      '@docusaurus/plugin-google-gtag': 3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
-      '@docusaurus/plugin-google-tag-manager': 3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
-      '@docusaurus/plugin-sitemap': 3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
-      '@docusaurus/theme-classic': 3.4.0(@types/react@17.0.80)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
-      '@docusaurus/theme-common': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
-      '@docusaurus/theme-search-algolia': 3.4.0(@algolia/client-search@4.24.0)(@docusaurus/types@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@17.0.80)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.15.0)(typescript@5.5.3)
-      '@docusaurus/types': 3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
+      '@docusaurus/plugin-content-blog': 3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
+      '@docusaurus/plugin-content-docs': 3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
+      '@docusaurus/plugin-content-pages': 3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
+      '@docusaurus/plugin-debug': 3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
+      '@docusaurus/plugin-google-analytics': 3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
+      '@docusaurus/plugin-google-gtag': 3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
+      '@docusaurus/plugin-google-tag-manager': 3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
+      '@docusaurus/plugin-sitemap': 3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
+      '@docusaurus/theme-classic': 3.4.0(@types/react@17.0.80)(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
+      '@docusaurus/theme-common': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
+      '@docusaurus/theme-search-algolia': 3.4.0(@algolia/client-search@4.24.0)(@docusaurus/types@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1))(@types/react@17.0.80)(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)(search-insights@2.15.0)(typescript@5.5.3)
+      '@docusaurus/types': 3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)
       react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      react-dom: 18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1)
     transitivePeerDependencies:
       - '@algolia/client-search'
       - '@parcel/css'
@@ -6202,20 +6207,20 @@ snapshots:
       '@types/react': 17.0.80
       react: 18.3.1
 
-  '@docusaurus/theme-classic@3.4.0(@types/react@17.0.80)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)':
+  '@docusaurus/theme-classic@3.4.0(@types/react@17.0.80)(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)(typescript@5.5.3)':
     dependencies:
-      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
-      '@docusaurus/mdx-loader': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
-      '@docusaurus/module-type-aliases': 3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/plugin-content-blog': 3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
-      '@docusaurus/plugin-content-docs': 3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
-      '@docusaurus/plugin-content-pages': 3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
-      '@docusaurus/theme-common': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
+      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
+      '@docusaurus/mdx-loader': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
+      '@docusaurus/module-type-aliases': 3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)
+      '@docusaurus/plugin-content-blog': 3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
+      '@docusaurus/plugin-content-docs': 3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
+      '@docusaurus/plugin-content-pages': 3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
+      '@docusaurus/theme-common': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
       '@docusaurus/theme-translations': 3.4.0
-      '@docusaurus/types': 3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.5.3)
-      '@docusaurus/utils-common': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.5.3)
+      '@docusaurus/types': 3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1))(typescript@5.5.3)
+      '@docusaurus/utils-common': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1))
+      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1))(typescript@5.5.3)
       '@mdx-js/react': 3.0.1(@types/react@17.0.80)(react@18.3.1)
       clsx: 2.1.1
       copy-text-to-clipboard: 3.2.0
@@ -6226,7 +6231,7 @@ snapshots:
       prism-react-renderer: 2.3.1(react@18.3.1)
       prismjs: 1.29.0
       react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      react-dom: 18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1)
       react-router-dom: 5.3.4(react@18.3.1)
       rtlcss: 4.1.1
       tslib: 2.6.3
@@ -6250,15 +6255,15 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/theme-common@3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)':
+  '@docusaurus/theme-common@3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)(typescript@5.5.3)':
     dependencies:
-      '@docusaurus/mdx-loader': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
-      '@docusaurus/module-type-aliases': 3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/plugin-content-blog': 3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
-      '@docusaurus/plugin-content-docs': 3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
-      '@docusaurus/plugin-content-pages': 3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
-      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.5.3)
-      '@docusaurus/utils-common': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@docusaurus/mdx-loader': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
+      '@docusaurus/module-type-aliases': 3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)
+      '@docusaurus/plugin-content-blog': 3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
+      '@docusaurus/plugin-content-docs': 3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
+      '@docusaurus/plugin-content-pages': 3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
+      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1))(typescript@5.5.3)
+      '@docusaurus/utils-common': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1))
       '@types/history': 4.7.11
       '@types/react': 17.0.80
       '@types/react-router-config': 5.0.11
@@ -6266,7 +6271,7 @@ snapshots:
       parse-numeric-range: 1.3.0
       prism-react-renderer: 2.3.1(react@18.3.1)
       react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      react-dom: 18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1)
       tslib: 2.6.3
       utility-types: 3.11.0
     transitivePeerDependencies:
@@ -6288,16 +6293,16 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/theme-search-algolia@3.4.0(@algolia/client-search@4.24.0)(@docusaurus/types@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@17.0.80)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.15.0)(typescript@5.5.3)':
+  '@docusaurus/theme-search-algolia@3.4.0(@algolia/client-search@4.24.0)(@docusaurus/types@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1))(@types/react@17.0.80)(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)(search-insights@2.15.0)(typescript@5.5.3)':
     dependencies:
-      '@docsearch/react': 3.6.1(@algolia/client-search@4.24.0)(@types/react@17.0.80)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.15.0)
-      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
+      '@docsearch/react': 3.6.1(@algolia/client-search@4.24.0)(@types/react@17.0.80)(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)(search-insights@2.15.0)
+      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
       '@docusaurus/logger': 3.4.0
-      '@docusaurus/plugin-content-docs': 3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
-      '@docusaurus/theme-common': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
+      '@docusaurus/plugin-content-docs': 3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
+      '@docusaurus/theme-common': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)(typescript@5.5.3)
       '@docusaurus/theme-translations': 3.4.0
-      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.5.3)
-      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.5.3)
+      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1))(typescript@5.5.3)
+      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1))(typescript@5.5.3)
       algoliasearch: 4.24.0
       algoliasearch-helper: 3.22.3(algoliasearch@4.24.0)
       clsx: 2.1.1
@@ -6305,7 +6310,7 @@ snapshots:
       fs-extra: 11.2.0
       lodash: 4.17.21
       react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      react-dom: 18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1)
       tslib: 2.6.3
       utility-types: 3.11.0
     transitivePeerDependencies:
@@ -6335,7 +6340,7 @@ snapshots:
       fs-extra: 11.2.0
       tslib: 2.6.3
 
-  '@docusaurus/types@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@docusaurus/types@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@mdx-js/mdx': 3.0.1
       '@types/history': 4.7.11
@@ -6343,8 +6348,8 @@ snapshots:
       commander: 5.1.0
       joi: 17.13.3
       react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      react-helmet-async: 1.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-dom: 18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1)
+      react-helmet-async: 1.3.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)
       utility-types: 3.11.0
       webpack: 5.93.0
       webpack-merge: 5.10.0
@@ -6355,17 +6360,17 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils-common@3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+  '@docusaurus/utils-common@3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1))':
     dependencies:
       tslib: 2.6.3
     optionalDependencies:
-      '@docusaurus/types': 3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/types': 3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)
 
-  '@docusaurus/utils-validation@3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.5.3)':
+  '@docusaurus/utils-validation@3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1))(typescript@5.5.3)':
     dependencies:
       '@docusaurus/logger': 3.4.0
-      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.5.3)
-      '@docusaurus/utils-common': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1))(typescript@5.5.3)
+      '@docusaurus/utils-common': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1))
       fs-extra: 11.2.0
       joi: 17.13.3
       js-yaml: 4.1.0
@@ -6380,10 +6385,10 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils@3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.5.3)':
+  '@docusaurus/utils@3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1))(typescript@5.5.3)':
     dependencies:
       '@docusaurus/logger': 3.4.0
-      '@docusaurus/utils-common': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@docusaurus/utils-common': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1))
       '@svgr/webpack': 8.1.0(typescript@5.5.3)
       escape-string-regexp: 4.0.0
       file-loader: 6.2.0(webpack@5.93.0)
@@ -6403,7 +6408,7 @@ snapshots:
       utility-types: 3.11.0
       webpack: 5.93.0
     optionalDependencies:
-      '@docusaurus/types': 3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/types': 3.4.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1)
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -9733,7 +9738,7 @@ snapshots:
       - supports-color
       - vue-template-compiler
 
-  react-dom@18.3.1(react@18.3.1):
+  react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1):
     dependencies:
       loose-envify: 1.4.0
       react: 18.3.1
@@ -9743,13 +9748,13 @@ snapshots:
 
   react-fast-compare@3.2.2: {}
 
-  react-helmet-async@1.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  react-helmet-async@1.3.0(react-dom@18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1))(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.24.8
       invariant: 2.2.4
       prop-types: 15.8.1
       react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      react-dom: 18.3.1(patch_hash=5dkn6a7gqm2p47xd5rmlr75cgy)(react@18.3.1)
       react-fast-compare: 3.2.2
       shallowequal: 1.1.0
 


### PR DESCRIPTION
Some non-English pages in pnpm.io has NUL (U+0000). 

https://github.com/facebook/docusaurus/issues/9985#issuecomment-2139649267

This is a bug in React 18.1.0–18.3.1. The fix (https://github.com/facebook/react/pull/26228) is available only in 19.x or later. You should patch `react-dom` until you upgrade React to 19.x.

https://github.com/facebook/react/issues/31134#issuecomment-2416257221
https://github.com/tats-u/react-dom-no-nul
https://github.com/tats-u/react-dom-no-nul/commit/850327cbc752bf95e94114699861d142741f4181

↓patched part in `*.production.min.js`:

![diff](https://private-user-images.githubusercontent.com/12870451/376970765-3d71dccf-0af5-49f3-b788-db4054a0da49.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MjkzODA3MjYsIm5iZiI6MTcyOTM4MDQyNiwicGF0aCI6Ii8xMjg3MDQ1MS8zNzY5NzA3NjUtM2Q3MWRjY2YtMGFmNS00OWYzLWI3ODgtZGI0MDU0YTBkYTQ5LnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDEwMTklMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQxMDE5VDIzMjcwNlomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTI5MDc2Mzk5NzBlMzkwZjU1ZDRhMWUyN2NiOWRjYmZkYzQzNjM3MDA0ZWQyMmM2YWMyYmNkZTRhNzQzN2JkODQmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.L4ViboJ5vW6H6snnUzYOkNkxhT2aWS6areqJEYZgYmw)