### PR TITLE
docs: clarify v10 default value for `pnpm.onlyBuiltDependencies`

### DIFF
--- a/docs/package_json.md
+++ b/docs/package_json.md
@@ -474,7 +474,7 @@ An example of the `"pnpm"."neverBuiltDependencies"` field:
 
 ## pnpm.onlyBuiltDependencies
 
-A list of package names that are allowed to be executed during installation. If this field exists, only the listed packages will be able to run install scripts.
+A list of package names that are allowed to be executed during installation. Only packages listed in this array will be able to run install scripts. If `onlyBuiltDependenciesFile` and `neverBuiltDependencies` are not set, this configuration option will default to blocking all install scripts.
 
 Example:
 


### PR DESCRIPTION
https://github.com/pnpm/pnpm/pull/8897 flipped the default value for `pnpm.onlyBuiltDependencies` so that no npm install scripts are run unless specifically allowlisted.

This PR clarifies the language in the documentation to reflect this new default.