### PR TITLE
docs(settings): Drop react-native note from `hoisted` docs

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -447,7 +447,7 @@ Defines what linker should be used for installing Node packages.
 
 * **isolated** - dependencies are symlinked from a virtual store at `node_modules/.pnpm`.
 * **hoisted** - a flat `node_modules` without symlinks is created. Same as the `node_modules` created by npm or Yarn Classic. One of Yarn's libraries is used for hoisting, when this setting is used. Legitimate reasons to use this setting:
-  1. Your tooling doesn't work well with symlinks. A React Native project will most probably only work if you use a hoisted `node_modules`.
+  1. Your tooling doesn't work well with symlinks.
   1. Your project is deployed to a serverless hosting provider. Some serverless providers (for instance, AWS Lambda) don't support symlinks. An alternative solution for this problem is to bundle your application before deployment.
   1. If you want to publish your package with [`"bundledDependencies"`].
   1. If you are running Node.js with the [--preserve-symlinks] flag.


### PR DESCRIPTION
Proposal to drop the "A React Native project will most probably only work if you use a hoisted `node_modules`."

There's a bit of nuance to this, because not all React Native projects are the same or set up the same. That said, one recommendation is to use a framework, e.g. Expo: https://reactnative.dev/docs/environment-setup

While I can't vouch for all React Native dependencies and setups to be isolated-safe, at Expo, we've actively worked on this and now support and guarantee that isolated installations work. In fact, we're looking to move this to be the default recommendation for pnpm gradually. We've also in the meantime have started switching the `expo/expo` monorepo to use pnpm in isolated mode as well.

There's kind of a longer story to this, [some of which I've written about in my blog post](https://kitten.sh/blog/autolinkings-broken-promise), but as a direct consequence, I'd love to see:
- the generic "React Native project" example removed from this section of the docs
- and; if it does need to be preserved, it shouldn't make generic statements that may change or are affected by non-Expo projects or make implications that users might generalise to apply to Expo projects

Cheers!