### PR TITLE
docs: add Bun to feature comparison

### DIFF
--- a/docs/feature-comparison.md
+++ b/docs/feature-comparison.md
@@ -5,25 +5,25 @@ title: Feature Comparison
 
 | Feature                          |pnpm              |Yarn              |npm               |Bun               | Notes |
 | ---                              |:--:              |:--:              |:--:              |:--:              | ---   |
-| [Workspace support]              |:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|
+| [Workspace support]              |:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:| |
 | Isolated `node_modules`          |:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:| Default in pnpm and new Bun workspaces. |
 | [Hoisted `node_modules`]         |:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:| Default in npm and new Bun single-package projects. |
 | Plug'n'Play                      |:white_check_mark:|:white_check_mark:|:x:               |:x:               | Default in Yarn. |
-| [Autoinstalling peers]           |:white_check_mark:|:x:               |:white_check_mark:|:white_check_mark:|
-| Zero-Installs                    |:x:               |:white_check_mark:|:x:               |:x:               |
-| [Patching dependencies]          |:white_check_mark:|:white_check_mark:|:x:               |:white_check_mark:|
-| [Managing runtimes]              |:white_check_mark:|:x:               |:x:               |:x:               |
-| [Managing versions of itself]    |:white_check_mark:|:white_check_mark:|:x:               |:x:               |
+| [Autoinstalling peers]           |:white_check_mark:|:x:               |:white_check_mark:|:white_check_mark:| |
+| Zero-Installs                    |:x:               |:white_check_mark:|:x:               |:x:               | |
+| [Patching dependencies]          |:white_check_mark:|:white_check_mark:|:x:               |:white_check_mark:| |
+| [Managing runtimes]              |:white_check_mark:|:x:               |:x:               |:x:               | |
+| [Managing versions of itself]    |:white_check_mark:|:white_check_mark:|:x:               |:x:               | |
 | Has a lockfile                   |:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:| `pnpm-lock.yaml`, `yarn.lock`, `package-lock.json`, `bun.lock`. |
 | [Overrides support]              |:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:| Known as "resolutions" in Yarn. Bun supports both `overrides` and `resolutions`. |
 | Content-addressable storage      |:white_check_mark:|:white_check_mark:|:x:               |:x:               | Yarn uses a CAS when `nodeLinker` is set to `pnpm`. |
 | [Dynamic package execution]      |:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:| `pnpm dlx`, `yarn dlx`, `npx`, `bunx`. |
-| [Side-effects cache]             |:white_check_mark:|:x:               |:x:               |:x:               |
-| [Catalogs]                       |:white_check_mark:|:x:               |:x:               |:white_check_mark:|
-| [Config dependencies]            |:white_check_mark:|:x:               |:x:               |:x:               |
-| [JSR registry support]           |:white_check_mark:|:white_check_mark:|:x:               |:x:               |
+| [Side-effects cache]             |:white_check_mark:|:x:               |:x:               |:x:               | |
+| [Catalogs]                       |:white_check_mark:|:x:               |:x:               |:white_check_mark:| |
+| [Config dependencies]            |:white_check_mark:|:x:               |:x:               |:x:               | |
+| [JSR registry support]           |:white_check_mark:|:white_check_mark:|:x:               |:x:               | |
 | [Auto-install before script run] |:white_check_mark:|:x:               |:x:               |:x:               | In Yarn, Plug'n'Play ensures dependencies are always up to date. |
-| [Hooks]                          |:white_check_mark:|:white_check_mark:|:x:               |:x:               |
+| [Hooks]                          |:white_check_mark:|:white_check_mark:|:x:               |:x:               | |
 | [Build script security]          |:white_check_mark:|:x:               |:x:               |:white_check_mark:| Bun uses `trustedDependencies` to allow dependency lifecycle scripts. |
 | [SBOM generation]                |:white_check_mark:|:x:               |:white_check_mark:|:x:               | `pnpm sbom`, `npm sbom`. |
 | [Listing licenses]               |:white_check_mark:|:white_check_mark:|:x:               |:x:               | pnpm supports it via `pnpm licenses list`. Yarn has a plugin for it. |

--- a/docs/feature-comparison.md
+++ b/docs/feature-comparison.md
@@ -5,25 +5,25 @@ title: Feature Comparison
 
 | Feature                          |pnpm              |Yarn              |npm               |Bun               | Notes |
 | ---                              |:--:              |:--:              |:--:              |:--:              | ---   |
-| [Workspace support]              |:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:| |
+| [Workspace support]              |:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|       |
 | Isolated `node_modules`          |:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:| Default in pnpm and new Bun workspaces. |
 | [Hoisted `node_modules`]         |:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:| Default in npm and new Bun single-package projects. |
 | Plug'n'Play                      |:white_check_mark:|:white_check_mark:|:x:               |:x:               | Default in Yarn. |
-| [Autoinstalling peers]           |:white_check_mark:|:x:               |:white_check_mark:|:white_check_mark:| |
-| Zero-Installs                    |:x:               |:white_check_mark:|:x:               |:x:               | |
-| [Patching dependencies]          |:white_check_mark:|:white_check_mark:|:x:               |:white_check_mark:| |
-| [Managing runtimes]              |:white_check_mark:|:x:               |:x:               |:x:               | |
-| [Managing versions of itself]    |:white_check_mark:|:white_check_mark:|:x:               |:x:               | |
+| [Autoinstalling peers]           |:white_check_mark:|:x:               |:white_check_mark:|:white_check_mark:|       |
+| Zero-Installs                    |:x:               |:white_check_mark:|:x:               |:x:               |       |
+| [Patching dependencies]          |:white_check_mark:|:white_check_mark:|:x:               |:white_check_mark:|       |
+| [Managing runtimes]              |:white_check_mark:|:x:               |:x:               |:x:               |       |
+| [Managing versions of itself]    |:white_check_mark:|:white_check_mark:|:x:               |:x:               |       |
 | Has a lockfile                   |:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:| `pnpm-lock.yaml`, `yarn.lock`, `package-lock.json`, `bun.lock`. |
 | [Overrides support]              |:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:| Known as "resolutions" in Yarn. Bun supports both `overrides` and `resolutions`. |
 | Content-addressable storage      |:white_check_mark:|:white_check_mark:|:x:               |:x:               | Yarn uses a CAS when `nodeLinker` is set to `pnpm`. |
 | [Dynamic package execution]      |:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:| `pnpm dlx`, `yarn dlx`, `npx`, `bunx`. |
-| [Side-effects cache]             |:white_check_mark:|:x:               |:x:               |:x:               | |
-| [Catalogs]                       |:white_check_mark:|:x:               |:x:               |:white_check_mark:| |
-| [Config dependencies]            |:white_check_mark:|:x:               |:x:               |:x:               | |
-| [JSR registry support]           |:white_check_mark:|:white_check_mark:|:x:               |:x:               | |
+| [Side-effects cache]             |:white_check_mark:|:x:               |:x:               |:x:               |       |
+| [Catalogs]                       |:white_check_mark:|:x:               |:x:               |:white_check_mark:|       |
+| [Config dependencies]            |:white_check_mark:|:x:               |:x:               |:x:               |       |
+| [JSR registry support]           |:white_check_mark:|:white_check_mark:|:x:               |:x:               |       |
 | [Auto-install before script run] |:white_check_mark:|:x:               |:x:               |:x:               | In Yarn, Plug'n'Play ensures dependencies are always up to date. |
-| [Hooks]                          |:white_check_mark:|:white_check_mark:|:x:               |:x:               | |
+| [Hooks]                          |:white_check_mark:|:white_check_mark:|:x:               |:x:               |       |
 | [Build script security]          |:white_check_mark:|:x:               |:x:               |:white_check_mark:| Bun uses `trustedDependencies` to allow dependency lifecycle scripts. |
 | [SBOM generation]                |:white_check_mark:|:x:               |:white_check_mark:|:x:               | `pnpm sbom`, `npm sbom`. |
 | [Listing licenses]               |:white_check_mark:|:white_check_mark:|:x:               |:x:               | pnpm supports it via `pnpm licenses list`. Yarn has a plugin for it. |

--- a/docs/feature-comparison.md
+++ b/docs/feature-comparison.md
@@ -3,30 +3,30 @@ id: feature-comparison
 title: Feature Comparison
 ---
 
-| Feature                          |pnpm              |Yarn              |npm               | Notes |
-| ---                              |:--:              |:--:              |:--:              | ---   |
-| [Workspace support]              |:white_check_mark:|:white_check_mark:|:white_check_mark:|
-| Isolated `node_modules`          |:white_check_mark:|:white_check_mark:|:white_check_mark:| Default in pnpm. |
-| [Hoisted `node_modules`]         |:white_check_mark:|:white_check_mark:|:white_check_mark:| Default in npm. |
-| Plug'n'Play                      |:white_check_mark:|:white_check_mark:|:x:               | Default in Yarn. |
-| [Autoinstalling peers]           |:white_check_mark:|:x:               |:white_check_mark:|
-| Zero-Installs                    |:x:               |:white_check_mark:|:x:               |
-| [Patching dependencies]          |:white_check_mark:|:white_check_mark:|:x:               |
-| [Managing runtimes]              |:white_check_mark:|:x:               |:x:               |
-| [Managing versions of itself]    |:white_check_mark:|:white_check_mark:|:x:               |
-| Has a lockfile                   |:white_check_mark:|:white_check_mark:|:white_check_mark:| `pnpm-lock.yaml`, `yarn.lock`, `package-lock.json`. |
-| [Overrides support]              |:white_check_mark:|:white_check_mark:|:white_check_mark:| Known as "resolutions" in Yarn. |
-| Content-addressable storage      |:white_check_mark:|:white_check_mark:|:x:               | Yarn uses a CAS when `nodeLinker` is set to `pnpm`. |
-| [Dynamic package execution]      |:white_check_mark:|:white_check_mark:|:white_check_mark:| `pnpm dlx`, `yarn dlx`, `npx`. |
-| [Side-effects cache]             |:white_check_mark:|:x:               |:x:               |
-| [Catalogs]                       |:white_check_mark:|:x:               |:x:               |
-| [Config dependencies]            |:white_check_mark:|:x:               |:x:               |
-| [JSR registry support]           |:white_check_mark:|:white_check_mark:|:x:               |
-| [Auto-install before script run] |:white_check_mark:|:x:               |:x:               | In Yarn, Plug'n'Play ensures dependencies are always up to date. |
-| [Hooks]                          |:white_check_mark:|:white_check_mark:|:x:               |
-| [Build script security]          |:white_check_mark:|:x:               |:x:               |
-| [SBOM generation]                |:white_check_mark:|:x:               |:white_check_mark:| `pnpm sbom`, `npm sbom`. |
-| [Listing licenses]               |:white_check_mark:|:white_check_mark:|:x:               | pnpm supports it via `pnpm licenses list`. Yarn has a plugin for it. |
+| Feature                          |pnpm              |Yarn              |npm               |Bun               | Notes |
+| ---                              |:--:              |:--:              |:--:              |:--:              | ---   |
+| [Workspace support]              |:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|
+| Isolated `node_modules`          |:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:| Default in pnpm and new Bun workspaces. |
+| [Hoisted `node_modules`]         |:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:| Default in npm and new Bun single-package projects. |
+| Plug'n'Play                      |:white_check_mark:|:white_check_mark:|:x:               |:x:               | Default in Yarn. |
+| [Autoinstalling peers]           |:white_check_mark:|:x:               |:white_check_mark:|:white_check_mark:|
+| Zero-Installs                    |:x:               |:white_check_mark:|:x:               |:x:               |
+| [Patching dependencies]          |:white_check_mark:|:white_check_mark:|:x:               |:white_check_mark:|
+| [Managing runtimes]              |:white_check_mark:|:x:               |:x:               |:x:               |
+| [Managing versions of itself]    |:white_check_mark:|:white_check_mark:|:x:               |:x:               |
+| Has a lockfile                   |:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:| `pnpm-lock.yaml`, `yarn.lock`, `package-lock.json`, `bun.lock`. |
+| [Overrides support]              |:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:| Known as "resolutions" in Yarn. Bun supports both `overrides` and `resolutions`. |
+| Content-addressable storage      |:white_check_mark:|:white_check_mark:|:x:               |:x:               | Yarn uses a CAS when `nodeLinker` is set to `pnpm`. |
+| [Dynamic package execution]      |:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:| `pnpm dlx`, `yarn dlx`, `npx`, `bunx`. |
+| [Side-effects cache]             |:white_check_mark:|:x:               |:x:               |:x:               |
+| [Catalogs]                       |:white_check_mark:|:x:               |:x:               |:white_check_mark:|
+| [Config dependencies]            |:white_check_mark:|:x:               |:x:               |:x:               |
+| [JSR registry support]           |:white_check_mark:|:white_check_mark:|:x:               |:x:               |
+| [Auto-install before script run] |:white_check_mark:|:x:               |:x:               |:x:               | In Yarn, Plug'n'Play ensures dependencies are always up to date. |
+| [Hooks]                          |:white_check_mark:|:white_check_mark:|:x:               |:x:               |
+| [Build script security]          |:white_check_mark:|:x:               |:x:               |:white_check_mark:| Bun uses `trustedDependencies` to allow dependency lifecycle scripts. |
+| [SBOM generation]                |:white_check_mark:|:x:               |:white_check_mark:|:x:               | `pnpm sbom`, `npm sbom`. |
+| [Listing licenses]               |:white_check_mark:|:white_check_mark:|:x:               |:x:               | pnpm supports it via `pnpm licenses list`. Yarn has a plugin for it. |
 
 [Auto-install before script run]: ./settings.md#verifydepsbeforerun
 [Autoinstalling peers]: ./settings.md#autoinstallpeers


### PR DESCRIPTION
## Summary

Adds Bun to the feature comparison table.

Bun is a comparable package manager, but it wasn’t listed on the comparison page.

## Validation

Ran the docs site locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Bun package manager to the feature comparison table.
  * Updated feature support details including workspace isolation and dependency management.
  * Extended comparison to cover Bun-specific capabilities and lockfile formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->