### PR TITLE
Add an example to `docs/pnpm-workspace_yaml.md` that doesn't use a wildcard

### DIFF
--- a/docs/pnpm-workspace_yaml.md
+++ b/docs/pnpm-workspace_yaml.md
@@ -11,6 +11,8 @@ For example:
 
 ```yaml title="pnpm-workspace.yaml"
 packages:
+  # specify a package dir
+  - 'my-app/'
   # all packages in direct subdirs of packages/
   - 'packages/*'
   # all packages in subdirs of components/

--- a/docs/pnpm-workspace_yaml.md
+++ b/docs/pnpm-workspace_yaml.md
@@ -11,8 +11,8 @@ For example:
 
 ```yaml title="pnpm-workspace.yaml"
 packages:
-  # specify a package dir
-  - 'my-app/'
+  # specify a package in a direct subdir of the root
+  - 'my-app'
   # all packages in direct subdirs of packages/
   - 'packages/*'
   # all packages in subdirs of components/


### PR DESCRIPTION
While submitting [another issue](https://github.com/vercel/turborepo/issues/9490), I realized that it'd be nice to document how to specify a package directory without a wildcard. It's pretty basic/obvious, but I think it'd be nice to state it explicitly.