### PR TITLE
docs: add reporter setting to settings reference

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -949,6 +949,18 @@ Controls colors in the output.
 Any logs at or higher than the given level will be shown.
 You can instead pass `--silent` to turn off all output logs.
 
+### reporter
+
+* Default: **default**
+* Type: **silent**, **default**, **append-only**, **ndjson**
+
+Allows you to customize the output style of the logs.
+
+* **silent** - no output is logged to the console, not even fatal errors.
+* **default** - the default reporter when the stdout is a terminal or TTY.
+* **append-only** - the output is always appended to the end. No cursor manipulations are performed. This is useful in CI environments or when you want to see full log output.
+* **ndjson** - the most verbose reporter. Prints all logs in [ndjson](https://github.com/ndjson/ndjson-spec) format.
+
 ### useBetaCli
 
 * Default: **false**


### PR DESCRIPTION
## Summary

The `reporter` option is documented as a CLI flag (`--reporter`) on the [install page](https://pnpm.io/cli/install#--reportername), and it works correctly when set in either `.npmrc` or `pnpm-workspace.yaml`. However, it was missing from the [settings reference](https://pnpm.io/settings) page.

This omission causes practical issues for users who want to configure `reporter` at the project level:

- Setting `reporter=append-only` in `.npmrc` triggers an npm warning:
  ```
  npm warn Unknown user config "reporter". This will stop working in the next major version of npm. See `npm help npmrc` for supported config options.
  ```

- Setting `reporter: append-only` in `pnpm-workspace.yaml` triggers an editor/IDE warning from SchemaStore validation:
  ```
  Property reporter is not allowed. yaml-schema: pnpm Workspace (pnpm-workspace.yaml)(513)
  ```

Both configurations work as expected with pnpm, but users have no warning-free way to set this option.

## Changes

Added `reporter` setting documentation between `loglevel` and `useBetaCli` in `docs/settings.md`, following the same format as other enum-type settings like `color` and `loglevel`.

## Related

- Closes https://github.com/pnpm/pnpm/issues/7238
- https://pnpm.io/cli/install#--reportername
