### PR TITLE
docs: add zsh completion setup

### DIFF
--- a/docs/completion.md
+++ b/docs/completion.md
@@ -27,6 +27,13 @@ To setup autocompletion for Fish, run:
 pnpm completion fish > ~/.config/fish/completions/pnpm.fish
 ```
 
+To setup autocompletion for Zsh, run:
+
+```text
+pnpm completion zsh > ~/completion-for-pnpm.zsh
+echo 'source ~/completion-for-pnpm.zsh' >> ~/.zshrc
+```
+
 ## g-plane/pnpm-shell-completion
 
 [pnpm-shell-completion] is a shell plugin maintained by Pig Fang on Github.


### PR DESCRIPTION
## Summary

- adds Zsh setup commands to the command-line completion docs
- keeps the new example aligned with the existing Bash/Fish completion section

Closes #718.

## Testing

- `pnpm completion zsh | sed -n '1,20p'`
- `git diff --check`
- `pnpm build` (passes; reports existing broken links in `/blog/releases/11.0`, unrelated to this change)