### PR TITLE
docs(only-allow-pnpm): added option to enforce pnpm with package.json and .npmrc

### DIFF
--- a/docs/only-allow-pnpm.md
+++ b/docs/only-allow-pnpm.md
@@ -1,21 +1,51 @@
 ---
 id: only-allow-pnpm
-title: Only allow pnpm
+title: Only Allow PNPM
 ---
 
-When you use pnpm on a project, you don't want others to accidentally run
-`npm install` or `yarn`. To prevent devs from using other package managers,
-you can add the following `preinstall` script to your `package.json`:
+When many developers are working on the same project together, you need a failsafe in case someone accidentally runs commands with another package manager (like NPM, Yarn, Bun).
 
-```json
+To prevent dependency management conflicts between package managers:
+
+1. Create a file, if it doesn't already exist, named `.npmrc` at the root of your project.
+2. Write the following content into your `.npmrc`:
+
+```
+engine-strict=true
+```
+
+3. Write the following content into your `package.json`:
+
+```
 {
-	"scripts": {
-		"preinstall": "npx only-allow pnpm"
-	}
+  "devEngines": {
+    "runtime": {
+      "name": "node",
+      "onFail": "error"
+    },
+    "packageManager": {
+      "name": "pnpm",
+      "onFail": "error"
+    }
+  },
+  "engines": {
+    "node": ">=18.18.0",
+    "pnpm": ">=10.0.0"
+  },
 }
 ```
 
-Now, whenever someone runs `npm install` or `yarn`, they'll get an
-error instead and installation will not proceed.
+- Now, when you run `npm i`, `npm i -D` (or an equivalent), these commands return this error (before the preinstall script can run):
 
-If you use npm v7, use `npx -y` instead.
+```
+username@hostname some-project % npm i -D package
+npm error code EBADDEVENGINES
+npm error EBADDEVENGINES The developer of this package has specified the following through devEngines
+npm error EBADDEVENGINES Invalid engine "packageManager"
+npm error EBADDEVENGINES Invalid name "pnpm" does not match "npm" for "packageManager"
+npm error EBADDEVENGINES {
+npm error EBADDEVENGINES   current: { name: 'npm', version: '10.0.0' },
+npm error EBADDEVENGINES   required: { name: 'pnpm', onFail: 'error' }
+npm error EBADDEVENGINES }
+npm error A complete log of this run can be found in: /Users/username/.npm/_logs/2021-08-21T00_00_00_000Z-debug-0.log
+```

--- a/docs/only-allow-pnpm.md
+++ b/docs/only-allow-pnpm.md
@@ -5,10 +5,10 @@ title: Only Allow PNPM
 
 When many developers are working on the same project together, you need a failsafe in case someone accidentally runs commands with another package manager (like NPM, Yarn, or Bun).
 
-To prevent dependency management conflicts between package managers:
+As of Node v16.9.0 (backported to v14.19.0), to prevent dependency management conflicts between package managers:
 
 1. Create a file, if it doesn't already exist, named `.npmrc` at the root of your project.
-2. Toggle the following configuration variable in your `.npmrc` on:
+2. Set the following configuration variable in your `.npmrc` to `true`:
 
 ```
 engine-strict=true

--- a/docs/only-allow-pnpm.md
+++ b/docs/only-allow-pnpm.md
@@ -3,7 +3,7 @@ id: only-allow-pnpm
 title: Only Allow PNPM
 ---
 
-When many developers are working on the same project together, you need a failsafe in case someone accidentally runs commands with another package manager (like NPM, Yarn, Bun).
+When many developers are working on the same project together, you need a failsafe in case someone accidentally runs commands with another package manager (like NPM, Yarn, or Bun).
 
 To prevent dependency management conflicts between package managers:
 
@@ -25,6 +25,7 @@ engine-strict=true
     },
     "packageManager": {
       "name": "pnpm",
+      "version": "10.13.1",
       "onFail": "error"
     }
   },
@@ -35,7 +36,7 @@ engine-strict=true
 }
 ```
 
-- Now, when you run `npm i`, `npm i -D` (or an equivalent), these commands return this error (before the preinstall script can run):
+- Now, when you run `npm i`, `npm i -D` (or an equivalent), these commands return this error:
 
 ```
 username@hostname some-project % npm i -D package
@@ -49,3 +50,16 @@ npm error EBADDEVENGINES   required: { name: 'pnpm', onFail: 'error' }
 npm error EBADDEVENGINES }
 npm error A complete log of this run can be found in: /Users/username/.npm/_logs/2021-08-21T00_00_00_000Z-debug-0.log
 ```
+
+Alternatively, in your `package.json`, you can specify the following `preinstall` script:
+
+```
+{
+  "scripts": {
+    "preinstall": "npx only-allow pnpm"
+  }
+}
+```
+
+- You may also install the package `only-allow` as a dev dependency.
+- For NPM version 7+, you may need to run `npx -y only-allow pnpm` instead.

--- a/docs/only-allow-pnpm.md
+++ b/docs/only-allow-pnpm.md
@@ -8,13 +8,13 @@ When many developers are working on the same project together, you need a failsa
 To prevent dependency management conflicts between package managers:
 
 1. Create a file, if it doesn't already exist, named `.npmrc` at the root of your project.
-2. Write the following content into your `.npmrc`:
+2. Toggle the following configuration variable in your `.npmrc` on:
 
 ```
 engine-strict=true
 ```
 
-3. Write the following content into your `package.json`:
+3. Specify the following fields in your `package.json`:
 
 ```
 {
@@ -50,6 +50,8 @@ npm error EBADDEVENGINES   required: { name: 'pnpm', onFail: 'error' }
 npm error EBADDEVENGINES }
 npm error A complete log of this run can be found in: /Users/username/.npm/_logs/2021-08-21T00_00_00_000Z-debug-0.log
 ```
+
+---
 
 Alternatively, in your `package.json`, you can specify the following `preinstall` script:
 


### PR DESCRIPTION
# TLDR

I added a non-invasive update to a single page of the docs. Currently, the docs only tell you to add `npx only-allow pnpm` to the `preinstall` script inside `package.json`, the option—to set the `.npmrc` configuration variable `engine-strict` as true and specify PNPM as the enforced package manager in the `package.json`—is not in the docs, which is why I added this option to the docs and created a pull request.

## How to Enforce PNPM as the Only Package Manager

For easier reference, here is one of many GitHub threads that describe the same [issue](https://github.com/pnpm/only-allow/issues/33#issuecomment-3094948348):

As per the NPM [docs](https://docs.npmjs.com/cli/v11/configuring-npm/package-json), to prevent the use of an unspecified package manager, from Node v16.9.0 (backported to v14.19.0) onwards, you should:

1. Create a file, if it doesn't already exist, named `.npmrc` at the root of your project.
2. Set the following configuration variable in your `.npmrc` to `true`:

```
engine-strict=true
```

3. Specify the following fields in your `package.json`:

```
{
  "devEngines": {
    "runtime": {
      "name": "node",
      "onFail": "error"
    },
    "packageManager": {
      "name": "pnpm",
      "version": "10.13.1",
      "onFail": "error"
    }
  },
  "engines": {
    "node": ">=18.18.0",
    "pnpm": ">=10.0.0"
  },
}
```

- Now, when you run `npm i` or `npm i -D`, these commands return this error (before the preinstall script can run):

```
username@hostname nodejs-project % npm i -D package
npm error code EBADDEVENGINES
npm error EBADDEVENGINES The developer of this package has specified the following through devEngines
npm error EBADDEVENGINES Invalid engine "packageManager"
npm error EBADDEVENGINES Invalid name "pnpm" does not match "npm" for "packageManager"
npm error EBADDEVENGINES {
npm error EBADDEVENGINES   current: { name: 'npm', version: '10.9.2' },
npm error EBADDEVENGINES   required: { name: 'pnpm', onFail: 'error' }
npm error EBADDEVENGINES }
npm error A complete log of this run can be found in: /Users/username/.npm/_logs/2021-08-21T00_00_00_000Z-debug-0.log
```