### PR TITLE
docs: document pnpm v11.1

### DIFF
--- a/blog/releases/11.1.md
+++ b/blog/releases/11.1.md
@@ -1,0 +1,75 @@
+---
+title: pnpm 11.1
+authors: zkochan
+tags: [release]
+date: 2026-05-11
+---
+
+pnpm 11.1 adds a few new commands — [`pnpm audit signatures`](/cli/audit#signatures), [`pnpm bugs`](/cli/bugs), and [`pnpm owner`](/cli/owner) — alongside support for installing from arbitrary named registries (including a built-in alias for the GitHub Packages npm registry), the ability to skip runtime installation in CI, and several fixes.
+
+<!-- truncate -->
+
+### Minor Changes
+
+#### `pnpm audit signatures`
+
+A new [`pnpm audit signatures`](/cli/audit#signatures) subcommand verifies ECDSA registry signatures for installed packages against keys published at `/-/npm/v1/keys` [#7909](https://github.com/pnpm/pnpm/issues/7909). Scoped registries are respected; registries that don't publish signing keys are skipped.
+
+```sh
+pnpm audit signatures
+```
+
+#### Named registries (and a built-in `gh:` alias)
+
+You can now install packages from the [GitHub Packages npm registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-npm-registry) via a built-in `gh:` prefix, and — more broadly — from arbitrary named registries in the style of [vlt's named-registry aliases](https://docs.vlt.sh/cli/registries):
+
+```sh
+pnpm add gh:@acme/private
+```
+
+Authentication is picked up from existing per-URL `.npmrc` entries (e.g. `//npm.pkg.github.com/:_authToken=...`), so no separate auth mechanism is required.
+
+Additional aliases — or an override for the built-in `gh` alias, for GitHub Enterprise Server — can be configured under `namedRegistries` in `pnpm-workspace.yaml`:
+
+```yaml title="pnpm-workspace.yaml"
+namedRegistries:
+  gh: https://npm.pkg.github.example.com/
+  work: https://npm.work.example.com/
+```
+
+With this, `work:@corp/lib@^2.0.0` resolves against `https://npm.work.example.com/`. See [#8941](https://github.com/pnpm/pnpm/issues/8941).
+
+#### `--sbom-spec-version`
+
+[`pnpm sbom`](/cli/sbom) now accepts a `--sbom-spec-version` flag to choose the CycloneDX specification version (`1.5`, `1.6`, or `1.7` — default `1.7`). The flag is only valid with `--sbom-format cyclonedx`. See [#11389](https://github.com/pnpm/pnpm/pull/11389).
+
+#### `--no-runtime` for CI matrices
+
+A new `--no-runtime` flag (config: `runtime=false`) skips installing runtime entries (e.g. Node.js downloaded via `devEngines.runtime`) without modifying the lockfile. The lockfile keeps the runtime entry so frozen-lockfile validation still passes; only the runtime fetch and `.bin` linking are skipped. This is useful in CI matrices where the runtime is provisioned externally (e.g. via `pnpm runtime -g set node <version>`) before `pnpm install` runs.
+
+#### `pnpm bugs`
+
+The new [`pnpm bugs`](/cli/bugs) command opens a package's bug tracker URL in the browser. With no arguments, it reads the current project's `package.json`; with one or more package names, it fetches each package's metadata from the registry and opens its bug tracker. It falls back to `<repository>/issues` when the `bugs` field is missing. See [#11279](https://github.com/pnpm/pnpm/pull/11279).
+
+#### `pnpm owner`
+
+The new [`pnpm owner`](/cli/owner) command manages package owners on the registry:
+
+```sh
+pnpm owner ls <package>
+pnpm owner add <package> <user>
+pnpm owner rm <package> <user>
+```
+
+### Patch Changes
+
+- `pnpm view` now prints "published X ago by Y" alongside the rest of its output, mirroring `npm view`. This is useful when comparing against `minimumReleaseAge`. For example, `pnpm view pnpm` now shows `published 17 hours ago by GitHub Actions`.
+- `pnpm publish` now honors the configured HTTP/HTTPS proxy (including the `https_proxy` / `http_proxy` / `no_proxy` environment variables) when polling the registry's `doneUrl` during the web-based authentication flow. Previously the poll bypassed the proxy, causing the registry to respond `403` from a different source IP and the login to never complete [#11561](https://github.com/pnpm/pnpm/issues/11561).
+- `pnpm add -g` now installs each space-separated package into its own isolated directory by default. To bundle multiple packages into the same isolated install (so they share dependencies and are removed together), pass them as a comma-separated list. For example:
+
+  - `pnpm add -g foo bar` installs `foo` and `bar` as two independent globals — removing one does not affect the other.
+  - `pnpm add -g foo,bar qar` bundles `foo` and `bar` into a single isolated install while `qar` is installed on its own.
+
+  Related: [#11587](https://github.com/pnpm/pnpm/issues/11587).
+- `pnpm runtime set <name> <version>` no longer fails in the root of a multi-package workspace with the `ADDING_TO_ROOT` error. Installing the workspace root is a valid target for a runtime, so the command now bypasses that safety check.
+- Fixed `pnpm --version` hanging for the lifetime of the worker pool after the version was printed. The CLI entry now runs `finishWorkers()` from its own `finally`, so every exit path tears the pool down.

--- a/blog/releases/11.1.md
+++ b/blog/releases/11.1.md
@@ -9,9 +9,9 @@ pnpm 11.1 adds a few new commands — [`pnpm audit signatures`](/cli/audit#signa
 
 <!-- truncate -->
 
-### Minor Changes
+## Minor Changes
 
-#### `pnpm audit signatures`
+### `pnpm audit signatures`
 
 A new [`pnpm audit signatures`](/cli/audit#signatures) subcommand verifies ECDSA registry signatures for installed packages against keys published at `/-/npm/v1/keys` [#7909](https://github.com/pnpm/pnpm/issues/7909). Scoped registries are respected; registries that don't publish signing keys are skipped.
 
@@ -19,7 +19,7 @@ A new [`pnpm audit signatures`](/cli/audit#signatures) subcommand verifies ECDSA
 pnpm audit signatures
 ```
 
-#### Named registries (and a built-in `gh:` alias)
+### Named registries (and a built-in `gh:` alias)
 
 You can now install packages from the [GitHub Packages npm registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-npm-registry) via a built-in `gh:` prefix, and — more broadly — from arbitrary named registries in the style of [vlt's named-registry aliases](https://docs.vlt.sh/cli/registries):
 
@@ -39,19 +39,19 @@ namedRegistries:
 
 With this, `work:@corp/lib@^2.0.0` resolves against `https://npm.work.example.com/`. See [#8941](https://github.com/pnpm/pnpm/issues/8941).
 
-#### `--sbom-spec-version`
+### `--sbom-spec-version`
 
 [`pnpm sbom`](/cli/sbom) now accepts a `--sbom-spec-version` flag to choose the CycloneDX specification version (`1.5`, `1.6`, or `1.7` — default `1.7`). The flag is only valid with `--sbom-format cyclonedx`. See [#11389](https://github.com/pnpm/pnpm/pull/11389).
 
-#### `--no-runtime` for CI matrices
+### `--no-runtime` for CI matrices
 
 A new `--no-runtime` flag (config: `runtime=false`) skips installing runtime entries (e.g. Node.js downloaded via `devEngines.runtime`) without modifying the lockfile. The lockfile keeps the runtime entry so frozen-lockfile validation still passes; only the runtime fetch and `.bin` linking are skipped. This is useful in CI matrices where the runtime is provisioned externally (e.g. via `pnpm runtime -g set node <version>`) before `pnpm install` runs.
 
-#### `pnpm bugs`
+### `pnpm bugs`
 
 The new [`pnpm bugs`](/cli/bugs) command opens a package's bug tracker URL in the browser. With no arguments, it reads the current project's `package.json`; with one or more package names, it fetches each package's metadata from the registry and opens its bug tracker. It falls back to `<repository>/issues` when the `bugs` field is missing. See [#11279](https://github.com/pnpm/pnpm/pull/11279).
 
-#### `pnpm owner`
+### `pnpm owner`
 
 The new [`pnpm owner`](/cli/owner) command manages package owners on the registry:
 
@@ -61,7 +61,7 @@ pnpm owner add <package> <user>
 pnpm owner rm <package> <user>
 ```
 
-### Patch Changes
+## Patch Changes
 
 - `pnpm view` now prints "published X ago by Y" alongside the rest of its output, mirroring `npm view`. This is useful when comparing against `minimumReleaseAge`. For example, `pnpm view pnpm` now shows `published 17 hours ago by GitHub Actions`.
 - `pnpm publish` now honors the configured HTTP/HTTPS proxy (including the `https_proxy` / `http_proxy` / `no_proxy` environment variables) when polling the registry's `doneUrl` during the web-based authentication flow. Previously the poll bypassed the proxy, causing the registry to respond `403` from a different source IP and the login to never complete [#11561](https://github.com/pnpm/pnpm/issues/11561).

--- a/docs/cli/audit.md
+++ b/docs/cli/audit.md
@@ -24,6 +24,20 @@ Since v11, `pnpm audit` queries the registry's `/-/npm/v1/security/advisories/bu
 [overrides]: ../settings.md#overrides
 [`auditConfig.ignoreGhsas`]: #auditconfigignoreghsas
 
+## Commands
+
+### signatures
+
+Added in: v11.1.0
+
+```sh
+pnpm audit signatures
+```
+
+Verifies the ECDSA registry signatures of installed packages against the public keys published by each registry at `/-/npm/v1/keys`. Scoped registries configured via [`registries`](../settings.md#registries) are respected; registries that don't publish signing keys are skipped.
+
+The command exits with code `1` if any package has an invalid signature, or if a registry advertises signing keys but a package was published without a signature. Combine with `--json` to get machine-readable output.
+
 ## Options
 
 ### --audit-level &lt;severity\>

--- a/docs/cli/bugs.md
+++ b/docs/cli/bugs.md
@@ -1,0 +1,38 @@
+---
+id: bugs
+title: pnpm bugs
+---
+
+Added in: v11.1.0
+
+Opens a package's bug tracker URL in the browser.
+
+```sh
+pnpm bugs [<pkg> ...]
+```
+
+When run without arguments inside a package directory, it opens the bug tracker for the current project (using the `bugs` field from `package.json`).
+
+When one or more package names are passed, pnpm fetches each package's metadata from the registry and opens its bug tracker.
+
+If a package does not declare a `bugs` field, pnpm falls back to `<repository>/issues` derived from the `repository` field.
+
+## Examples
+
+Open the bug tracker for a published package:
+
+```sh
+pnpm bugs lodash
+```
+
+Open the bug tracker for multiple packages at once:
+
+```sh
+pnpm bugs react react-dom
+```
+
+Open the bug tracker for the current project:
+
+```sh
+pnpm bugs
+```

--- a/docs/cli/install.md
+++ b/docs/cli/install.md
@@ -55,6 +55,16 @@ were already installed.
 
 `optionalDependencies` are not installed.
 
+### --no-runtime
+
+Added in: v11.1.0
+
+Skip installing runtime entries (e.g. Node.js downloaded via [`devEngines.runtime`](../package_json.md#devenginesruntime)). The lockfile is left untouched, so frozen installs still validate; only the runtime fetch and bin-linking are skipped.
+
+This is useful in CI matrices where the runtime is provisioned externally (e.g. via `pnpm runtime -g set node <version>`) before `pnpm install` runs.
+
+This can also be set via the `runtime=false` config in `pnpm-workspace.yaml`.
+
 ## Options
 
 ### --force

--- a/docs/cli/owner.md
+++ b/docs/cli/owner.md
@@ -1,0 +1,48 @@
+---
+id: owner
+title: pnpm owner
+---
+
+Added in: v11.1.0
+
+Aliases: `owners`
+
+Manages package owners on the registry.
+
+## Commands
+
+### ls
+
+```sh
+pnpm owner ls <package>
+```
+
+Aliases: `list`
+
+List all owners of a package. This is the default subcommand if no other subcommand is given.
+
+### add
+
+```sh
+pnpm owner add <package> <user>
+```
+
+Add a user as an owner of a package. Requires authentication.
+
+### rm
+
+```sh
+pnpm owner rm <package> <user>
+```
+
+Remove a user from the list of owners of a package. Requires authentication.
+
+## Options
+
+### --registry &lt;url\>
+
+The base URL of the npm registry to use for the operation. Per-scope and named registries (configured via [`registries`](../settings.md#registries) and [`namedRegistries`](../settings.md#namedregistries)) are respected for the package being modified.
+
+### --otp &lt;otp\>
+
+When the registry requires two-factor authentication, this option supplies a one-time password.

--- a/docs/cli/sbom.md
+++ b/docs/cli/sbom.md
@@ -33,6 +33,15 @@ The SBOM output format. This option is required. Supported values: `cyclonedx`, 
 
 The component type for the root package.
 
+### --sbom-spec-version &lt;version\>
+
+Added in: v11.1.0
+
+* Default: **1.7**
+* Type: **1.5**, **1.6**, **1.7**
+
+The CycloneDX specification version to emit. Only valid with `--sbom-format cyclonedx`.
+
 ### --lockfile-only
 
 Only use lockfile data (skip reading from the store).

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -366,6 +366,27 @@ registries:
   "@internal": https://nexus.corp.com/
 ```
 
+### namedRegistries
+
+Added in: v11.1.0
+
+* Default: **undefined**
+* Type: **Record&lt;string, string&gt;**
+
+Defines named registry aliases that can be used as a prefix when installing packages, in the style of [vlt's named-registry aliases](https://docs.vlt.sh/cli/registries). For example, with the following configuration:
+
+```yaml title="pnpm-workspace.yaml"
+namedRegistries:
+  gh: https://npm.pkg.github.example.com/
+  work: https://npm.work.example.com/
+```
+
+`pnpm add work:@corp/lib@^2.0.0` resolves `@corp/lib@^2.0.0` against `https://npm.work.example.com/`.
+
+The `gh:` alias is built in and points at the [GitHub Packages npm registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-npm-registry) (`https://npm.pkg.github.com/`) by default. Override it under `namedRegistries` for GitHub Enterprise Server.
+
+Authentication is picked up from the existing per-URL `.npmrc` entries (e.g. `//npm.pkg.github.com/:_authToken=...`), so no separate auth mechanism is required.
+
 ## Dependency Hoisting Settings
 
 ### hoist

--- a/sidebars.json
+++ b/sidebars.json
@@ -54,7 +54,8 @@
           "cli/peers",
           "cli/view",
           "cli/search",
-          "cli/docs"
+          "cli/docs",
+          "cli/bugs"
         ]
       },
       {
@@ -105,6 +106,7 @@
           "cli/deprecate",
           "cli/unpublish",
           "cli/dist-tag",
+          "cli/owner",
           "cli/star",
           "cli/ping",
           "cli/recursive",

--- a/versioned_sidebars/version-11.x-sidebars.json
+++ b/versioned_sidebars/version-11.x-sidebars.json
@@ -173,6 +173,10 @@
             {
               "type": "doc",
               "id": "cli/docs"
+            },
+            {
+              "type": "doc",
+              "id": "cli/bugs"
             }
           ]
         },
@@ -316,6 +320,10 @@
             {
               "type": "doc",
               "id": "cli/dist-tag"
+            },
+            {
+              "type": "doc",
+              "id": "cli/owner"
             },
             {
               "type": "doc",


### PR DESCRIPTION
## Summary

- Adds release blog post for pnpm v11.1.
- Documents new CLI commands: [`pnpm bugs`](https://github.com/pnpm/pnpm/pull/11279) and [`pnpm owner`](https://github.com/pnpm/pnpm/pull/11536).
- Documents the new `pnpm audit signatures` subcommand ([#7909](https://github.com/pnpm/pnpm/issues/7909)).
- Documents the new `--sbom-spec-version` flag for `pnpm sbom` ([#11389](https://github.com/pnpm/pnpm/pull/11389)) and the new `--no-runtime` flag (config: `runtime=false`) for `pnpm install`.
- Documents the new `namedRegistries` setting (built-in `gh:` alias for GitHub Packages, plus arbitrary user-defined aliases — see [#8941](https://github.com/pnpm/pnpm/issues/8941)).
- Wires the new commands into both `sidebars.json` and `versioned_sidebars/version-11.x-sidebars.json` (under Review dependencies → bugs, and Misc → owner).

## Test plan

- [x] `pnpm build` succeeds (only pre-existing broken-link warnings on `/blog/releases/11.0` for `/11.x/cli/*` URLs, unrelated to this change)
- [x] New pages render under `/cli/bugs`, `/cli/owner`, and `/blog/releases/11.1`
- [x] Updated pages render the new sections (`signatures` under `/cli/audit`, `--sbom-spec-version` under `/cli/sbom`, `--no-runtime` under `/cli/install`, `namedRegistries` under `/settings`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Docs for new CLI commands: audit signatures, bugs, and owner
  * Named registries with a built-in gh: alias
  * SBOM option to select CycloneDX spec version
  * install --no-runtime flag (runtime=false) to skip runtime installation

* **Bug Fixes**
  * Improved view output, publish proxy handling during web-auth polling
  * Fixed global add behavior, workspace runtime set, and a hang on --version

* **Documentation**
  * Published v11.1 release notes and updated CLI docs

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm.io/pull/793)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->