### PR TITLE
feat(benchmarks): add Bun to benchmark generation

### DIFF
--- a/benchmarks/benchmarkFixture.js
+++ b/benchmarks/benchmarkFixture.js
@@ -17,6 +17,7 @@ const lockfileNameByPM = {
   npm: 'package-lock.json',
   pnpm: 'pnpm-lock.yaml',
   pacquet: 'pnpm-lock.yaml',
+  bun: 'bun.lock',
   yarn: 'yarn.lock'
 }
 
@@ -255,4 +256,3 @@ function spawnSyncOrThrow (cmd, opts) {
   }
   return result;
 }
-

--- a/benchmarks/commandsMap.js
+++ b/benchmarks/commandsMap.js
@@ -45,6 +45,21 @@ export default {
       '--ignore-scripts',
     ]
   },
+  bun: {
+    scenario: 'bun',
+    legend: 'Bun',
+    color: '#f47216',
+    name: 'bun',
+    args: [
+      'install',
+      '--ignore-scripts',
+      '--cache-dir=cache',
+      '--registry=https://registry.npmjs.org/',
+      '--no-summary',
+      '--no-progress',
+      '--silent',
+    ]
+  },
   yarn: {
     scenario: 'yarn',
     legend: 'Yarn',

--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -103,7 +103,7 @@ run()
 async function run () {
   const tmpDir = tempy.directory()
   const managersDirs = {}
-  for (const pm of ['npm', 'pnpm11', 'pnpm12', 'yarn']) {
+  for (const pm of ['npm', 'pnpm11', 'pnpm12', 'bun', 'yarn']) {
     managersDirs[pm] = path.join(tmpDir, pm)
   }
   await Promise.allSettled([
@@ -123,6 +123,7 @@ async function run () {
     { key: 'npm', managersDir: managersDirs.npm },
     { key: 'pnpm11', managersDir: managersDirs.pnpm11 },
     { key: 'pnpm12', managersDir: managersDirs.pnpm12 },
+    { key: 'bun', managersDir: managersDirs.bun },
     { key: 'yarn', managersDir: managersDirs.yarn },
     { key: 'yarn_pnp', managersDir: managersDirs.yarn, hasNodeModules: false },
   ]
@@ -178,6 +179,7 @@ async function run () {
         primaryKey: 'pnpm12',
         secondaryKey: 'pnpm11',
       },
+      { ...cmdsMap.bun, key: 'bun' },
       { ...cmdsMap.yarn, key: 'yarn' },
       { ...cmdsMap.yarn_pnp, key: 'yarn_pnp' },
     ]
@@ -255,7 +257,7 @@ async function run () {
 
   **Last benchmarked at**: _${formattedNow}_ (_daily_ updated).
 
-  This benchmark compares the performance of npm, pnpm, Yarn Classic, and Yarn PnP (check [Yarn's benchmarks](https://yarnpkg.com/benchmarks) for any other Yarn modes that are not included here).
+  This benchmark compares the performance of npm, pnpm, Bun, Yarn Classic, and Yarn PnP (check [Yarn's benchmarks](https://yarnpkg.com/benchmarks) for any other Yarn modes that are not included here).
   `
 
   const explanationItems = sortedTests.map(t => `- ${explanationByTest[t]}`).join('\n  ')

--- a/benchmarks/regenerate-svgs.mjs
+++ b/benchmarks/regenerate-svgs.mjs
@@ -61,6 +61,7 @@ const pmConfigs = [
   { key: 'npm' },
   { key: 'pnpm11' },
   { key: 'pnpm12' },
+  { key: 'bun' },
   { key: 'yarn' },
   { key: 'yarn_pnp', hasNodeModules: false },
 ]
@@ -84,10 +85,6 @@ function minPerTest (entries) {
   const out = {}
   for (const t of tests) out[t] = Math.min(...entries.map(e => e[t]))
   return out
-}
-
-function toResArray (testList, keys, data) {
-  return testList.map(t => keys.map(k => data[k].results[t]).map(ms => Math.round(ms / 100) / 10))
 }
 
 const data = {}
@@ -118,6 +115,7 @@ const mainBars = [
     primaryKey: 'pnpm12',
     secondaryKey: 'pnpm11',
   },
+  { ...cmdsMap.bun, key: 'bun', version: data.bun.version },
   { ...cmdsMap.yarn, key: 'yarn', version: data.yarn.version },
   { ...cmdsMap.yarn_pnp, key: 'yarn_pnp', version: data.yarn_pnp.version },
 ]


### PR DESCRIPTION
# Adds Bun benchmarks to the comparison

Currently we are missing Bun from comparison.
This simply adds bun to it.

## Benchmark Results
- PNPM 12 is faster in firstInstall and repeatInstall
- Bun is faster in withWarmCacheAndLockfile, withWarmCache and else
So we could see the room of improvement for PNPM Rust port

<img width="706" height="890" alt="image" src="https://github.com/user-attachments/assets/ef02377d-364e-44d5-b90a-a23d297e4838" />

## CI
After merging to main, "benchmark.yml" CI script will run benchmark suite and will regenerate bench results.
p.s. bench results are not included in PR because of it
p.p.s. current CI script already includes Bun setup, might be later switched to oven-sh/setup-bun@v2 action but lets do it in separate PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bun is now included in the benchmark suite, with end-to-end measurement, installation scenarios, and reporting in charts and generated SVGs.

* **Bug Fixes**
  * Lockfile cleaning during benchmark runs now correctly handles Bun’s lockfile format.

* **Chores**
  * Benchmark documentation updated to list Bun alongside other package managers.
  * Removed a legacy npm benchmark results file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->