### PR TITLE
Add Discord link to Community section in footer

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -268,7 +268,7 @@ const docusaurusConfig = {
             },
             {
               label: 'Discord',
-              href: 'https://bit.ly/pnpm-discord-invite'
+              href: 'https://r.pnpm.io/chat'
             },
           ]
         },

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -266,6 +266,10 @@ const docusaurusConfig = {
               label: 'Bluesky',
               href: 'https://bsky.app/profile/pnpm.io'
             },
+            {
+              label: 'Discord',
+              href: 'https://bit.ly/pnpm-discord-invite'
+            },
           ]
         },
         {


### PR DESCRIPTION
I was having trouble finding the Discord link (ended up finding it through the issue https://github.com/pnpm/pnpm/issues/3095)

What do you think about including it prominently in the footer?

Companion PR, adding to `pnpm/pnpm` readme

- https://github.com/pnpm/pnpm/pull/11166