### PR TITLE
Document `ignoreWorkspaceRootCheck` configuration

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -1130,6 +1130,15 @@ Migration:
 
 See also [`pnpm with`](./cli/with.md) for running pnpm at a specific version without changing this setting.
 
+### ignoreWorkspaceRootCheck
+
+* Default: **false**
+* Type: **Boolean**
+
+If this is enabled, running `pnpm install`/`pnpm add` from the project's root 
+folder will no longer error when `-w`/`--ignore-workspace-root-check` is not 
+provided.
+
 ## Build Settings
 
 ### ignoreScripts


### PR DESCRIPTION
Hey 👋 

closes #787.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for the `ignoreWorkspaceRootCheck` CLI setting, a Boolean option that defaults to `false` for controlling error behavior when running package management commands from the workspace root.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->