### PR TITLE
fix example cmd and add pattern in aliases.md

### DIFF
--- a/docs/aliases.md
+++ b/docs/aliases.md
@@ -17,11 +17,21 @@ Publish a new package called `awesome-lodash` and install it using `lodash` as
 its alias:
 
 ```
-pnpm add lodash@npm:awesome-lodash
+pnpm add awesome-lodash@npm:lodash
 ```
 
 No changes in code are needed. All the requires of `lodash` will now resolve to
 `awesome-lodash`.
+
+The general pattern is:
+
+```
+<alias>@npm:<target-package>[@version]
+```
+
+- `<alias>`: the name you’ll use in your code
+- `<target-package>`: the actual package name on npm
+- `[@version]`: optional version specifier
 
 Sometimes you'll want to use two different versions of a package in your
 project. Easy:


### PR DESCRIPTION
The docs for aliases display a wrong command. This PR fixes that and also adds a general explanation of the pattern to be used. 

- related to https://github.com/pnpm/pnpm/issues/5645