### PR TITLE
[codex] docs: add releases link to installation

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -7,6 +7,12 @@ title: Installation
 
 If you don't use the standalone script or `@pnpm/exe` to install pnpm, then you need to have Node.js (at least v22) to be installed on your system.
 
+:::tip
+
+Prefer downloading a prebuilt binary directly? You can get the latest standalone executables from the [pnpm releases page](https://github.com/pnpm/pnpm/releases).
+
+:::
+
 ## Using a standalone script
 
 You may install pnpm even if you don't have Node.js installed, using the following scripts.


### PR DESCRIPTION
## Summary
- add a direct GitHub Releases link near the top of the installation page
- make the standalone binary download path easier to discover for users who prefer direct binaries

Closes #751.

## Validation
- reviewed the rendered markdown diff locally
- `npx prettier --check docs/installation.md` could not run because this repo pins `devEngines.runtime.version` to Node 22 and this machine is running Node 24
