### PR TITLE
docs: add docusaurus-plugin-copy-page-button

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -99,6 +99,7 @@ const docusaurusConfig = {
       }),
     ],
     'docusaurus-plugin-sass',
+    'docusaurus-plugin-copy-page-button',
   ],
   "themeConfig": {
     "colorMode": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@pnpm/website.pages.homepage": "1.0.1",
     "@types/react": "^19.1.9",
     "clsx": "^1.2.1",
+    "docusaurus-plugin-copy-page-button": "^0.6.1",
     "docusaurus-plugin-sass": "^0.2.6",
     "prism-react-renderer": "^2.4.1",
     "react": "^19.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,6 +43,9 @@ importers:
       clsx:
         specifier: ^1.2.1
         version: 1.2.1
+      docusaurus-plugin-copy-page-button:
+        specifier: ^0.6.1
+        version: 0.6.1(@docusaurus/core@3.9.1(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@19.2.3))(@rspack/core@1.6.7)(@swc/core@1.15.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(react@19.2.3)
       docusaurus-plugin-sass:
         specifier: ^0.2.6
         version: 0.2.6(@docusaurus/core@3.9.1(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@19.2.3))(@rspack/core@1.6.7)(@swc/core@1.15.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(@rspack/core@1.6.7)(sass@1.96.0)(webpack@5.103.0(@swc/core@1.15.3))
@@ -3043,6 +3046,13 @@ packages:
   dns-packet@5.6.1:
     resolution: {integrity: sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==}
     engines: {node: '>=6'}
+
+  docusaurus-plugin-copy-page-button@0.6.1:
+    resolution: {integrity: sha512-84LUG23owdGlUx5rgg7lcyuuxFZ+84u9u+adYjFZ1E5lM+g6bkduOGcZXLUqbI0R2Ve2RjG0OPv2KaL01tGW4w==}
+    engines: {node: '>=18.0'}
+    peerDependencies:
+      '@docusaurus/core': ^3.0.0
+      react: ^18.0.0 || ^19.0.0
 
   docusaurus-plugin-sass@0.2.6:
     resolution: {integrity: sha512-2hKQQDkrufMong9upKoG/kSHJhuwd+FA3iAe/qzS/BmWpbIpe7XKmq5wlz4J5CJaOPu4x+iDJbgAxZqcoQf0kg==}
@@ -10015,6 +10025,11 @@ snapshots:
   dns-packet@5.6.1:
     dependencies:
       '@leichtgewicht/ip-codec': 2.0.5
+
+  docusaurus-plugin-copy-page-button@0.6.1(@docusaurus/core@3.9.1(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@19.2.3))(@rspack/core@1.6.7)(@swc/core@1.15.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(react@19.2.3):
+    dependencies:
+      '@docusaurus/core': 3.9.1(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@19.2.3))(@rspack/core@1.6.7)(@swc/core@1.15.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
+      react: 19.2.3
 
   docusaurus-plugin-sass@0.2.6(@docusaurus/core@3.9.1(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)))(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@19.2.3))(@rspack/core@1.6.7)(@swc/core@1.15.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(@rspack/core@1.6.7)(sass@1.96.0)(webpack@5.103.0(@swc/core@1.15.3)):
     dependencies:


### PR DESCRIPTION
## Summary
- add `docusaurus-plugin-copy-page-button` to the docs dependencies
- register the plugin in `docusaurus.config.ts`

## Why
pnpm docs include CLI and package manager reference pages that developers often bring into AI tools. This adds a page-level copy/open button that exports the current page as clean markdown and includes one-click Open in ChatGPT, Claude, and Gemini actions.

I checked the repo first for existing page-level copy/Open-in-AI UI and LLM export features (`CopyPageButton`, `DocActionsDropdown`, `copy as markdown`, `Open in ChatGPT`, `Open in Claude`, `llms.txt`, `docusaurus-plugin-llms`, and similar terms) and did not find an overlapping feature.

The plugin has no runtime dependencies and uses peer dependencies for Docusaurus and React.

## Validation
- `git diff --check`
- package manifest, lockfile, and config sanity check

Not run locally: full docs build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Documentation pages now include a copy button feature that allows users to easily copy page content to their clipboard with a single click. This new functionality is available across all documentation pages, providing convenient access to page content. The button appears in a prominent location on each page.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm.io/pull/806?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->