### PR TITLE
Docs: errors.md: Extend `ERR_PNPM_MISSMATCHED_RELEASE_CHANNEL`

### DIFF
--- a/docs/errors.md
+++ b/docs/errors.md
@@ -64,6 +64,9 @@ For example:
 
 To fix this error, either remove the release channel prefix or correct the version suffix.
 
+Note that it is not allowed to specify node versions like `lts/Jod`.
+The correct syntax for stable release is strictly X.Y.Z or release/X.Y.Z.
+
 ## ERR_PNPM_INVALID_NODE_VERSION
 
 The value of config field `use-node-version` has an invalid syntax.


### PR DESCRIPTION
Extend the docs for the error `ERR_PNPM_MISSMATCHED_RELEASE_CHANNEL` to hint that node version definitions like `lts/Jod` are not allowed.

I am migrating from `nvmrc` and was used to this way of specifying the node version. This addition would have saved me a few minutes of additional research.