### PR TITLE
Fix link in release notes for v11.0 migration guide

### DIFF
--- a/blog/releases/11.0.md
+++ b/blog/releases/11.0.md
@@ -9,7 +9,7 @@ pnpm 11 is here! This release tightens the security defaults introduced througho
 
 It also requires Node.js 22 or newer — pnpm itself is now pure ESM.
 
-Upgrading from v10? See the [Migrating from v10 to v11](/11.x/migration) guide. Most config changes are mechanical and can be applied by the `pnpm-v10-to-v11` codemod.
+Upgrading from v10? See the [Migrating from v10 to v11](/migration) guide. Most config changes are mechanical and can be applied by the `pnpm-v10-to-v11` codemod.
 
 <!-- truncate -->
 

--- a/blog/releases/11.0.md
+++ b/blog/releases/11.0.md
@@ -239,7 +239,7 @@ Installing a Node.js runtime via `node@runtime:<version>` (including `pnpm env u
 
 ## Upgrading
 
-See the full [Migrating from v10 to v11](/11.x/migration) guide for the codemod and manual follow-ups. The short version:
+See the full [Migrating from v10 to v11](/migration) guide for the codemod and manual follow-ups. The short version:
 
 - Bump your CI and dev environments to **Node.js 22+** before upgrading.
 - Move pnpm settings out of `.npmrc` into `pnpm-workspace.yaml` (or the global `~/.config/pnpm/config.yaml`).


### PR DESCRIPTION
Hello,

The [v11 release notes](https://pnpm.io/blog/releases/11.0)￼ currently link to an incorrect migration guide page. The correct migration guide is available here: https://pnpm.io/migration.

Cheers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the “Migrating from v10 to v11” links in the v11.0 release notes to point to the canonical migration guide instead of a versioned path, ensuring users are directed to the current, maintained migration documentation across both the detailed and short “Upgrading” sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->