### PR TITLE
chore: migrate docusaurus.config to .ts format

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -1,6 +1,8 @@
-const path = require('path');
-const { themes } = require('prism-react-renderer');
-const progress = require("./scripts/progress_lang.json");
+import path from 'node:path';
+import { themes } from 'prism-react-renderer';
+import progress from "./scripts/progress_lang.json" with { type: "json" };
+import type { Config } from '@docusaurus/types';
+import type * as Preset from '@docusaurus/preset-classic';
 
 const GITHUB_URL = 'https://github.com/pnpm/pnpm';
 const GITHUB_SPONSOR_URL = 'https://github.com/sponsors/pnpm';
@@ -29,7 +31,7 @@ function makeEditUrl (locale, path1, path2) {
   return `https://github.com/pnpm/${PROJECT_NAME}/edit/main/${path1}/${path2}`;
 }
 
-module.exports={
+const docusaurusConfig = {
   "title": "pnpm",
   "tagline": "Fast, disk space efficient package manager",
   "url": "https://pnpm.io",
@@ -72,7 +74,7 @@ module.exports={
         "theme": {
           customCss: require.resolve('./src/css/customTheme.css'),
         }
-      }
+      } satisfies Preset.Options
     ]
   ],
   "plugins": [
@@ -291,7 +293,7 @@ module.exports={
       "indexName": "pnpm",
       "contextualSearch": true,
     },
-  },
+  } satisfies Preset.ThemeConfig,
   i18n: {
     defaultLocale: DEFAULT_LOCALE,
     locales: LOCALE_CI ? [LOCALE_CI] : ['en', 'it', 'zh', 'ja', 'ko', 'pt', 'zh-TW', 'ru', 'uk', 'fr', 'tr', 'es', 'id'],
@@ -320,4 +322,6 @@ module.exports={
       // de: { label: `Deutsch (${progress["de"].translationProgress}%)` },
     },
   },
-}
+} satisfies Config;
+
+export default docusaurusConfig;

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "devDependencies": {
     "@crowdin/crowdin-api-client": "1.41.2",
+    "@docusaurus/types": "^3.8.1",
     "@types/node": "^20.12.2",
     "shx": "^0.3.4",
     "ts-node": "10.9.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       '@crowdin/crowdin-api-client':
         specifier: 1.41.2
         version: 1.41.2
+      '@docusaurus/types':
+        specifier: ^3.8.1
+        version: 3.8.1(acorn@8.15.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@types/node':
         specifier: ^20.12.2
         version: 20.17.19
@@ -718,10 +721,6 @@ packages:
 
   '@babel/runtime-corejs3@7.28.2':
     resolution: {integrity: sha512-FVFaVs2/dZgD3Y9ZD+AKNKjyGKzwu0C54laAXWUXgLcVXcCX6YZ6GhK2cp7FogSN2OA0Fu+QT8dP3FUdo9ShSQ==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/runtime@7.28.2':
-    resolution: {integrity: sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/runtime@7.28.3':
@@ -6007,8 +6006,6 @@ snapshots:
     dependencies:
       core-js-pure: 3.45.0
 
-  '@babel/runtime@7.28.2': {}
-
   '@babel/runtime@7.28.3': {}
 
   '@babel/template@7.27.2':
@@ -6345,7 +6342,7 @@ snapshots:
       '@babel/preset-env': 7.28.0(@babel/core@7.28.0)
       '@babel/preset-react': 7.27.1(@babel/core@7.28.0)
       '@babel/preset-typescript': 7.27.1(@babel/core@7.28.0)
-      '@babel/runtime': 7.28.2
+      '@babel/runtime': 7.28.3
       '@babel/runtime-corejs3': 7.28.2
       '@babel/traverse': 7.28.0
       '@docusaurus/logger': 3.8.1
@@ -7446,11 +7443,11 @@ snapshots:
   '@types/eslint-scope@3.7.7':
     dependencies:
       '@types/eslint': 9.6.1
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.8
 
   '@types/eslint@9.6.1':
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.8
       '@types/json-schema': 7.0.15
 
   '@types/estree-jsx@1.0.5':
@@ -8999,7 +8996,7 @@ snapshots:
 
   history@4.10.1:
     dependencies:
-      '@babel/runtime': 7.28.2
+      '@babel/runtime': 7.28.3
       loose-envify: 1.4.0
       resolve-pathname: 3.0.0
       tiny-invariant: 1.3.3
@@ -10688,19 +10685,19 @@ snapshots:
 
   react-loadable-ssr-addon-v5-slorber@1.0.1(@docusaurus/react-loadable@6.0.0(react@19.1.1))(webpack@5.98.0):
     dependencies:
-      '@babel/runtime': 7.28.2
+      '@babel/runtime': 7.28.3
       react-loadable: '@docusaurus/react-loadable@6.0.0(react@19.1.1)'
       webpack: 5.98.0
 
   react-router-config@5.1.1(react-router@5.3.4(react@19.1.1))(react@19.1.1):
     dependencies:
-      '@babel/runtime': 7.28.2
+      '@babel/runtime': 7.28.3
       react: 19.1.1
       react-router: 5.3.4(react@19.1.1)
 
   react-router-dom@5.3.4(react@19.1.1):
     dependencies:
-      '@babel/runtime': 7.28.2
+      '@babel/runtime': 7.28.3
       history: 4.10.1
       loose-envify: 1.4.0
       prop-types: 15.8.1
@@ -10711,7 +10708,7 @@ snapshots:
 
   react-router@5.3.4(react@19.1.1):
     dependencies:
-      '@babel/runtime': 7.28.2
+      '@babel/runtime': 7.28.3
       history: 4.10.1
       hoist-non-react-statics: 3.3.2
       loose-envify: 1.4.0
@@ -11318,7 +11315,7 @@ snapshots:
   terser@5.39.0:
     dependencies:
       '@jridgewell/source-map': 0.3.6
-      acorn: 8.14.0
+      acorn: 8.15.0
       commander: 2.20.3
       source-map-support: 0.5.21
 


### PR DESCRIPTION
Docusaurus 3.x supports docusaurus.config.ts.

https://docusaurus.io/docs/api/docusaurus-config

You can use `import` and `export` statements there unlike the previous docusaurus.config.js.