### PR TITLE
docs: pin v11 examples to major version

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -34,7 +34,7 @@ Supported platforms: `linux/amd64`, `linux/arm64`.
 Use [`pnpm runtime set`](./cli/runtime.md) with the global flag so the `node` binary is discoverable on `PATH` in subsequent layers and at runtime:
 
 ```dockerfile
-FROM ghcr.io/pnpm/pnpm:latest
+FROM ghcr.io/pnpm/pnpm:11
 RUN pnpm runtime set node 22 -g
 WORKDIR /app
 COPY . .
@@ -57,7 +57,7 @@ Or let pnpm install Node.js automatically from [`devEngines.runtime`](./package_
 ```
 
 ```dockerfile
-FROM ghcr.io/pnpm/pnpm:latest
+FROM ghcr.io/pnpm/pnpm:11
 WORKDIR /app
 COPY package.json pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile

--- a/docs/package_json.md
+++ b/docs/package_json.md
@@ -125,7 +125,7 @@ Allows specifying the pnpm version via `devEngines.packageManager` in `package.j
   "devEngines": {
     "packageManager": {
       "name": "pnpm",
-      "version": ">=11.0.0",
+      "version": ">=11.0.0 <12.0.0",
       "onFail": "download"
     }
   }


### PR DESCRIPTION
## Summary

- changes the v11 Docker examples to use `ghcr.io/pnpm/pnpm:11` instead of `latest`
- narrows the `devEngines.packageManager` example to `>=11.0.0 <12.0.0`

Closes #797.

## Testing

- `rg "ghcr\\.io/pnpm/pnpm:latest" -n docs versioned_docs/version-11.x || true`
- `rg '"version": ">=11\\.0\\.0"' -n docs versioned_docs/version-11.x || true`
- `git diff --check`
- `pnpm build` (passes; reports existing broken links in `/blog/releases/11.0`, unrelated to this change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Docker installation examples to use a specific pnpm image version
  * Enhanced package.json documentation with refined pnpm version constraints

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm.io/pull/808?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->