### PR TITLE
Document default of `--location` for `pnpm config`

### DIFF
--- a/docs/cli/config.md
+++ b/docs/cli/config.md
@@ -44,6 +44,8 @@ Set the configuration in the global config file.
 
 ### --location
 
+By default, `--location` is set to `global`.
+
 When set to `project`, the `.npmrc` file at the nearest `package.json` will be used. If no `.npmrc` file is present in the directory, the setting will be written to a `pnpm-workspace.yaml` file.
 
 When set to `global`, the performance is the same as setting the `--global` option.


### PR DESCRIPTION
Document the default of the `--location` flag for `pnpm config` commands

It appears that the default of the `--location` setting for `pnpm config` is `global`:

```bash
$ pnpm config set x true
$ pnpm config get x
true
$ cat "$HOME/Library/Preferences/pnpm/rc"
x=true
```