### PR TITLE
docs: add tip about excluding pnpm in Microsoft Defender

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -27,12 +27,12 @@ Using PowerShell:
 Invoke-WebRequest https://get.pnpm.io/install.ps1 -UseBasicParsing | Invoke-Expression
 ```
 
-::: tip
+On Windows, Microsoft Defender can significantly slow down installation of packages. You can add pnpm to Microsoft Defender's list
+of excluded folders in a PowerShell window with administrator rights by executing:
 
-On Windows, Microsoft Defender can significantly slow down installation of packages. After installing pnpm, you can
-[add the pnpm store to Microsoft Defender's list of excluded folders](#windows-performance) to get a significant speedup.
-
-:::
+```powershell
+Add-MpPreference -ExclusionPath $(pnpm store path)
+```
 
 ### On POSIX systems
 
@@ -213,15 +213,6 @@ $ which pnpm
 
 Now that you know where the pnpm CLI is, open that directory and remove any pnpm-related files (`pnpm.cmd`, `pnpx.cmd`, `pnpm`, etc).
 Once done, install pnpm again and it should work as expected.
-
-### Windows performance
-
-On Windows, Microsoft Defender can significantly slow down installation of packages. You can add pnpm to Microsoft Defender's list
-of excluded folders in a PowerShell window with administrator rights by executing:
-
-```powershell
-Add-MpPreference -ExclusionPath $(pnpm store path)
-```
 
 ## Using a shorter alias
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -27,6 +27,13 @@ Using PowerShell:
 Invoke-WebRequest https://get.pnpm.io/install.ps1 -UseBasicParsing | Invoke-Expression
 ```
 
+::: tip
+
+On Windows, Microsoft Defender can significantly slow down installation of packages. After installing pnpm, you can
+[add the pnpm store to Microsoft Defender's list of excluded folders](#windows-performance) to get a significant speedup.
+
+:::
+
 ### On POSIX systems
 
 ```sh
@@ -206,6 +213,15 @@ $ which pnpm
 
 Now that you know where the pnpm CLI is, open that directory and remove any pnpm-related files (`pnpm.cmd`, `pnpx.cmd`, `pnpm`, etc).
 Once done, install pnpm again and it should work as expected.
+
+### Windows performance
+
+On Windows, Microsoft Defender can significantly slow down installation of packages. You can add pnpm to Microsoft Defender's list
+of excluded folders in a PowerShell window with administrator rights by executing:
+
+```powershell
+Add-MpPreference -ExclusionPath $(pnpm store path)
+```
 
 ## Using a shorter alias
 


### PR DESCRIPTION
This adds a little tip on the installation page with a quick way to add pnpm store to the list of excluded folders in Microsoft Defender, which can **significantly** speedup installation speeds, from 5+ minutes to just a few seconds.