### PR TITLE
[codex] docs: add windows uninstall instructions

### DIFF
--- a/docs/uninstall.md
+++ b/docs/uninstall.md
@@ -16,11 +16,22 @@ To list all the global packages, run `pnpm ls -g`. There are two ways to remove 
 
 If you used the standalone script to install pnpm, then you should be able to uninstall the pnpm CLI by removing the pnpm home directory:
 
+### On POSIX systems
+
 ```
 rm -rf "$PNPM_HOME"
 ```
 
 You might also want to clean the `PNPM_HOME` env variable in your shell configuration file (`$HOME/.bashrc`, `$HOME/.zshrc` or `$HOME/.config/fish/config.fish`).
+
+### On Windows
+
+```powershell
+Remove-Item -Recurse -Force $env:PNPM_HOME
+[Environment]::SetEnvironmentVariable('PNPM_HOME', $null, 'User')
+```
+
+If `PNPM_HOME` was added to your `Path`, remove that entry from your user environment variables as well.
 
 If you used npm to install pnpm, then you should use npm to uninstall pnpm:
 
@@ -30,10 +41,17 @@ npm rm -g pnpm
 
 ## Removing the global content-addressable store
 
+### On POSIX systems
+
 ```
 rm -rf "$(pnpm store path)"
 ```
 
+### On Windows
+
+```powershell
+Remove-Item -Recurse -Force (pnpm store path)
+```
+
 If you used pnpm in non-primary disks, then you must run the above command in every disk, where pnpm was used.
 pnpm creates one store per disk.
-


### PR DESCRIPTION
## Summary
- add Windows-specific uninstall commands for removing `PNPM_HOME`
- add a Windows command for removing the global store directory
- keep the existing POSIX instructions and make the platform split explicit

Closes #689.

## Validation
- reviewed the rendered markdown diff locally
- `npx prettier --check docs/uninstall.md` could not run because this repo pins `devEngines.runtime.version` to Node 22 and this machine is running Node 24
