### PR TITLE
docs: add note about Node.js 22+ script execution without pnpm

### DIFF
--- a/docs/settings/_shellEmulator.mdx
+++ b/docs/settings/_shellEmulator.mdx
@@ -18,5 +18,11 @@ next script will fail on non-POSIX-compliant systems:
 But if the `shellEmulator` setting is set to `true`, it will work on all
 platforms.
 
+:::note
+
+Node.js 22 or higher supports running scripts without pnpm's assistance. For the example above, you can run the `test` script with `node --run test`. However, the `shellEmulator` option has no effect on this. Scripts that depend on POSIX features are required to be run `pnpm run` instead of `node --run` to work in non-POSIX-compliant environments.
+
+:::
+
 [bash-like shell]: https://www.npmjs.com/package/@yarnpkg/shell
 


### PR DESCRIPTION
Node.js 22+ supports `node --run` without pnpm, but it does not respect `shellEmulator`. It should be warned that `pnpm run` is required to run scripts that depend on Bash features.