### PR TITLE
fix(css): don't use `system-ui` in font stack

### DIFF
--- a/src/css/customTheme.css
+++ b/src/css/customTheme.css
@@ -6,7 +6,9 @@
   --ifm-color-primary-dark: #F0850A;
   --ifm-color-primary-darker: #E37D09;
   --ifm-color-primary-darkest: #BB6708;
-  --ifm-font-family-base: ui-sans-serif,system-ui,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji";
+  /* Respect https://github.com/pnpm/pnpm.io/pull/446 and don't use system-ui here, as this is not a part of WebView of desktop applications or widgets */
+  /* Refer to https://github.com/withastro/starlight/pull/3729/changes#diff-3e03f77157bcc4a066397ec53cae30394deec0bf418621d96a3bc93e4c0de390 */
+  --ifm-font-family-base: ui-sans-serif, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
 }
 
 .header-github-link::before {


### PR DESCRIPTION
Partially reverts #778 
Partially reapplies #446 

`system-ui` is optimal for WebView of desktop apps or widgets. It cause some rendering problems in general i18n web sites. (especially in CJK languages in Windows).

See for the details:

https://github.com/withastro/starlight/pull/3729
https://github.com/facebook/docusaurus/issues/11727

- macOS → still uses system fonts by (`ui-sans-serif` and) `-apple-system` and `BlinkMacSystemFont`
- Greek-derived scripts (Latin, Cyrillic) → famous Latin system fonts in various OSes
- non-Greek-derived scripts → ditto or fall back to `sans-serif` (standard fonts chosen by a user or browser)

Other than `ui-sans-serif` (no effect outside Apple devices) are taken from https://github.com/withastro/starlight/pull/3729

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the default font stack to improve typography consistency and visual appearance across the application.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm.io/pull/790)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->