### PR TITLE
doc(add): Escape ampersand in shell

### DIFF
--- a/docs/cli/add.md
+++ b/docs/cli/add.md
@@ -167,7 +167,7 @@ If `[provider]:` is omitted, it defaults to `github:`.
 It is possible to combine multiple parameters by separating them with `&`. This can be useful for forks of monorepos:
 
 ```
-pnpm add RexSkz/test-git-subdir-fetch.git#beta&path:/packages/simple-react-app
+pnpm add RexSkz/test-git-subdir-fetch.git#beta\&path:/packages/simple-react-app
 ```
 
 Installs from the `beta` branch and only the subdirectory at `/packages/simple-react-app`.


### PR DESCRIPTION
Any posix shell out there will fork a process if you pass `&` as a command line parameter without escaping it, see https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html.

I suggest we escape it in the docs too, so people can copy&paste the command directly.