### PR TITLE
docs: sort continuous integration recipes in alphabetical order

### DIFF
--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -11,56 +11,6 @@ In all the provided configuration files the store is cached. However, this is no
 
 :::
 
-## Travis
-
-On [Travis CI], you can use pnpm for installing your dependencies by adding this
-to your `.travis.yml` file:
-
-```yaml title=".travis.yml"
-cache:
-  npm: false
-  directories:
-    - "~/.pnpm-store"
-before_install:
-  - npm install --global corepack@latest
-  - corepack enable
-  - corepack prepare pnpm@latest-10 --activate
-  - pnpm config set store-dir ~/.pnpm-store
-install:
-  - pnpm install
-```
-
-[Travis CI]: https://travis-ci.org
-
-## Semaphore
-
-On [Semaphore], you can use pnpm for installing and caching your dependencies by
-adding this to your `.semaphore/semaphore.yml` file:
-
-```yaml title=".semaphore/semaphore.yml"
-version: v1.0
-name: Semaphore CI pnpm example
-agent:
-  machine:
-    type: e1-standard-2
-    os_image: ubuntu1804
-blocks:
-  - name: Install dependencies
-    task:
-      jobs:
-        - name: pnpm install
-          commands:
-            - npm install --global corepack@latest
-            - corepack enable
-            - corepack prepare pnpm@latest-10 --activate
-            - checkout
-            - cache restore node-$(checksum pnpm-lock.yaml)
-            - pnpm install
-            - cache store node-$(checksum pnpm-lock.yaml) $(pnpm store path)
-```
-
-[Semaphore]: https://semaphoreci.com
-
 ## AppVeyor
 
 On [AppVeyor], you can use pnpm for installing your dependencies by adding this
@@ -76,89 +26,6 @@ install:
 ```
 
 [AppVeyor]: https://www.appveyor.com
-
-## GitHub Actions
-
-On GitHub Actions, you can use pnpm for installing and caching your dependencies
-like so (belongs in `.github/workflows/NAME.yml`):
-
-```yaml title=".github/workflows/NAME.yml"
-name: pnpm Example Workflow
-on:
-  push:
-
-jobs:
-  build:
-    runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        node-version: [20]
-    steps:
-    - uses: actions/checkout@v4
-    - name: Install pnpm
-      uses: pnpm/action-setup@v4
-      with:
-        version: 10
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
-      with:
-        node-version: ${{ matrix.node-version }}
-        cache: 'pnpm'
-    - name: Install dependencies
-      run: pnpm install
-```
-
-## GitLab CI
-
-On GitLab, you can use pnpm for installing and caching your dependencies
-like so (belongs in `.gitlab-ci.yml`):
-
-```yaml title=".gitlab-ci.yml"
-stages:
-  - build
-
-build:
-  stage: build
-  image: node:18.17.1
-  before_script:
-    - npm install --global corepack@latest
-    - corepack enable
-    - corepack prepare pnpm@latest-10 --activate
-    - pnpm config set store-dir .pnpm-store
-  script:
-    - pnpm install # install dependencies
-  cache:
-    key:
-      files:
-        - pnpm-lock.yaml
-    paths:
-      - .pnpm-store
-```
-
-## Bitbucket Pipelines
-
-You can use pnpm for installing and caching your dependencies:
-
-```yaml title=".bitbucket-pipelines.yml"
-definitions:
-  caches:
-    pnpm: $BITBUCKET_CLONE_DIR/.pnpm-store
-
-pipelines:
-  pull-requests:
-    "**":
-      - step:
-          name: Build and test
-          image: node:18.17.1
-          script:
-            - npm install --global corepack@latest
-            - corepack enable
-            - corepack prepare pnpm@latest-10 --activate
-            - pnpm install
-            - pnpm run build # Replace with your build/test…etc. commands
-          caches:
-            - pnpm
-```
 
 ## Azure Pipelines
 
@@ -188,6 +55,30 @@ steps:
     displayName: "pnpm install and build"
 ```
 
+## Bitbucket Pipelines
+
+You can use pnpm for installing and caching your dependencies:
+
+```yaml title=".bitbucket-pipelines.yml"
+definitions:
+  caches:
+    pnpm: $BITBUCKET_CLONE_DIR/.pnpm-store
+
+pipelines:
+  pull-requests:
+    "**":
+      - step:
+          name: Build and test
+          image: node:18.17.1
+          script:
+            - npm install --global corepack@latest
+            - corepack enable
+            - corepack prepare pnpm@latest-10 --activate
+            - pnpm install
+            - pnpm run build # Replace with your build/test…etc. commands
+          caches:
+            - pnpm
+```
 
 ## CircleCI
 
@@ -227,6 +118,64 @@ jobs:
             - .pnpm-store
 ```
 
+## GitHub Actions
+
+On GitHub Actions, you can use pnpm for installing and caching your dependencies
+like so (belongs in `.github/workflows/NAME.yml`):
+
+```yaml title=".github/workflows/NAME.yml"
+name: pnpm Example Workflow
+on:
+  push:
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        node-version: [20]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "pnpm"
+      - name: Install dependencies
+        run: pnpm install
+```
+
+## GitLab CI
+
+On GitLab, you can use pnpm for installing and caching your dependencies
+like so (belongs in `.gitlab-ci.yml`):
+
+```yaml title=".gitlab-ci.yml"
+stages:
+  - build
+
+build:
+  stage: build
+  image: node:18.17.1
+  before_script:
+    - npm install --global corepack@latest
+    - corepack enable
+    - corepack prepare pnpm@latest-10 --activate
+    - pnpm config set store-dir .pnpm-store
+  script:
+    - pnpm install # install dependencies
+  cache:
+    key:
+      files:
+        - pnpm-lock.yaml
+    paths:
+      - .pnpm-store
+```
+
 ## Jenkins
 
 You can use pnpm for installing and caching your dependencies:
@@ -235,12 +184,12 @@ You can use pnpm for installing and caching your dependencies:
 pipeline {
     agent {
         docker {
-            image 'node:lts-bullseye-slim' 
-            args '-p 3000:3000' 
+            image 'node:lts-bullseye-slim'
+            args '-p 3000:3000'
         }
     }
     stages {
-        stage('Build') { 
+        stage('Build') {
             steps {
                 sh 'npm install --global corepack@latest'
                 sh 'corepack enable'
@@ -251,3 +200,53 @@ pipeline {
     }
 }
 ```
+
+## Semaphore
+
+On [Semaphore], you can use pnpm for installing and caching your dependencies by
+adding this to your `.semaphore/semaphore.yml` file:
+
+```yaml title=".semaphore/semaphore.yml"
+version: v1.0
+name: Semaphore CI pnpm example
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
+blocks:
+  - name: Install dependencies
+    task:
+      jobs:
+        - name: pnpm install
+          commands:
+            - npm install --global corepack@latest
+            - corepack enable
+            - corepack prepare pnpm@latest-10 --activate
+            - checkout
+            - cache restore node-$(checksum pnpm-lock.yaml)
+            - pnpm install
+            - cache store node-$(checksum pnpm-lock.yaml) $(pnpm store path)
+```
+
+[Semaphore]: https://semaphoreci.com
+
+## Travis
+
+On [Travis CI], you can use pnpm for installing your dependencies by adding this
+to your `.travis.yml` file:
+
+```yaml title=".travis.yml"
+cache:
+  npm: false
+  directories:
+    - "~/.pnpm-store"
+before_install:
+  - npm install --global corepack@latest
+  - corepack enable
+  - corepack prepare pnpm@latest-10 --activate
+  - pnpm config set store-dir ~/.pnpm-store
+install:
+  - pnpm install
+```
+
+[Travis CI]: https://travis-ci.org


### PR DESCRIPTION
Nitpicking, but it felt weird to have the list unordered, so I had to rely on the table of contents, but even there, it was confusing. I figured it would be beneficial to have this list sorted in alphabetical order.