### PR TITLE
docs: update pnpr documentation

### DIFF
--- a/blog/releases/11.7.md
+++ b/blog/releases/11.7.md
@@ -29,7 +29,7 @@ The store must already contain everything the install needs, including the build
 
 The new opt-in `--batch` flag for `pnpm publish --recursive` sends all selected packages to the registry in a single `PUT /-/pnpm/v1/publish` request instead of one request per package.
 
-The target registry has to implement the batch publish endpoint ([pnpr](https://github.com/pnpm/pnpr) does); registries that don't are reported with a clear `ERR_PNPM_BATCH_PUBLISH_UNSUPPORTED` error. The batch is processed all-or-nothing: if any package in the batch fails validation, none of the packages are published.
+The target registry has to implement the batch publish endpoint ([pnpr](https://github.com/pnpm/pnpm/tree/main/pnpr) does); registries that don't are reported with a clear `ERR_PNPM_BATCH_PUBLISH_UNSUPPORTED` error. The batch is processed all-or-nothing: if any package in the batch fails validation, none of the packages are published.
 
 ### Scope-specific auth tokens
 

--- a/docs/cli/publish.md
+++ b/docs/cli/publish.md
@@ -80,7 +80,7 @@ Added in: v11.7.0
 
 When publishing recursively (`pnpm -r publish`), send all selected packages to the registry in a single `PUT /-/pnpm/v1/publish` request instead of one request per package.
 
-The target registry has to implement the batch publish endpoint ([pnpr](https://github.com/pnpm/pnpr) does); registries that don't are reported with an `ERR_PNPM_BATCH_PUBLISH_UNSUPPORTED` error. The batch is processed all-or-nothing: if any package in the batch fails validation, none of the packages are published.
+The target registry has to implement the batch publish endpoint ([pnpr](https://github.com/pnpm/pnpm/tree/main/pnpr) does); registries that don't are reported with an `ERR_PNPM_BATCH_PUBLISH_UNSUPPORTED` error. The batch is processed all-or-nothing: if any package in the batch fails validation, none of the packages are published.
 
 ### --skip-manifest-obfuscation
 
@@ -156,4 +156,3 @@ publishBranch: production
 * `postpack`
 * `publish`
 * `postpublish`
-

--- a/pnpr-docs/auth-backends.md
+++ b/pnpr-docs/auth-backends.md
@@ -75,6 +75,8 @@ backend:
   postgres:
     url: ${PNPR_POSTGRES_URL}
     maxConnections: 16
+    timeout: 30s
+    startupTimeout: 5m
 ```
 
 ## MySQL
@@ -84,8 +86,19 @@ backend:
   mysql:
     url: ${PNPR_MYSQL_URL}
     maxConnections: 16
+    timeout: 30s
+    startupTimeout: 5m
 ```
+
+| Key | Required | Description |
+| --- | --- | --- |
+| `url` | yes | Driver connection URL, such as `postgres://user:pass@host/db` or `mysql://user:pass@host/db`. |
+| `maxConnections` | no | Maximum connections in the backend pool. Omit to use the driver's default. |
+| `timeout` | no | Request-path auth database deadline. Defaults to `30s`. |
+| `startupTimeout` | no | Startup connection and schema setup deadline. Defaults to `5m`. |
 
 When the `backend:` block is absent, auth stays on local disk and the
 `auth.htpasswd` / `auth.tokens` settings apply as before. The
-`auth.htpasswd.max_users` registration cap is honored either way.
+`auth.htpasswd.max_users` registration cap is honored either way. Omitted
+`max_users` and `max_users: -1` both disable self-registration; set a
+non-negative cap to let new users register.

--- a/pnpr-docs/cli.md
+++ b/pnpr-docs/cli.md
@@ -12,13 +12,15 @@ pnpr [OPTIONS]
 | Flag | Description |
 | --- | --- |
 | `-c, --config <path>` | Path to a [verdaccio-shaped YAML config](configuration.md). When omitted, the global `config.yaml` in pnpr's config dir is used if it exists, otherwise the bundled default config. |
-| `--listen <addr>` | Address to bind to. Defaults to `127.0.0.1:4873`. |
+| `--listen <addr>` | Address to bind to. Defaults to `127.0.0.1:7677`. |
 | `--storage <path>` | Override the [storage](configuration.md) directory from the loaded config — the source of truth for hosted packages. |
 | `--cache <path>` | Override the disposable proxy-cache directory (the mirror of upstream registries plus the resolver cache). Defaults to a `.pnpr-cache` subdirectory of the storage path. |
 | `--public-url <url>` | URL clients should use to reach the server, used when rewriting `dist.tarball` URLs in served packuments. Defaults to `http://<listen>`. |
 | `--packument-ttl-secs <n>` | Seconds before a cached packument is considered stale and refetched. When omitted, the loaded config's value wins. |
 | `--osv` | Enable local [OSV](https://osv.dev/) npm vulnerability checks. Requires a local OSV npm database zip at `--osv-db` or `<cache>/osv/npm/all.zip`. |
 | `--osv-db <path>` | Path to the local OSV npm database zip or extracted JSON directory. |
+| `--disable-registry` | Disable the npm registry surface: packument and tarball reads, publish, unpublish, dist-tags, search, and login/token endpoints. Overrides `registry.enabled`. |
+| `--disable-resolver` | Disable the install-accelerator surface: `GET /-/pnpr`, `POST /-/pnpr/v0/resolve`, and `POST /-/pnpr/v0/verify-lockfile`. Overrides `resolver.enabled`. |
 | `-h, --help` | Print help. |
 | `-V, --version` | Print version. |
 
@@ -31,17 +33,27 @@ which always wins over the level set in the config file:
 RUST_LOG=debug pnpr
 ```
 
+The config `log.level` accepts `trace`, `debug`, `http`, `info`, `warn`, and
+`error`. `http` enables one access-log record per request while keeping the
+rest of the crate quieter.
+
 ## Examples
 
 Bind to all interfaces and tell clients to reach the server through a public
 hostname:
 
 ```sh
-pnpr --listen 0.0.0.0:4873 --public-url https://registry.example.com
+pnpr --listen 0.0.0.0:7677 --public-url https://registry.example.com
 ```
 
 Run with a custom config and a separate, ephemeral cache volume:
 
 ```sh
 pnpr -c ./pnpr.yaml --cache /mnt/ephemeral/pnpr-cache
+```
+
+Run only the pnpr resolver endpoints, without exposing an npm registry surface:
+
+```sh
+pnpr --disable-registry
 ```

--- a/pnpr-docs/configuration.md
+++ b/pnpr-docs/configuration.md
@@ -20,11 +20,13 @@ packages:
   '@*/*':
     access: $all
     publish: $authenticated
+    unpublish: $authenticated
     proxy: npmjs
 
   '**':
     access: $all
     publish: $authenticated
+    unpublish: $authenticated
     proxy: npmjs
 ```
 
@@ -41,7 +43,8 @@ pnpr keeps two kinds of data:
 - **`storage`** — the source of truth: packages published to this server plus
   anything served in static mode. Back this up and keep it on a durable volume.
 - **`cache`** — the disposable mirror of upstream registries plus the resolver
-  cache. Safe to wipe at any time. Defaults to a `.pnpr-cache` subdirectory of
+  store, resolver cache, lockfile-verdict cache, and S3 upload staging scratch.
+  Safe to wipe at any time. Defaults to a `.pnpr-cache` subdirectory of
   `storage`; point it at a separate, ephemeral volume to keep cached upstream
   content off the durable disk.
 
@@ -61,32 +64,61 @@ Upstream registries pnpr can proxy from:
 uplinks:
   npmjs:
     url: https://registry.npmjs.org/
+    maxage: 5m
+    timeout: 30s
+    max_fails: 2
+    fail_timeout: 5m
+    cache: true
 ```
+
+Supported uplink keys:
+
+| Key | Description |
+| --- | --- |
+| `url` | Upstream registry URL. |
+| `auth` | Optional auth block. `type` is `bearer` or `basic`; provide `token`, or `token_env: true` to read `NPM_TOKEN`, or `token_env: NAME` to read a named environment variable. |
+| `headers` | Extra request headers to send to the uplink. If `headers.Authorization` is set, it overrides the `auth`-derived header. |
+| `maxage` | Per-uplink packument freshness window. Overrides pnpr's global packument TTL / `--packument-ttl-secs` for this uplink. |
+| `timeout` | Per-request upstream deadline. Defaults to `30s`. |
+| `max_fails` | Consecutive failures before the uplink circuit breaker opens. Defaults to `2`; `0` disables the breaker. |
+| `fail_timeout` | Cooldown before an open uplink is probed again. Defaults to `5m`. |
+| `cache` | Whether tarballs fetched from this uplink are written to the local mirror. Defaults to `true`; `false` streams verified tarballs through a temporary file. |
+
+Interval values accept Verdaccio-style strings such as `30s`, `5m`, `1h30m`,
+or a bare number of seconds.
 
 ## `packages`
 
-Per-package access and publish rules, matched top to bottom by glob. Each entry
-can set `access`, `publish`, and a `proxy` uplink:
+Per-package access, publish, unpublish, and proxy rules are matched top to
+bottom by glob. The first matching rule wins. Each entry can set `access`,
+`publish`, `unpublish`, and a `proxy` uplink:
 
 ```yaml
 packages:
   '@private/*':
     access: $authenticated
     publish: $authenticated
+    unpublish: $authenticated
 
   '@*/*':
     access: $all
     publish: $authenticated
+    unpublish: $authenticated
     proxy: npmjs
 
   '**':
     access: $all
     publish: $authenticated
+    unpublish: $authenticated
     proxy: npmjs
 ```
 
 Common access values are `$all` (anyone), `$authenticated` (logged-in users),
 and `$anonymous`.
+
+When a key is omitted, `access` defaults to `$all`, `publish` defaults to
+`$authenticated`, and `unpublish` defaults to nobody. Omit `proxy` to make a
+matching package storage-only.
 
 ## `auth`
 
@@ -97,13 +129,58 @@ database:
 auth:
   htpasswd:
     file: ./htpasswd
-    # Maximum number of users allowed to register. Defaults to "+inf".
-    # Set to -1 to disable registration.
-    #max_users: 1000
+    # Self-registration is disabled when omitted or set to -1.
+    # Set a non-negative cap to allow new users.
+    max_users: -1
+  tokens:
+    # Optional. Defaults to a tokens.db sibling of the htpasswd file.
+    file: ./tokens.db
 ```
+
+`max_users` is deliberately safer than Verdaccio's default: omitted means
+registration disabled, not unlimited registration. Existing users can still log
+in. When `auth.tokens.file` is omitted and `auth.htpasswd.file` is set, the
+token database defaults to `tokens.db` next to the htpasswd file.
 
 To share auth state across several stateless pnpr replicas, move users and
 tokens into a shared SQL database — see [Auth backends](auth-backends.md).
+
+## `registry` and `resolver`
+
+pnpr exposes two configurable HTTP surfaces:
+
+```yaml
+registry:
+  enabled: true
+
+resolver:
+  enabled: true
+```
+
+- **`registry`** mounts the npm-compatible registry routes: packument and
+  tarball reads, publish, unpublish, dist-tags, search, and login/token
+  endpoints.
+- **`resolver`** mounts the pnpr install-accelerator routes:
+  `GET /-/pnpr`, `POST /-/pnpr/v0/resolve`, and
+  `POST /-/pnpr/v0/verify-lockfile`.
+
+Both are enabled by default. At least one must stay enabled. The CLI flags
+`--disable-registry` and `--disable-resolver` override these settings.
+
+## `osv`
+
+Local OSV checks can hide or reject known vulnerable npm versions without live
+OSV API calls:
+
+```yaml
+osv:
+  enabled: true
+  path: ./osv/npm/all.zip
+```
+
+`path` may point to an OSV npm database zip or an extracted JSON directory. When
+omitted, pnpr looks for `<cache>/osv/npm/all.zip`. The same feature can be
+enabled from the CLI with `--osv` and `--osv-db`.
 
 ## `log`
 
@@ -111,7 +188,7 @@ tokens into a shared SQL database — see [Auth backends](auth-backends.md).
 log:
   type: stdout
   format: pretty   # or `json`
-  level: error
+  level: error     # trace, debug, http, info, warn, or error
 ```
 
 `RUST_LOG` always overrides the configured level. See the

--- a/pnpr-docs/endpoints.md
+++ b/pnpr-docs/endpoints.md
@@ -1,0 +1,106 @@
+---
+id: endpoints
+title: HTTP endpoints
+---
+
+pnpr exposes one always-on health endpoint plus two configurable surfaces:
+
+- **Registry surface** (`registry.enabled`) - npm-compatible package, auth, and
+  publish endpoints.
+- **Resolver surface** (`resolver.enabled`) - pnpr install-accelerator
+  endpoints under `/-/pnpr`.
+
+Both surfaces are enabled by default. See
+[Configuration](configuration.md#registry-and-resolver) for the config keys and
+[CLI reference](cli.md) for the command-line overrides.
+
+## Always available
+
+| Method | Path | Description |
+| --- | --- | --- |
+| `GET` | `/-/ping` | Health check. Returns `{}`. |
+
+## Resolver endpoints
+
+The resolver endpoints are mounted when `resolver.enabled` is true. The
+`POST` endpoints require a valid pnpr `Authorization` header.
+
+| Method | Path | Description |
+| --- | --- | --- |
+| `GET` | `/-/pnpr` | Capability handshake. Returns supported protocol versions, currently `{"pnpr":{"versions":[0]}}`. A 404 means the server has no compatible resolver surface. |
+| `POST` | `/-/pnpr/v0/resolve` | Resolves one project or workspace against the registries and policy sent by the client. Returns `application/x-ndjson` frames. |
+| `POST` | `/-/pnpr/v0/verify-lockfile` | Verifies an existing lockfile under the client's registry and policy settings without resolving again. Returns `application/x-ndjson` frames. |
+
+`POST /-/pnpr/v0/resolve` accepts fields such as `projects`, `dependencies`,
+`devDependencies`, `optionalDependencies`, `registry`, `namedRegistries`,
+`authHeaders`, `overrides`, `lockfile`, `frozenLockfile`,
+`preferFrozenLockfile`, `ignoreManifestCheck`, `trustLockfile`,
+`minimumReleaseAge`, `minimumReleaseAgeExclude`,
+`minimumReleaseAgeIgnoreMissingTime`, `trustPolicy`, `trustPolicyExclude`, and
+`trustPolicyIgnoreAfter`.
+
+The `resolve` response is an NDJSON stream:
+
+| Frame | Description |
+| --- | --- |
+| `package` | One resolved tarball: `id`, `name`, `version`, `integrity`, `tarball`, and optional `unpackedSize` / `fileCount`. |
+| `done` | Terminal success frame. For `resolve`, carries `lockfile` and `stats.totalPackages`; for `verify-lockfile`, only indicates success. |
+| `violations` | Terminal policy failure frame. Carries rendered lockfile or OSV violations. |
+| `error` | Terminal server-side resolution or verification error. |
+
+## Registry read endpoints
+
+These endpoints are mounted when `registry.enabled` is true. Package reads are
+checked against the matching package rule's `access` list.
+
+| Method | Path | Description |
+| --- | --- | --- |
+| `GET` | `/{name}` | Unscoped package packument. |
+| `GET` | `/@scope/{name}` | Scoped package packument. |
+| `GET` | `/{name}/{version-or-tag}` | Unscoped version manifest by exact version or dist-tag. |
+| `GET` | `/@scope/{name}/{version-or-tag}` | Scoped version manifest by exact version or dist-tag. |
+| `GET` | `/{name}/-/{filename}` | Unscoped tarball. |
+| `GET` | `/@scope/{name}/-/{filename}` | Scoped tarball. |
+| `GET` | `/-/package/{package}/dist-tags` | Package `dist-tags` object. Use a percent-encoded scoped package name, for example `@scope%2Fname`. |
+| `GET` | `/-/v1/search?text=<query>&size=<n>` | npm search v1 shape. Searches hosted packages by package-name substring and may add an exact upstream match. Results are filtered by access policy. |
+
+Packument responses rewrite `dist.tarball` URLs to the configured
+`public_url`. If the client sends
+`Accept: application/vnd.npm.install-v1+json`, pnpr returns npm's abbreviated
+install-v1 packument shape.
+
+When OSV checks are enabled, vulnerable versions are removed from packuments
+and dist-tags. Version manifests and tarballs for vulnerable versions are
+denied.
+
+## Registry write endpoints
+
+These endpoints are mounted when `registry.enabled` is true. `PUT` and
+`DELETE` requests require credentials. A read-only bearer token cannot use
+write methods, and CIDR-restricted bearer tokens are checked against the peer
+socket address.
+
+| Method | Path | Description |
+| --- | --- | --- |
+| `PUT` | `/{name}` | Publish an unscoped package. Body is the npm publish document with `_attachments`. Requires `publish`. |
+| `PUT` | `/@scope/{name}` | Publish a scoped package. Body is the npm publish document with `_attachments`. Requires `publish`. |
+| `PUT` | `/-/pnpm/v1/publish` | pnpm batch publish. Body is `{"packages":[<publish document>, ...]}`. The batch is all-or-nothing and each package requires `publish`. |
+| `PUT` | `/{package}/-rev/{rev}` | Replace a packument, used by partial unpublish. Requires both `publish` and `unpublish`. Use a percent-encoded scoped package name, for example `@scope%2Fname`. |
+| `DELETE` | `/{package}/-rev/{rev}` | Remove an entire package, used by force unpublish. Requires `unpublish`. Use a percent-encoded scoped package name for scoped packages. |
+| `DELETE` | `/{name}/-/{filename}/-rev/{rev}` | Remove an unscoped tarball. Requires `unpublish`. |
+| `DELETE` | `/@scope/{name}/-/{filename}/-rev/{rev}` | Remove a scoped tarball. Requires `unpublish`. |
+| `PUT` | `/-/package/{package}/dist-tags/{tag}` | Add or update a dist-tag. Body is a JSON string version, for example `"1.0.0"`. Requires `publish`. |
+| `DELETE` | `/-/package/{package}/dist-tags/{tag}` | Remove a dist-tag. Requires `publish`. |
+
+## User and token endpoints
+
+These endpoints are mounted when `registry.enabled` is true.
+
+| Method | Path | Description |
+| --- | --- | --- |
+| `PUT` | `/-/user/org.couchdb.user:{name}` | npm adduser/login endpoint. Creates a user only when `auth.htpasswd.max_users` allows registration; existing users can log in with the correct password. Returns a bearer token. |
+| `GET` | `/-/whoami` | Returns `{"username": ...}` for the authenticated caller. |
+| `GET` | `/-/npm/v1/user` | npm profile endpoint. Returns the authenticated username and placeholder profile fields. |
+| `GET` | `/-/npm/v1/tokens` | Lists bearer tokens for the authenticated caller in npm-compatible shape. |
+| `DELETE` | `/-/npm/v1/tokens/token/{key}` | Revokes one of the caller's tokens by listing-side token key. |
+| `DELETE` | `/-/user/token/{token}` | npm logout endpoint. Revokes the raw bearer token in the path when it belongs to the authenticated caller. |

--- a/pnpr-docs/install-acceleration.md
+++ b/pnpr-docs/install-acceleration.md
@@ -33,10 +33,9 @@ pnpr collapses that depth:
 
 Crucially, pnpr only does the resolution. The tarballs are still fetched by the
 client, **directly from the registries in parallel** — exactly like a normal
-install, which a single connection through the server could never match. That's
-why the accelerated path is never slower than a plain install: it removes the
-latency-bound resolution waterfall and changes nothing about the
-bandwidth-bound tarball download.
+install, which a single connection through the server could never match. The
+accelerated path removes the latency-bound resolution waterfall without turning
+tarball downloads into a single server-mediated stream.
 
 When the project already has an up-to-date lockfile, there's nothing to resolve,
 so this path doesn't apply — the speedup is for cold installs and dependency
@@ -44,25 +43,38 @@ changes.
 
 ## How it works
 
-1. pnpm sends `POST /v1/install` to the pnpr server with the project's
-   dependencies (and the existing lockfile, if any, for incremental
-   resolution).
-2. The server resolves against the client's registries, verifies the input
-   lockfile under the client's policy, and answers with one gzipped JSON object
-   carrying the resolved lockfile and stats.
-3. pnpm uses the resolved lockfile for its headless install, fetching tarballs
-   directly from the registries — like a normal install.
+1. pnpm checks `GET /-/pnpr` to verify that the server speaks a compatible pnpr
+   resolver protocol version.
+2. pnpm sends `POST /-/pnpr/v0/resolve` with the project's dependencies,
+   registry settings, forwarded upstream credentials, policy settings, and the
+   existing lockfile when one is available.
+3. The server resolves against the client's registries, verifies the input
+   lockfile under the client's policy, and streams an `application/x-ndjson`
+   response. `package` frames announce resolved tarballs as the tree walk
+   progresses, and a terminal `done` frame carries the resolved lockfile and
+   stats. A terminal `violations` or `error` frame aborts the install.
+4. pnpm writes the resolved lockfile and fetches tarballs directly from the
+   registries, like a normal install.
 
-pnpr acts as a stateless resolver here: it stores no tarballs and serves no file
-content. See [pnpm/pnpm#12230](https://github.com/pnpm/pnpm/issues/12230) for
-background.
+For frozen restores with an already-fresh lockfile, pnpm can use
+`POST /-/pnpr/v0/verify-lockfile` to get only the server-side trust verdict
+instead of resolving again.
+
+The resolver surface is stateless for package contents: it stores no tarballs
+and serves no file content. See
+[pnpm/pnpm#12230](https://github.com/pnpm/pnpm/issues/12230) and
+[pnpm/pnpm#12234](https://github.com/pnpm/pnpm/issues/12234) for background.
 
 ## Enabling it
 
 Set `pnprServer` in your `pnpm-workspace.yaml` to the URL of a pnpr server:
 
 ```yaml
-pnprServer: http://localhost:4000
+pnprServer: http://127.0.0.1:7677
 ```
 
-pnpm will offload resolution to that server during `pnpm install`.
+pnpm will offload resolution to that server during `pnpm install`. The resolver
+`POST` endpoints require a valid pnpr `Authorization` header. pnpm forwards the
+auth configured for the `pnprServer` URL; if the same pnpr server is also your
+registry, a normal `pnpm login --registry <server-url>` writes the token pnpm
+uses for both registry and resolver requests.

--- a/pnpr-docs/installation.md
+++ b/pnpr-docs/installation.md
@@ -4,7 +4,7 @@ title: Installation
 ---
 
 pnpr is distributed on npm as [`@pnpm/pnpr`](https://www.npmjs.com/package/@pnpm/pnpr).
-Install it globally:
+The npm wrapper requires Node.js 18 or newer. Install it globally:
 
 ```sh
 pnpm add -g @pnpm/pnpr

--- a/pnpr-docs/quick-start.md
+++ b/pnpr-docs/quick-start.md
@@ -11,7 +11,7 @@ Run `pnpr` with the bundled default config:
 pnpr
 ```
 
-It listens on `127.0.0.1:4873` and proxies `https://registry.npmjs.org/` by
+It listens on `127.0.0.1:7677` and proxies `https://registry.npmjs.org/` by
 default.
 
 ## Point a client at it
@@ -19,7 +19,7 @@ default.
 Configure pnpm (or npm/yarn) to use the local server as its registry:
 
 ```sh
-pnpm config set registry http://127.0.0.1:4873/
+pnpm config set registry http://127.0.0.1:7677/
 ```
 
 Now `pnpm install` fetches packages through pnpr. Packages proxied from the
@@ -27,12 +27,36 @@ upstream are cached, so subsequent installs are served locally.
 
 ## Publish a package
 
-By default the bundled config requires authentication to publish. Create a user
-and publish:
+The bundled config requires authentication to publish and disables self-service
+registration. To try publishing locally, run pnpr with a config that opts into
+registration:
+
+```yaml
+storage: ./storage
+
+auth:
+  htpasswd:
+    file: ./htpasswd
+    max_users: 1
+
+uplinks:
+  npmjs:
+    url: https://registry.npmjs.org/
+
+packages:
+  '**':
+    access: $all
+    publish: $authenticated
+    unpublish: $authenticated
+    proxy: npmjs
+```
+
+Start pnpr with that file, then create a user and publish:
 
 ```sh
-pnpm login --registry http://127.0.0.1:4873/
-pnpm publish --registry http://127.0.0.1:4873/
+pnpr -c ./pnpr.yaml
+pnpm login --registry http://127.0.0.1:7677/
+pnpm publish --registry http://127.0.0.1:7677/
 ```
 
 ## Where to go next

--- a/pnpr-docs/storage.md
+++ b/pnpr-docs/storage.md
@@ -8,7 +8,8 @@ pnpr keeps two kinds of data:
 - **Hosted** — the source of truth: packages published to this server plus
   anything served in static mode. Lives under `storage`.
 - **Cache** — the disposable mirror of upstream registries plus the resolver
-  cache. Lives under `cache` (defaults to `<storage>/.pnpr-cache`).
+  cache, lockfile-verdict cache, and S3 upload staging scratch. Lives under
+  `cache` (defaults to `<storage>/.pnpr-cache`).
 
 By default both are local directories. Adding an `s3:` block moves the **hosted**
 store into an S3-compatible object store, so the durable data is replicated by
@@ -20,7 +21,8 @@ Because any S3-compatible endpoint works, this also covers **Cloudflare R2**,
 host.
 
 ```yaml
-storage: ./storage   # still backs the local cache + upload staging
+storage: ./storage
+# cache: ./cache     # local proxy cache + resolver cache + S3 upload staging
 
 s3:
   bucket: my-pnpr-packages
@@ -67,13 +69,14 @@ packages:
   '**':
     access: $all
     publish: $authenticated
+    unpublish: $authenticated
     proxy: npmjs
 ```
 
 ```sh
 export AWS_ACCESS_KEY_ID="<r2-access-key-id>"
 export AWS_SECRET_ACCESS_KEY="<r2-secret-access-key>"
-pnpr -c ./pnpr.yaml --listen 0.0.0.0:4873 --public-url https://registry.example.com
+pnpr -c ./pnpr.yaml --listen 0.0.0.0:7677 --public-url https://registry.example.com
 ```
 
 `--public-url` rewrites the `dist.tarball` URLs in served packuments, so clients

--- a/sidebars-pnpr.json
+++ b/sidebars-pnpr.json
@@ -14,6 +14,7 @@
       ]
     },
     "install-acceleration",
+    "endpoints",
     "license"
   ]
 }


### PR DESCRIPTION
## Summary

- align pnpr docs with the current server defaults, resolver endpoints, auth behavior, storage/cache split, OSV support, and feature toggles
- add a pnpr HTTP endpoints reference covering registry, resolver, batch publish, dist-tag, user, and token routes
- fix stale pnpr repository links in publish docs and the 11.7 release note

## Validation

- `git diff --check`
- `pnpm build` (completed successfully; reports the pre-existing `/blog/releases/11.0 -> /cli/pn` broken link for each locale)
