### PR TITLE
Fix incorrect link for `auditConfig.ignoreCves` in pnpm audit docs

### DIFF
--- a/versioned_docs/version-10.x/cli/audit.md
+++ b/versioned_docs/version-10.x/cli/audit.md
@@ -20,7 +20,7 @@ Or alternatively, run `pnpm audit --fix`.
 If you want to tolerate some vulnerabilities as they don't affect your project, you may use the [`auditConfig.ignoreCves`] setting.
 
 [overrides]: ../settings.md#overrides
-[`auditConfig.ignoreCves`]: ../settings.md#auditconfigignorecves
+[`auditConfig.ignoreCves`]: #auditconfigignorecves
 
 ## Options
 


### PR DESCRIPTION
In the pnpm audit docs, the link for `auditConfig.ignoreCves` was pointing to a non-existent header ID on the settings page instead of the correct header ID on it's own page.

This issue is not present in the updated docs for v11.

Affected page: https://pnpm.io/10.x/cli/audit

Old incorrect link: https://pnpm.io/10.x/settings#auditconfigignorecves
New link: https://pnpm.io/10.x/cli/audit#auditconfigignorecves

I have tested this locally : )

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed an internal reference link in the CLI audit documentation to improve navigation between related documentation sections.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm.io/pull/798)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->