### PR TITLE
docs(settings): add `reporter` as a valid CLI and config file option

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -488,10 +488,10 @@ Add the full URL to the package's tarball to every entry in `pnpm-lock.yaml`.
 * Default: **false**
 * Type: **Boolean**
 
-When set to `true`, the generated lockfile name after installation will be named 
+When set to `true`, the generated lockfile name after installation will be named
 based on the current branch name to completely avoid merge conflicts. For example,
 if the current branch name is `feature-foo`, the corresponding lockfile name will
-be `pnpm-lock.feature-foo.yaml` instead of `pnpm-lock.yaml`. It is typically used 
+be `pnpm-lock.feature-foo.yaml` instead of `pnpm-lock.yaml`. It is typically used
 in conjunction with the command line argument `--merge-git-branch-lockfiles` or by
 setting `mergeGitBranchLockfilesBranchPattern` in the `pnpm-workspace.yaml` file.
 
@@ -500,9 +500,9 @@ setting `mergeGitBranchLockfilesBranchPattern` in the `pnpm-workspace.yaml` file
 * Default: **null**
 * Type: **Array or null**
 
-This configuration matches the current branch name to determine whether to merge 
-all git branch lockfile files. By default, you need to manually pass the 
-`--merge-git-branch-lockfiles` command line parameter. This configuration allows 
+This configuration matches the current branch name to determine whether to merge
+all git branch lockfile files. By default, you need to manually pass the
+`--merge-git-branch-lockfiles` command line parameter. This configuration allows
 this process to be automatically completed.
 
 For instance:
@@ -545,7 +545,7 @@ Define the authentication bearer token to use when accessing the specified
 registry. For example:
 
 ```ini
-//registry.npmjs.org/:_authToken=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx 
+//registry.npmjs.org/:_authToken=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 ```
 
 You may also use an environment variable. For example:
@@ -557,7 +557,7 @@ You may also use an environment variable. For example:
 Or you may just use an environment variable directly, without changing `.npmrc` at all:
 
 ```
-npm_config_//registry.npmjs.org/:_authToken=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx 
+npm_config_//registry.npmjs.org/:_authToken=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 ```
 
 ### &lt;URL&gt;&#58;tokenHelper
@@ -955,6 +955,19 @@ Controls colors in the output.
 
 Any logs at or higher than the given level will be shown.
 You can instead pass `--silent` to turn off all output logs.
+
+### reporter
+
+* Default: **default**
+* Type: **silent**, **default**, **append-only**, **ndjson**
+
+Controls the output of npm scripts.
+
+* **silent** - No output is logged to the console, except fatal errors.
+* **default** - The default reporter when the stdout is TTY.
+* **append-only** - The output is always appended to the end. No cursor
+  manipulations are performed.
+* **ndjson** - The most verbose reporter. Prints all logs in ndjson format
 
 ### useBetaCli
 


### PR DESCRIPTION
Updated `settings.md` to reflect the addition of `reporter` as a valid CLI and config file option. Default setting and possible settings reflect help command output from `cli/common-cli-options-help/src/index.ts` within [pnpm/pnpm](https://github.com/derekkramer/pnpm/blob/main/cli/common-cli-options-help/src/index.ts)