### PR TITLE
docs: update URL of git subfolder test repository

### DIFF
--- a/docs/cli/add.md
+++ b/docs/cli/add.md
@@ -149,7 +149,7 @@ pnpm add andreineculau/npm-publish-git#semver:<=v0.0.7
 You may also install just a subdirectory from a Git-hosted monorepo using the `path:` parameter. For instance:
 
 ```
-pnpm add RexSkz/test-git-subdir-fetch#path:/packages/simple-react-app
+pnpm add RexSkz/test-git-subfolder-fetch#path:/packages/simple-react-app
 ```
 
 #### Install from a Git repository via a full URL


### PR DESCRIPTION
Today when trying the command from <https://pnpm.io/cli/add#install-from-a-subdirectory-of-a-git-repository>, I encountered a `Repository not found` error. Later I discovered that `RexSkz/test-git-subdir-fetch` has been renamed to `RexSkz/test-git-subfolder-fetch`.
This PR updates the documentation to reflect the current repository name.