### PR TITLE
docs(patch): Tweak note about overriding dependencies

### DIFF
--- a/docs/cli/patch.md
+++ b/docs/cli/patch.md
@@ -19,7 +19,7 @@ pnpm patch <pkg name>@<version>
 
 :::note
 
-To change a package's dependences, don't use `pnpm patch` to modify its `package.json`! To override dependencies, use [overrides] or a [package hook].
+To change a package's dependencies, don't use `pnpm patch` to modify its `package.json`! Use [overrides] or a [package hook] instead.
 
 :::
 

--- a/docs/cli/patch.md
+++ b/docs/cli/patch.md
@@ -19,7 +19,7 @@ pnpm patch <pkg name>@<version>
 
 :::note
 
-If you want to change the dependencies of a package, don't use patching to modify the `package.json` file of the package. For overriding dependencies, use [overrides] or a [package hook].
+To change a package's dependences, don't use `pnpm patch` to modify its `package.json`! To override dependencies, use [overrides] or a [package hook].
 
 :::
 


### PR DESCRIPTION
I made **exactly** this mistake when I first started using pnpm. :-)

I hope that terser, more direct wording, along with an exclamation mark, help this note “stick” in the minds of future pnpm newbies as they are soaking up all the cool things that pnpm can do.  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified `pnpm patch` docs: dependency changes must not be made by editing the patched package’s package.json; use `overrides` or a package hook to apply dependency overrides instead.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm.io/pull/796)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->