### PR TITLE
Update npmrc.md

### DIFF
--- a/docs/npmrc.md
+++ b/docs/npmrc.md
@@ -443,7 +443,7 @@ Define the path to a Certificate Authority file to use when accessing the specif
 registry. For example:
 
 ```sh
-//registry.npmjs.org/:keyfile=client-cert.pem
+//registry.npmjs.org/:cafile=ca-cert.pem
 ```
 
 ### cert


### PR DESCRIPTION
docs: improve documentation

This commit fixes an example of how to use custom CA certificates.

It might have been a copy & paste error.