### PR TITLE
docs(global-packages): document directory layout and list -g semantics

### DIFF
--- a/docs/global-packages.md
+++ b/docs/global-packages.md
@@ -61,7 +61,7 @@ The contents of `{pnpmHomeDir}/global/v11/` look like:
 
 - The `{hash}` entries are symlinks; pnpm scans for them to enumerate active installs.
 - The targets are real directories that act as ordinary pnpm projects — each has its own `package.json` and lockfile.
-- The shared `store/` directory holds the [global virtual store](./global-virtual-store.md), which is referenced by `node_modules/.pnpm` inside every install group.
+- The shared `store/` directory holds the [global virtual store](./global-virtual-store.md). Each install group's direct dependencies — the entries at the root of its `node_modules/` — are symlinks into that store, so the actual package contents are shared rather than copied per group.
 - Bin shims live in `{pnpmHomeDir}/bin/` and point through the appropriate install group's `node_modules`.
 
 When a package is removed or its install group is replaced, the hash symlink is updated and orphaned target directories are eventually cleaned up by `pnpm store prune`.

--- a/docs/global-packages.md
+++ b/docs/global-packages.md
@@ -32,6 +32,57 @@ pnpm add -g prettier
 
 creates two separate isolated installations — `typescript` and `prettier` each get their own `node_modules` tree and cannot affect each other's dependency resolution.
 
+Installing multiple packages in a single command groups them into one isolated install:
+
+```sh
+pnpm add -g eslint prettier
+```
+
+`eslint` and `prettier` share a `node_modules` tree and lockfile, so peer dependencies are resolved against each other. Removing either with `pnpm remove -g` removes the entire group.
+
+## Directory layout
+
+The contents of `{pnpmHomeDir}/global/v11/` look like:
+
+```text
+{pnpmHomeDir}/global/v11/
+├── {hash-A}              → symlink → ./{hash-A-target}/
+├── {hash-A-target}/      ← isolated install dir
+│   ├── package.json      ← lists the packages installed together
+│   ├── pnpm-lock.yaml    ← lockfile for this install group
+│   └── node_modules/
+│       ├── <pkg>/        ← top-level dep, symlinked into the global virtual store
+│       └── .pnpm/
+├── {hash-B}              → symlink → ./{hash-B-target}/
+├── {hash-B-target}/      ← another isolated install dir
+└── store/                ← shared global virtual store
+    └── ...
+```
+
+- The `{hash}` entries are symlinks; pnpm scans for them to enumerate active installs.
+- The targets are real directories that act as ordinary pnpm projects — each has its own `package.json` and lockfile.
+- The shared `store/` directory holds the [global virtual store](./global-virtual-store.md), which is referenced by `node_modules/.pnpm` inside every install group.
+- Bin shims live in `{pnpmHomeDir}/bin/` and point through the appropriate install group's `node_modules`.
+
+When a package is removed or its install group is replaced, the hash symlink is updated and orphaned target directories are eventually cleaned up by `pnpm store prune`.
+
+## Listing global packages
+
+```sh
+pnpm list -g
+pnpm list -g --json        # machine-readable
+pnpm list -g --parseable   # paths only
+```
+
+Because each install group has its own lockfile, listing across multiple groups can only reliably aggregate the top-level packages they were installed with — transitive dependency trees from different groups can't be coherently merged. As a result:
+
+- `pnpm list -g` (default `--depth=0`) always works and shows every globally installed package.
+- `pnpm list -g --depth=<n>` (with `n > 0`) shows the full dependency tree only when:
+  - there is just one global install group, or
+  - a positional argument narrows the request to a single install group, e.g. `pnpm list -g eslint --depth=1`.
+
+If `--depth>0` is requested but the request can't be narrowed to a single install group, pnpm errors with `ERR_PNPM_GLOBAL_LS_DEPTH_NOT_SUPPORTED`.
+
 ## Managing global packages
 
 | Command | Description |


### PR DESCRIPTION
## Summary
Extends `docs/global-packages.md` with two new sections that explain the v11 isolated-globals architecture in more detail, in connection with [pnpm/pnpm#11451](https://github.com/pnpm/pnpm/pull/11451) (which fixes the `pnpm -g ls --json` regression and tightens `--depth>0` semantics).

- **Directory layout** — describes the `{pnpmHomeDir}/global/v11/{hash}` symlink → install-dir structure, what each install dir contains (`package.json`, `pnpm-lock.yaml`, `node_modules` with `.pnpm` linking into the shared global virtual store), where bin shims live, and how `pnpm store prune` cleans up orphans.
- **Listing global packages** — covers `pnpm list -g`, `--json`, `--parseable`, and explains the new `--depth=<n>` rules (works when there is a single install group, or when a positional argument narrows to one; otherwise errors with `ERR_PNPM_GLOBAL_LS_DEPTH_NOT_SUPPORTED`).

## Test plan
- [x] Markdown renders correctly in a local Docusaurus preview (no broken links, code blocks formatted).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarifies that installing multiple global packages together creates a single isolated install group and that removing one package removes the whole group.
  * Describes the global install directory layout, shared store and symlink behavior, per-install metadata, and location of executable shims.
  * Notes cleanup via store pruning and limits of `pnpm list -g --depth>0` for multi-package groups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->