### PR TITLE
docs: Upgrade Node.js version in Dockerfile

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -34,9 +34,10 @@ dist
 ```
 
 ```dockerfile title="Dockerfile"
-FROM node:20-slim AS base
+FROM node:24-slim AS base
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
+RUN npm install --global corepack@latest
 RUN corepack enable
 COPY . /app
 WORKDIR /app
@@ -104,9 +105,10 @@ dist
 ```
 
 ```dockerfile title="Dockerfile"
-FROM node:20-slim AS base
+FROM node:24-slim AS base
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
+RUN npm install --global corepack@latest
 RUN corepack enable
 
 FROM base AS build
@@ -144,10 +146,11 @@ On CI or CD environments, the BuildKit cache mounts might not be available, beca
 So an alternative is to use a typical Dockerfile with layers that are built incrementally, for this scenario, `pnpm fetch` is the best option, as it only needs the `pnpm-lock.yaml` file and the layer cache will only be lost when you change the dependencies.
 
 ```dockerfile title="Dockerfile"
-FROM node:20-slim AS base
+FROM node:24-slim AS base
 
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
+RUN npm install --global corepack@latest
 RUN corepack enable
 
 FROM base AS prod

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -37,7 +37,6 @@ dist
 FROM node:24-slim AS base
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-RUN npm install --global corepack@latest
 RUN corepack enable
 COPY . /app
 WORKDIR /app
@@ -108,7 +107,6 @@ dist
 FROM node:24-slim AS base
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-RUN npm install --global corepack@latest
 RUN corepack enable
 
 FROM base AS build
@@ -150,7 +148,6 @@ FROM node:24-slim AS base
 
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-RUN npm install --global corepack@latest
 RUN corepack enable
 
 FROM base AS prod


### PR DESCRIPTION
This PR updates the Dockerfile based on the official pnpm guide.
The base image is upgraded from Node.js 20 to Node.js 24 as Node.js 20 is nearing end of LTS.
It also adds an explicit Corepack installation to align with changes in newer Node.js versions.
These updates ensure pnpm works reliably in the container environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Docker examples to reference Node.js 24, ensuring compatibility with the latest Node.js version in provided configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->