### PR TITLE
doc: delete the redundant  ' . '

### DIFF
--- a/versioned_docs/version-9.x/workspaces.md
+++ b/versioned_docs/version-9.x/workspaces.md
@@ -116,7 +116,7 @@ Versioning packages inside a workspace is a complex task and pnpm currently does
 not provide a built-in solution for it. However, there are 2 well tested tools
 that handle versioning and support pnpm:
 - [changesets](https://github.com/changesets/changesets)
-- [Rush](https://rushjs.io).
+- [Rush](https://rushjs.io)
 
 For how to set up a repository using Rush, read [this page][rush-setup].
 


### PR DESCRIPTION
before
![image](https://github.com/user-attachments/assets/e0b3645b-c0e9-4fcc-96de-e24f68f3f778)

after

![image](https://github.com/user-attachments/assets/6117c5b7-ac17-4ef5-9797-b45bad9d07ac)

