### PR TITLE
Put double quotes around rm command args

### DIFF
--- a/docs/uninstall.md
+++ b/docs/uninstall.md
@@ -17,7 +17,7 @@ To list all the global packages, run `pnpm ls -g`. There are two ways to remove 
 If you used the standalone script to install pnpm, then you should be able to uninstall the pnpm CLI by removing the pnpm home directory:
 
 ```
-rm -rf $PNPM_HOME
+rm -rf "$PNPM_HOME"
 ```
 
 You might also want to clean the `PNPM_HOME` env variable in your shell configuration file (`$HOME/.bashrc`, `$HOME/.zshrc` or `$HOME/.config/fish/config.fish`).
@@ -31,7 +31,7 @@ npm rm -g pnpm
 ## Removing the global content-addressable store
 
 ```
-rm -rf $(pnpm store path)
+rm -rf "$(pnpm store path)"
 ```
 
 If you used pnpm in non-primary disks, then you must run the above command in every disk, where pnpm was used.


### PR DESCRIPTION
if `$PNPM_HOME` or `$(pnpm store path)` expand to values with a space character, then the shell will treat it as two different arguments for `rm` to delete.

Depending on where the space is, it could delete something bad.

But putting double quotes around it, we prevent that, and the shell will always treat is as a single argument