### PR TITLE
docs: update Docker PNPM_HOME path for pnpm v11

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -96,7 +96,7 @@ dist
 ```dockerfile title="Dockerfile"
 FROM node:24-slim AS base
 ENV PNPM_HOME="/pnpm"
-ENV PATH="$PNPM_HOME:$PATH"
+ENV PATH="$PNPM_HOME/bin:$PATH"
 RUN corepack enable
 COPY . /app
 WORKDIR /app
@@ -166,7 +166,7 @@ dist
 ```dockerfile title="Dockerfile"
 FROM node:24-slim AS base
 ENV PNPM_HOME="/pnpm"
-ENV PATH="$PNPM_HOME:$PATH"
+ENV PATH="$PNPM_HOME/bin:$PATH"
 RUN corepack enable
 
 FROM base AS build
@@ -207,7 +207,7 @@ So an alternative is to use a typical Dockerfile with layers that are built incr
 FROM node:24-slim AS base
 
 ENV PNPM_HOME="/pnpm"
-ENV PATH="$PNPM_HOME:$PATH"
+ENV PATH="$PNPM_HOME/bin:$PATH"
 RUN corepack enable
 
 FROM base AS prod


### PR DESCRIPTION
## Summary
- update the current Docker examples to put `$PNPM_HOME/bin` on `PATH`
- keep older versioned docs unchanged because the v11 global-bin layout is the affected path

Refs pnpm/pnpm#11749.

## Verification
- `git diff --check`
- focused Node verifier checked all 3 current Docker examples with `PNPM_HOME` use `$PNPM_HOME/bin:$PATH` and no current example still uses `$PNPM_HOME:$PATH`

## Payment ask
If this is useful and you are open to settling small docs fixes, I would appreciate $10 via the project GitHub Sponsors route: https://github.com/sponsors/pnpm. No pressure if you prefer to treat it as a normal contribution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Docker setup instructions with corrected path configuration for package management tools across multiple examples.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm.io/pull/805?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->