### PR TITLE
chore: corepack is bundled with nodejs on brew

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -78,12 +78,6 @@ If you have installed Node.js with `pnpm env` Corepack won't be installed on you
 corepack enable pnpm
 ```
 
-If you installed Node.js using Homebrew, you'll need to install corepack separately:
-
-```
-brew install corepack
-```
-
 This will automatically install pnpm on your system.
 
 You can pin the version of pnpm used on your project using the following command:


### PR DESCRIPTION
Corepack is now bundled within the Homebrew formulae for Node.js