### PR TITLE
Change base image in Dockerfile examples to Node.js 24

### DIFF
--- a/docs/cli/fetch.md
+++ b/docs/cli/fetch.md
@@ -16,7 +16,7 @@ From that guide, we learn to write an optimized Dockerfile for projects using
 pnpm, which looks like
 
 ```Dockerfile
-FROM node:20
+FROM node:24
 
 WORKDIR /path/to/somewhere
 
@@ -51,7 +51,7 @@ It's also hard to maintain a Dockerfile that builds a monorepo project, it may
 look like
 
 ```Dockerfile
-FROM node:20
+FROM node:24
 
 WORKDIR /path/to/somewhere
 
@@ -85,7 +85,7 @@ sub-packages.
 to load packages into the virtual store using only information from a lockfile and a configuration file (`pnpm-workspace.yaml`).
 
 ```Dockerfile
-FROM node:20
+FROM node:24
 
 WORKDIR /path/to/somewhere
 


### PR DESCRIPTION
Updated Dockerfile examples to use Node.js 24 instead of 20.

pnpm can no longer run on 24 with v11

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Docker examples to use Node.js 24 instead of Node.js 20 in CLI documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm.io/pull/799)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->