### PR TITLE
docs: fix auditConfig examples

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -1514,7 +1514,7 @@ A list of CVE IDs that will be ignored by the [`pnpm audit`] command.
 ```yaml
 auditConfig:
   ignoreCves:
-    CVE-2022-36313
+    - CVE-2022-36313
 ```
 
 [`pnpm audit`]: ./cli/audit.md
@@ -1526,10 +1526,10 @@ A list of GHSA Codes that will be ignored by the [`pnpm audit`] command.
 ```yaml
 auditConfig:
   ignoreGhsas:
-    GHSA-42xw-2xvc-qx8m
-    GHSA-4w2v-q235-vp99
-    GHSA-cph5-m8f7-6c5x
-    GHSA-vh95-rmgr-6w4m
+    - GHSA-42xw-2xvc-qx8m
+    - GHSA-4w2v-q235-vp99
+    - GHSA-cph5-m8f7-6c5x
+    - GHSA-vh95-rmgr-6w4m
 ```
 
 [`pnpm audit`]: ./cli/audit.md


### PR DESCRIPTION
`auditConfig.ignoreCves` and `auditConfig.ignoreGhsas` fields expect arrays, so the lines should start with `- ` in YAML.