### PR TITLE
fix: update staged publishing docs link

### DIFF
--- a/blog/releases/11.3.md
+++ b/blog/releases/11.3.md
@@ -13,7 +13,7 @@ pnpm 11.3 adds support for npm's staged publishing (`pnpm stage`), the new [`tru
 
 ### `pnpm stage`
 
-A new [`pnpm stage`](/cli/stage) command brings npm's [staged publishing](https://docs.npmjs.com/about-staged-publishing) workflow to pnpm. Staged publishing lets you publish a version that's hidden from `npm install` until you explicitly approve it — useful for verifying release artifacts, smoke-testing CI, or coordinating multi-package releases.
+A new [`pnpm stage`](/cli/stage) command brings npm's [staged publishing](https://docs.npmjs.com/staged-publishing) workflow to pnpm. Staged publishing lets you publish a version that's hidden from `npm install` until you explicitly approve it — useful for verifying release artifacts, smoke-testing CI, or coordinating multi-package releases.
 
 The available subcommands are:
 

--- a/docs/cli/stage.md
+++ b/docs/cli/stage.md
@@ -5,7 +5,7 @@ title: pnpm stage
 
 Added in: v11.3.0
 
-Stages packages for publishing using npm's [staged publishing](https://docs.npmjs.com/about-staged-publishing) workflow. Staged versions are not resolved by `pnpm install` until they are explicitly approved, letting you defer proof-of-presence (2FA) to a later point in time — useful for verifying release artifacts, smoke-testing CI, or coordinating multi-package releases.
+Stages packages for publishing using npm's [staged publishing](https://docs.npmjs.com/staged-publishing) workflow. Staged versions are not resolved by `pnpm install` until they are explicitly approved, letting you defer proof-of-presence (2FA) to a later point in time — useful for verifying release artifacts, smoke-testing CI, or coordinating multi-package releases.
 
 ```sh
 pnpm stage <subcommand> [options]


### PR DESCRIPTION
## Summary

- updates the npm staged publishing URL in the 11.3 release post
- updates the same link in the `pnpm stage` docs

Closes pnpm/pnpm#11917.

## Testing

- `rg "about-staged-publishing" -n blog docs versioned_docs || true`
- `git diff --check`
- `pnpm build` (passes; reports existing broken links in `/blog/releases/11.0`, unrelated to this change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated references in the `pnpm stage` command documentation to link to npm's current staged publishing documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm.io/pull/807?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->