### PR TITLE
docs: file-free registry auth via npm_config_// and pnpm_config_// env vars (v11.6)

### DIFF
--- a/docs/npmrc.md
+++ b/docs/npmrc.md
@@ -48,11 +48,9 @@ If your project relied on a committed `.npmrc` containing a line like `//registr
 
   `pnpm config set` writes to the global location by default (`<pnpm config>/auth.ini` for auth settings), not to the project `.npmrc`, so the token never ends up in the repository.
 
-* **Set the credential through an environment variable, with no `.npmrc` file at all** (since v11.6). pnpm reads URL-scoped registry settings from `npm_config_//…` and `pnpm_config_//…` environment variables:
+* **Set the credential through an environment variable, with no `.npmrc` file at all** (since v11.6). pnpm reads URL-scoped registry settings from `pnpm_config_//…` environment variables:
 
   ```sh
-  export "npm_config_//registry.npmjs.org/:_authToken=$NPM_TOKEN"
-  # pnpm_config_ is also accepted and wins over npm_config_ for the same key:
   export "pnpm_config_//registry.npmjs.org/:_authToken=$NPM_TOKEN"
   ```
 

--- a/docs/npmrc.md
+++ b/docs/npmrc.md
@@ -48,6 +48,16 @@ If your project relied on a committed `.npmrc` containing a line like `//registr
 
   `pnpm config set` writes to the global location by default (`<pnpm config>/auth.ini` for auth settings), not to the project `.npmrc`, so the token never ends up in the repository.
 
+* **Set the credential through an environment variable, with no `.npmrc` file at all** (since v11.6). pnpm reads URL-scoped registry settings from `npm_config_//…` and `pnpm_config_//…` environment variables:
+
+  ```sh
+  export "npm_config_//registry.npmjs.org/:_authToken=$NPM_TOKEN"
+  # pnpm_config_ is also accepted and wins over npm_config_ for the same key:
+  export "pnpm_config_//registry.npmjs.org/:_authToken=$NPM_TOKEN"
+  ```
+
+  This is the most direct, file-free replacement for a committed `//registry.npmjs.org/:_authToken=${NPM_TOKEN}` line. Because the registry the credential applies to is encoded in the (trusted) variable name, a malicious repository cannot redirect it to another host. Such an environment value overrides the project `.npmrc` but is itself overridden by a command-line option. The `tokenHelper` setting is intentionally not read from environment variables.
+
 * Or keep the `${NPM_TOKEN}` placeholder line, but put it in the user-level `~/.npmrc` (or the file referenced by [`npmrcAuthFile`](./settings.md#npmrcauthfile)) instead of the repository.
 * In GitHub Actions, `actions/setup-node` with the `registry-url` input writes the auth setting to a user-level `.npmrc` (referenced by the `NPM_CONFIG_USERCONFIG` environment variable, which pnpm honors), so authentication via the `NODE_AUTH_TOKEN` environment variable continues to work.
 * If you cannot easily modify each CI pipeline, you may declare the project `.npmrc` trusted by setting a single environment variable in the CI environment (for example, at the organization or workspace level):


### PR DESCRIPTION
Documents the file-free registry authentication added in pnpm v11.6 (pnpm/pnpm#12338): pnpm now reads URL-scoped registry credentials from `npm_config_//…` and `pnpm_config_//…` environment variables.

Adds it as a migration option in the "Environment variables in auth settings" section of `/npmrc` — it's the most direct answer for users who hit the env-expansion change in a committed `.npmrc` (pnpm/pnpm#12314) and want auth with no config file at all. Notes:
- both `npm_config_` and `pnpm_config_` prefixes (pnpm wins),
- it's safe because the registry is encoded in the trusted variable name (can't be redirected by a repo),
- precedence (overrides project `.npmrc`, overridden by CLI),
- `tokenHelper` is excluded.

v11-only (11.6), so only `docs/` is edited (the v11 versioned docs are auto-generated; v10 is a separate, unaffected version).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced guidance on configuring registry credentials via environment variables without requiring a `.npmrc` file, including practical examples and configuration precedence details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->