### PR TITLE
chore: pin GitHub Actions

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -14,11 +14,11 @@ jobs:
     env:
       COREPACK_ENABLE_AUTO_PIN: 0
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
           fetch-depth: 0
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: 24
       - run: |
@@ -33,7 +33,7 @@ jobs:
       - run: pnpm --dir=benchmarks run benchmark
       - run: pnpm --dir=benchmarks run benchmark
       - name: Commit & Push changes
-        uses: actions-js/push@master
+        uses: actions-js/push@5a7cbd780d82c0c937b5977586e641b2fd94acc5 # v1.5
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           message: "chore: update benchmarks"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,11 @@ jobs:
       COREPACK_ENABLE_AUTO_PIN: 0
     steps:
       - name: Checkout Commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
       - name: Install pnpm
-        uses: pnpm/action-setup@v4.1.0
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
         with:
           standalone: true
       - name: Install dependencies

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -14,11 +14,11 @@ jobs:
       COREPACK_ENABLE_AUTO_PIN: 0
     steps:
       - name: Checkout Commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.nvmrc'
       - name: Install pnpm


### PR DESCRIPTION
## Summary

Pin GitHub Actions to full commit SHAs using [`pinact`](https://github.com/suzuki-shunsuke/pinact).

GitHub Action tags and branches are mutable, so an action referenced as `@v4` or `@master` can change without any workflow file change in this repository. Pinning actions to full commit SHAs makes the workflow dependency immutable and reduces supply chain risk. This aligns with GitHub’s support for [blocking and SHA pinning Actions](https://github.blog/changelog/2025-08-15-github-actions-policy-now-supports-blocking-and-sha-pinning-actions/). The version comments keep the pinned SHAs readable and easier to update later.

## Changes

- Pinned workflow actions in `.github/workflows/benchmark.yml`
- Pinned workflow actions in `.github/workflows/ci.yml`
- Pinned workflow actions in `.github/workflows/translations.yml`
- Converted `actions-js/push@master` to a pinned release SHA with version comment
- Preserved version comments for easier review and future updates

## Verification

Ran:

```sh
pinact run -check -verify-comment
```
