### PR TITLE
Docs: nodeVersion should be an exact semver version

### DIFF
--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -15,7 +15,7 @@ pnpm also no longer reads settings from the `pnpm` field of `package.json`. Sett
 Project-level settings go in `pnpm-workspace.yaml`:
 
 ```yaml title="pnpm-workspace.yaml"
-nodeVersion: "22"
+nodeVersion: "22.22.3"
 saveExact: true
 ```
 


### PR DESCRIPTION
It seems that this part of the docs is wrong and an exact version is needed

> [ERR_PNPM_INVALID_NODE_VERSION] The nodeVersion setting is "26", which is not exact semver version

Also mentioned here: https://pnpm.io/settings#nodeversion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated example pnpm workspace configuration to use a more specific Node.js version (22.22.3) instead of the broader version 22, improving precision in version management documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->