### PR TITLE
docs(sbom): Correct option name and document remaining flags

### DIFF
--- a/docs/cli/sbom.md
+++ b/docs/cli/sbom.md
@@ -15,12 +15,44 @@ Supported formats:
 ## Usage
 
 ```sh
-pnpm sbom --format cyclonedx
-pnpm sbom --format spdx
+pnpm sbom --sbom-format cyclonedx
+pnpm sbom --sbom-format spdx
+pnpm sbom --sbom-format cyclonedx --lockfile-only
+pnpm sbom --sbom-format spdx --prod
 ```
 
 ## Options
 
-### --format &lt;format\>
+### --sbom-format &lt;cyclonedx|spdx\>
 
-The SBOM format to generate. Supported values: `cyclonedx`, `spdx`.
+The SBOM output format. This option is required. Supported values: `cyclonedx`, `spdx`.
+
+### --sbom-type &lt;library|application\>
+
+* Default: **library**
+
+The component type for the root package.
+
+### --lockfile-only
+
+Only use lockfile data (skip reading from the store).
+
+### --sbom-authors &lt;names\>
+
+Comma-separated list of SBOM authors. Written to `metadata.authors` in the CycloneDX output.
+
+### --sbom-supplier &lt;name\>
+
+SBOM supplier name. Written to `metadata.supplier` in the CycloneDX output.
+
+### --prod, -P
+
+Only include `dependencies` and `optionalDependencies`.
+
+### --dev, -D
+
+Only include `devDependencies`.
+
+### --no-optional
+
+Don't include `optionalDependencies`.


### PR DESCRIPTION
- `--format` -> `--sbom-format`
- Add other options in docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated `pnpm sbom` command documentation with revised usage examples demonstrating proper command syntax and option combinations for Software Bill of Materials generation.
  * Provided comprehensive and detailed descriptions of all available configuration flags and their usage for customizing SBOM output format, type, dependency filtering, and metadata configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->