### PR TITLE
docs: fix typos

### DIFF
--- a/docs/cli/patch-commit.md
+++ b/docs/cli/patch-commit.md
@@ -5,7 +5,7 @@ title: "pnpm patch-commit <path>"
 
 Generate a patch out of a directory and save it (inspired by a similar command in Yarn).
 
-This command will compare the changes from `path` to the package it was supposed to patch, generate a patch file, save the a patch file to `patchesDir` (which can be customized by the `--patches-dir` option), and add an entry to [`patchedDependencies`].
+This command will compare the changes from `path` to the package it was supposed to patch, generate a patch file, save the patch file to `patchesDir` (which can be customized by the `--patches-dir` option), and add an entry to [`patchedDependencies`].
 
 Usage:
 

--- a/docs/completion.md
+++ b/docs/completion.md
@@ -29,7 +29,7 @@ pnpm completion fish > ~/.config/fish/completions/pnpm.fish
 
 ## g-plane/pnpm-shell-completion
 
-[pnpm-shell-completion] is a shell plugin maintained by Pig Fang on Github.
+[pnpm-shell-completion] is a shell plugin maintained by Pig Fang on GitHub.
 
 Features:
 

--- a/docs/filtering.md
+++ b/docs/filtering.md
@@ -167,7 +167,7 @@ pnpm --filter ...foo --filter bar --filter baz... test
 
 ## --filter-prod &lt;filtering_pattern>
 
-Acts the same a `--filter` but omits `devDependencies` when selecting dependency projects
+Acts the same as `--filter` but omits `devDependencies` when selecting dependency projects
 from the workspace.
 
 ## --test-pattern &lt;glob>

--- a/docs/pnpmfile.md
+++ b/docs/pnpmfile.md
@@ -192,7 +192,7 @@ This hook is executed after reading and parsing the lockfiles of the project, bu
 
 ### `hooks.importPackage(destinationDir, options): Promise<string | undefined>`
 
-This hook allows to change how packages are written to `node_modules`. The return value is optional and states what method was used for importing the dependency, e.g.: clone, hardlink.
+This hook allows changing how packages are written to `node_modules`. The return value is optional and states what method was used for importing the dependency, e.g.: clone, hardlink.
 
 #### Arguments
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -163,7 +163,7 @@ With the above configuration pnpm will not print deprecation warnings about any 
 
 #### updateConfig.ignoreDependencies
 
-Sometimes you can't update a dependency. For instance, the latest version of the dependency started to use ESM but your project is not yet in ESM. Annoyingly, such a package will be always printed out by the `pnpm outdated` command and updated, when running `pnpm update --latest`. However, you may list packages that you don't want to upgrade in the `ignoreDependencies` field:
+Sometimes you can't update a dependency. For instance, the latest version of the dependency started to use ESM but your project is not yet in ESM. Annoyingly, such a package will always be printed out by the `pnpm outdated` command and updated, when running `pnpm update --latest`. However, you may list packages that you don't want to upgrade in the `ignoreDependencies` field:
 
 ```yaml
 updateConfig:

--- a/versioned_docs/version-10.x/cli/patch-commit.md
+++ b/versioned_docs/version-10.x/cli/patch-commit.md
@@ -5,7 +5,7 @@ title: "pnpm patch-commit <path>"
 
 Generate a patch out of a directory and save it (inspired by a similar command in Yarn).
 
-This command will compare the changes from `path` to the package it was supposed to patch, generate a patch file, save the a patch file to `patchesDir` (which can be customized by the `--patches-dir` option), and add an entry to [`patchedDependencies`].
+This command will compare the changes from `path` to the package it was supposed to patch, generate a patch file, save the patch file to `patchesDir` (which can be customized by the `--patches-dir` option), and add an entry to [`patchedDependencies`].
 
 Usage:
 

--- a/versioned_docs/version-10.x/completion.md
+++ b/versioned_docs/version-10.x/completion.md
@@ -29,7 +29,7 @@ pnpm completion fish > ~/.config/fish/completions/pnpm.fish
 
 ## g-plane/pnpm-shell-completion
 
-[pnpm-shell-completion] is a shell plugin maintained by Pig Fang on Github.
+[pnpm-shell-completion] is a shell plugin maintained by Pig Fang on GitHub.
 
 Features:
 

--- a/versioned_docs/version-10.x/filtering.md
+++ b/versioned_docs/version-10.x/filtering.md
@@ -167,7 +167,7 @@ pnpm --filter ...foo --filter bar --filter baz... test
 
 ## --filter-prod &lt;filtering_pattern>
 
-Acts the same a `--filter` but omits `devDependencies` when selecting dependency projects
+Acts the same as `--filter` but omits `devDependencies` when selecting dependency projects
 from the workspace.
 
 ## --test-pattern &lt;glob>

--- a/versioned_docs/version-10.x/pnpmfile.md
+++ b/versioned_docs/version-10.x/pnpmfile.md
@@ -198,7 +198,7 @@ This hook is executed after reading and parsing the lockfiles of the project, bu
 
 ### `hooks.importPackage(destinationDir, options): Promise<string | undefined>`
 
-This hook allows to change how packages are written to `node_modules`. The return value is optional and states what method was used for importing the dependency, e.g.: clone, hardlink.
+This hook allows changing how packages are written to `node_modules`. The return value is optional and states what method was used for importing the dependency, e.g.: clone, hardlink.
 
 #### Arguments
 

--- a/versioned_docs/version-10.x/settings.md
+++ b/versioned_docs/version-10.x/settings.md
@@ -147,7 +147,7 @@ With the above configuration pnpm will not print deprecation warnings about any 
 
 #### updateConfig.ignoreDependencies
 
-Sometimes you can't update a dependency. For instance, the latest version of the dependency started to use ESM but your project is not yet in ESM. Annoyingly, such a package will be always printed out by the `pnpm outdated` command and updated, when running `pnpm update --latest`. However, you may list packages that you don't want to upgrade in the `ignoreDependencies` field:
+Sometimes you can't update a dependency. For instance, the latest version of the dependency started to use ESM but your project is not yet in ESM. Annoyingly, such a package will always be printed out by the `pnpm outdated` command and updated, when running `pnpm update --latest`. However, you may list packages that you don't want to upgrade in the `ignoreDependencies` field:
 
 ```yaml
 updateConfig:


### PR DESCRIPTION
## Summary
- Fix a few typos and grammar issues in active docs.
- Mirror the same fixes in versioned 10.x docs.

## Testing
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected multiple grammar, spelling, and punctuation errors across CLI documentation
  * Clarified descriptions for various commands and hooks including package patching and filtering behavior
  * Fixed inconsistent capitalization throughout documentation
  * Improved clarity in configuration settings explanations
  * Updated current and versioned documentation for consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->