### PR TITLE
docs: update pnpr docs for registry mounts and the authorization-aware resolver

### DIFF
--- a/pnpr-docs/cli.md
+++ b/pnpr-docs/cli.md
@@ -11,7 +11,7 @@ pnpr [OPTIONS]
 
 | Flag | Description |
 | --- | --- |
-| `-c, --config <path>` | Path to a [verdaccio-shaped YAML config](configuration.md). When omitted, the global `config.yaml` in pnpr's config dir is used if it exists, otherwise the bundled default config. |
+| `-c, --config <path>` | Path to a [YAML config](configuration.md). When omitted, the global `config.yaml` in pnpr's config dir is used if it exists, otherwise the bundled default config. |
 | `--listen <addr>` | Address to bind to. Defaults to `127.0.0.1:7677`. |
 | `--storage <path>` | Override the [storage](configuration.md) directory from the loaded config — the source of truth for hosted packages. |
 | `--cache <path>` | Override the disposable proxy-cache directory (the mirror of upstream registries plus the resolver cache). Defaults to a `.pnpr-cache` subdirectory of the storage path. |

--- a/pnpr-docs/configuration.md
+++ b/pnpr-docs/configuration.md
@@ -3,31 +3,35 @@ id: configuration
 title: Configuration
 ---
 
-pnpr uses a [verdaccio](https://verdaccio.org/docs/configuration)-shaped YAML
-config. When you don't pass `-c`, pnpr looks for a global `config.yaml` in its
-config directory and otherwise falls back to a bundled default.
+pnpr uses a YAML config. When you don't pass `-c`, pnpr looks for a global
+`config.yaml` in its config directory and otherwise falls back to a bundled
+default (which is shaped for pnpm's own test registry — write your own config
+for real use).
 
-A minimal config:
+A minimal config that hosts a private scope locally and routes everything else
+to the public npm registry:
 
 ```yaml
 storage: ./storage
 
-uplinks:
+mounts:
+  local:
+    type: hosted
+
   npmjs:
+    type: upstream
     url: https://registry.npmjs.org/
+    public: true
 
-packages:
-  '@*/*':
-    access: $all
-    publish: $authenticated
-    unpublish: $authenticated
-    proxy: npmjs
+  main:
+    type: router
+    routes:
+      - patterns: ['@mycompany/*']
+        source: local
+      - patterns: ['**']
+        source: npmjs
 
-  '**':
-    access: $all
-    publish: $authenticated
-    unpublish: $authenticated
-    proxy: npmjs
+defaultTarget: main
 ```
 
 Pass it with `-c`:
@@ -56,69 +60,197 @@ storage: ./storage
 The hosted store can instead live in an S3-compatible object store — see
 [Storage backends](storage.md).
 
-## `uplinks`
+## `mounts` and `defaultTarget`
 
-Upstream registries pnpr can proxy from:
+Registry mounts are pnpr's **only routing surface**. Every addressable registry
+origin is a mount, exposed as an npm registry at `https://<pnpr>/~<mount>/`.
+There are three kinds:
+
+- **`hosted`** — a registry pnpr itself is the authoritative origin for. The
+  only kind that accepts writes (publish, dist-tags, unpublish).
+- **`upstream`** — exactly one external registry origin, proxied and cached.
+- **`router`** — maps package-name patterns to exactly one concrete source
+  mount, first match wins.
+
+The model is governed by one invariant: **provenance is declared, never
+inferred**. A package resolves to exactly one declared origin, and no
+configuration can express a cross-origin fall-through — not on "not found" and
+not on "unavailable". A router that matches no route answers a definitive 404,
+and a matched-but-unreachable source is an error, never a silent fallback to
+another origin. This closes the dependency-confusion class of attacks by
+construction.
+
+`defaultTarget` names the mount that the path-less base URL
+(`https://<pnpr>/`) aliases — usually a router. When omitted, the bare host
+serves no registry and clients must address a `/~<mount>/` URL.
+
+A mount name is served as the single URL path segment `/~<name>/`, so it must
+be one URL-safe segment: it cannot be empty, `.` or `..`, start with `.`, or
+contain `/`, `\`, `:`, `%`, `?`, `#`, whitespace, or control characters.
+
+### Hosted mounts
 
 ```yaml
-uplinks:
-  npmjs:
-    url: https://registry.npmjs.org/
-    maxage: 5m
-    timeout: 30s
-    max_fails: 2
-    fail_timeout: 5m
-    cache: true
+mounts:
+  private:
+    type: hosted
+    org: mycompany
+    access: $authenticated
 ```
 
-Supported uplink keys:
+| Key | Description |
+| --- | --- |
+| `org` | Storage namespace for this mount's packages, so two hosted mounts can hold the same `name@version` without colliding. Omitted means the flat `storage` root. Must be a single path-safe segment. |
+| `access` | Who may read this mount's packages. Defaults to `$all`. |
+
+Two hosted mounts cannot share an `org` namespace — that's rejected at config
+load. Publishes routed to a hosted mount land in its namespace; an unauthorized
+read of a private hosted mount returns 404 (not 403), so it doesn't leak which
+packages exist.
+
+### Upstream mounts
+
+An upstream mount is one external origin — one URL, one credential, one cache
+namespace. It is either `public` (fetched anonymously, no credential, readable
+by anyone) or private (carries a server-owned credential and an `access:`
+policy naming who may use it):
+
+```yaml
+mounts:
+  npmjs:
+    type: upstream
+    url: https://registry.npmjs.org/
+    public: true
+
+  corp:
+    type: upstream
+    url: https://npm.corp.example.com/
+    auth:
+      type: bearer
+      token_env: CORP_NPM_TOKEN
+    access: $authenticated
+```
 
 | Key | Description |
 | --- | --- |
 | `url` | Upstream registry URL. |
-| `auth` | Optional auth block. `type` is `bearer` or `basic`; provide `token`, or `token_env: true` to read `NPM_TOKEN`, or `token_env: NAME` to read a named environment variable. |
-| `headers` | Extra request headers to send to the uplink. If `headers.Authorization` is set, it overrides the `auth`-derived header. |
-| `maxage` | Per-uplink packument freshness window. Overrides pnpr's global packument TTL / `--packument-ttl-secs` for this uplink. |
+| `public` | Marks an anonymous, world-readable origin (e.g. the public npm registry). A public mount sends no credential and no custom headers; declaring `auth`, `access`, or `headers` alongside `public: true` is a config error. |
+| `auth` | Server-owned credential for a private origin. `type` is `bearer` or `basic`; provide `token`, or `token_env: true` to read `NPM_TOKEN`, or `token_env: NAME` to read a named environment variable. |
+| `headers` | Extra request headers to send upstream. If `headers.Authorization` is set, it overrides the `auth`-derived header. |
+| `access` | Which pnpr users may reach this mount at `/~<mount>/` (and resolve through it). Required for a non-`public` upstream. |
+| `maxage` | Per-mount packument freshness window. Overrides pnpr's global packument TTL / `--packument-ttl-secs` for this mount. |
 | `timeout` | Per-request upstream deadline. Defaults to `30s`. |
-| `max_fails` | Consecutive failures before the uplink circuit breaker opens. Defaults to `2`; `0` disables the breaker. |
-| `fail_timeout` | Cooldown before an open uplink is probed again. Defaults to `5m`. |
-| `cache` | Whether tarballs fetched from this uplink are written to the local mirror. Defaults to `true`; `false` streams verified tarballs through a temporary file. |
+| `max_fails` | Consecutive failures before the upstream circuit breaker opens. Defaults to `2`; `0` disables the breaker. |
+| `fail_timeout` | Cooldown before an open circuit is probed again. Defaults to `5m`. |
+| `cache` | Whether tarballs fetched from this mount are cached locally. Defaults to `true`; `false` streams verified tarballs through a temporary file. |
 
-Interval values accept Verdaccio-style strings such as `30s`, `5m`, `1h30m`,
-or a bare number of seconds.
+Interval values accept strings such as `30s`, `5m`, `1h30m`, or a bare number
+of seconds.
+
+A private upstream mount is more than a proxy: it is a **pnpr-managed
+credential** for that origin. One upstream token, held by the server, is fanned
+out to a whole team through the mount's `access:` policy — clients authenticate
+to pnpr with their own tokens and never see the upstream credential. pnpr never
+forwards a client's credentials upstream, and the server-owned credential is
+only ever attached over the upstream's own scheme (an `https://` mount's token
+is never sent over plain `http://`).
+
+Each mount gets its own cache namespace: a `public` upstream uses a stable,
+secret-free namespace shared across restarts, while a private mount's cache is
+keyed by an HMAC of the mount and its credential — so rotating the upstream
+token automatically moves to a fresh namespace, and a private mount's content
+can never be served on a public path or through another mount.
+
+### Router mounts
+
+A router maps package-name patterns to concrete source mounts. Routes are
+evaluated in declared order and the **first matching route is authoritative**
+— later routes are never consulted:
+
+```yaml
+mounts:
+  main:
+    type: router
+    routes:
+      - patterns: ['@mycompany/*']
+        source: private
+      - patterns: ['@partner/sdk']
+        source: corp
+      - patterns: ['**']
+        source: npmjs
+```
+
+The pattern language is deliberately small so that route coverage can be
+checked statically:
+
+| Pattern | Matches |
+| --- | --- |
+| `**` | Every package name. |
+| `@*/*` | Every scoped package, any scope. |
+| `@scope/*` | Every package in one scope. |
+| `foo`, `@scope/foo` | Exactly that package. |
+
+Any other wildcard is a config error rather than a silently-never-matching
+literal.
+
+Because route order is load-bearing — a misordered router is the one way a
+mistake could send a private scope to a public origin — pnpr **refuses to
+start** (and fails a config reload) on an invalid router:
+
+- a route that is fully shadowed by earlier routes (including a `**` catch-all
+  that isn't last);
+- a single pattern already covered by an earlier route's pattern;
+- a duplicate pattern;
+- a source that is undefined, the router itself, or another router (routes
+  must target a hosted or upstream mount — no nesting, no cycles);
+- a router or route with no patterns.
 
 ## `packages`
 
-Per-package access, publish, unpublish, and proxy rules are matched top to
-bottom by glob. The first matching rule wins. Each entry can set `access`,
-`publish`, `unpublish`, and a `proxy` uplink:
+`packages:` is a pure **access-control layer** — routing a package to its
+origin is the mount graph's job. Rules are matched top to bottom by glob; the
+first matching rule wins. Each entry can set `access`, `publish`, and
+`unpublish`, and the rule is enforced on every mount-served read and write,
+hosted or upstream:
 
 ```yaml
 packages:
-  '@private/*':
+  '@mycompany/*':
     access: $authenticated
     publish: $authenticated
     unpublish: $authenticated
 
-  '@*/*':
-    access: $all
-    publish: $authenticated
-    unpublish: $authenticated
-    proxy: npmjs
-
   '**':
     access: $all
     publish: $authenticated
-    unpublish: $authenticated
-    proxy: npmjs
 ```
 
 Common access values are `$all` (anyone), `$authenticated` (logged-in users),
-and `$anonymous`.
+and `$anonymous`; a list can also name users and [groups](#groups).
 
 When a key is omitted, `access` defaults to `$all`, `publish` defaults to
-`$authenticated`, and `unpublish` defaults to nobody. Omit `proxy` to make a
-matching package storage-only.
+`$authenticated`, and `unpublish` defaults to nobody.
+
+## `groups`
+
+Static group/team memberships. Every access list accepts group names anywhere
+it accepts usernames — the per-package `packages:` rules and the mount-level
+`access:` lists alike:
+
+```yaml
+groups:
+  platform: alice bob
+  frontend: [carol, dave]
+
+mounts:
+  corp:
+    type: upstream
+    url: https://npm.corp.example.com/
+    auth:
+      type: bearer
+      token_env: CORP_NPM_TOKEN
+    access: platform
+```
 
 ## `auth`
 
@@ -137,13 +269,26 @@ auth:
     file: ./tokens.db
 ```
 
-`max_users` is deliberately safer than Verdaccio's default: omitted means
-registration disabled, not unlimited registration. Existing users can still log
-in. When `auth.tokens.file` is omitted and `auth.htpasswd.file` is set, the
-token database defaults to `tokens.db` next to the htpasswd file.
+Omitted `max_users` means registration disabled, not unlimited registration.
+Existing users can still log in. When `auth.tokens.file` is omitted and
+`auth.htpasswd.file` is set, the token database defaults to `tokens.db` next to
+the htpasswd file.
 
 To share auth state across several stateless pnpr replicas, move users and
 tokens into a shared SQL database — see [Auth backends](auth-backends.md).
+
+## `secret`
+
+```yaml
+secret: ${PNPR_SECRET}
+```
+
+The HMAC key for pnpr's private cache namespaces — private resolution-cache
+entries and private per-mount cache directories are keyed with it, so on-disk
+paths reveal neither mount names nor credentials. It must be at least 16 bytes.
+When omitted, a fresh random secret is generated per process, which means
+private cache entries only survive for that process's lifetime — set an
+explicit secret to keep private caches warm across restarts.
 
 ## `registry` and `resolver`
 
@@ -159,13 +304,33 @@ resolver:
 
 - **`registry`** mounts the npm-compatible registry routes: packument and
   tarball reads, publish, unpublish, dist-tags, search, and login/token
-  endpoints.
+  endpoints — on the path-less base and on every `/~<mount>/` endpoint.
 - **`resolver`** mounts the pnpr install-accelerator routes:
   `GET /-/pnpr`, `POST /-/pnpr/v0/resolve`, and
   `POST /-/pnpr/v0/verify-lockfile`.
 
 Both are enabled by default. At least one must stay enabled. The CLI flags
 `--disable-registry` and `--disable-resolver` override these settings.
+
+## `routes`
+
+Resolver route classification (see
+[Install acceleration](install-acceleration.md#private-registries)) treats the
+official npm registry as public out of the box. If clients resolve against
+other registries that serve anonymously-readable content, declare them as
+public routes so their resolutions can be cached and shared across all callers:
+
+```yaml
+routes:
+  public:
+    - registry: https://registry.mirror.example.com/
+    - registry: https://npm.corp.example.com/
+      package: '@oss/*'
+```
+
+Each rule may name a `registry` origin, a `package` glob, or both. Rules fail
+closed on a typo: a present-but-unparsable `registry` URL or `package` glob
+drops the whole rule (with a warning) rather than widening it.
 
 ## `osv`
 

--- a/pnpr-docs/endpoints.md
+++ b/pnpr-docs/endpoints.md
@@ -20,6 +20,35 @@ Both surfaces are enabled by default. See
 | --- | --- | --- |
 | `GET` | `/-/ping` | Health check. Returns `{}`. |
 
+## Registry bases: `/` and `/~<mount>/`
+
+Every [registry mount](configuration.md#mounts-and-defaulttarget) is served as
+a full npm registry at `/~<mount>/` — packument and tarball reads, version
+manifests, dist-tags, search, publish, unpublish, and the login/whoami
+endpoints all work under a mount prefix. The `~` prefix keeps mount names out
+of the package-name namespace (a package name can never begin with `~`).
+
+The path-less base (`/`) aliases the mount named by `defaultTarget`; with no
+`defaultTarget` configured, the bare host serves no registry and only the
+`/~<mount>/` bases answer.
+
+Every request routes through the mount graph:
+
+- A request to a **router** mount is answered by the first route whose pattern
+  matches the package. A router that matches no route is a definitive `404` —
+  there is no fall-through to another origin. A matched source that is
+  unavailable is an error, never a `404`.
+- **Writes** (publish, dist-tags, unpublish) must resolve to a hosted mount; a
+  write that routes to an upstream mount is rejected.
+- The matching `packages:` rule's ACL is enforced on every mount-served read
+  and write.
+- Served `dist.tarball` URLs are rewritten onto the configured `public_url`
+  and stay canonical for the base the client addressed (path-less or
+  `/~<mount>/`), so lockfiles don't bake in a mount name.
+
+The endpoint tables below show path-less shapes; each is equally available
+under a `/~<mount>/` prefix.
+
 ## Resolver endpoints
 
 The resolver endpoints are mounted when `resolver.enabled` is true. The
@@ -33,11 +62,20 @@ The resolver endpoints are mounted when `resolver.enabled` is true. The
 
 `POST /-/pnpr/v0/resolve` accepts fields such as `projects`, `dependencies`,
 `devDependencies`, `optionalDependencies`, `registry`, `namedRegistries`,
-`authHeaders`, `overrides`, `lockfile`, `frozenLockfile`,
-`preferFrozenLockfile`, `ignoreManifestCheck`, `trustLockfile`,
-`minimumReleaseAge`, `minimumReleaseAgeExclude`,
-`minimumReleaseAgeIgnoreMissingTime`, `trustPolicy`, `trustPolicyExclude`, and
-`trustPolicyIgnoreAfter`.
+`overrides`, `lockfile`, `frozenLockfile`, `preferFrozenLockfile`,
+`ignoreManifestCheck`, `trustLockfile`, `minimumReleaseAge`,
+`minimumReleaseAgeExclude`, `minimumReleaseAgeIgnoreMissingTime`,
+`trustPolicy`, `trustPolicyExclude`, and `trustPolicyIgnoreAfter`.
+
+Every registry the request would make pnpr fetch from — the `registry` and
+`namedRegistries` origins, plus any direct `http(s)`/`git` URL in a dependency
+spec, an override, or an input-lockfile tarball — must be on the server's fetch
+allowlist (the configured mounts, declared public routes, the built-in npm
+registry, and pnpr's own origin). An off-allowlist origin is rejected up front,
+before any server-side fetch. Upstream credentials are never taken from the
+client: pnpr selects its own server-owned credential per route (see
+[Install acceleration](install-acceleration.md#private-registries)), and a URL
+carrying inline `user:pass@` credentials is rejected.
 
 The `resolve` response is an NDJSON stream:
 
@@ -62,12 +100,10 @@ checked against the matching package rule's `access` list.
 | `GET` | `/{name}/-/{filename}` | Unscoped tarball. |
 | `GET` | `/@scope/{name}/-/{filename}` | Scoped tarball. |
 | `GET` | `/-/package/{package}/dist-tags` | Package `dist-tags` object. Use a percent-encoded scoped package name, for example `@scope%2Fname`. |
-| `GET` | `/-/v1/search?text=<query>&size=<n>` | npm search v1 shape. Searches hosted packages by package-name substring and may add an exact upstream match. Results are filtered by access policy. |
+| `GET` | `/-/v1/search?text=<query>&size=<n>` | npm search v1 shape. Searches locally hosted packages by package-name substring; search is local-only and never proxied upstream. Results are filtered by access policy. |
 
-Packument responses rewrite `dist.tarball` URLs to the configured
-`public_url`. If the client sends
-`Accept: application/vnd.npm.install-v1+json`, pnpr returns npm's abbreviated
-install-v1 packument shape.
+If the client sends `Accept: application/vnd.npm.install-v1+json`, pnpr
+returns npm's abbreviated install-v1 packument shape.
 
 When OSV checks are enabled, vulnerable versions are removed from packuments
 and dist-tags. Version manifests and tarballs for vulnerable versions are
@@ -78,7 +114,8 @@ denied.
 These endpoints are mounted when `registry.enabled` is true. `PUT` and
 `DELETE` requests require credentials. A read-only bearer token cannot use
 write methods, and CIDR-restricted bearer tokens are checked against the peer
-socket address.
+socket address. Every write routes through the mount graph and must land on a
+hosted mount.
 
 | Method | Path | Description |
 | --- | --- | --- |
@@ -94,7 +131,9 @@ socket address.
 
 ## User and token endpoints
 
-These endpoints are mounted when `registry.enabled` is true.
+These endpoints are mounted when `registry.enabled` is true. They are global —
+served identically on the path-less base and under any `/~<mount>/` prefix, so
+`pnpm login` against a mount URL works.
 
 | Method | Path | Description |
 | --- | --- | --- |

--- a/pnpr-docs/install-acceleration.md
+++ b/pnpr-docs/install-acceleration.md
@@ -46,8 +46,10 @@ changes.
 1. pnpm checks `GET /-/pnpr` to verify that the server speaks a compatible pnpr
    resolver protocol version.
 2. pnpm sends `POST /-/pnpr/v0/resolve` with the project's dependencies,
-   registry settings, forwarded upstream credentials, policy settings, and the
-   existing lockfile when one is available.
+   registry settings, policy settings, and the existing lockfile when one is
+   available. Client upstream credentials are never sent — private registries
+   are reached through the server's own credentials (see
+   [below](#private-registries)).
 3. The server resolves against the client's registries, verifies the input
    lockfile under the client's policy, and streams an `application/x-ndjson`
    response. `package` frames announce resolved tarballs as the tree walk
@@ -60,10 +62,52 @@ For frozen restores with an already-fresh lockfile, pnpm can use
 `POST /-/pnpr/v0/verify-lockfile` to get only the server-side trust verdict
 instead of resolving again.
 
-The resolver surface is stateless for package contents: it stores no tarballs
-and serves no file content. See
-[pnpm/pnpm#12230](https://github.com/pnpm/pnpm/issues/12230) and
+See [pnpm/pnpm#12230](https://github.com/pnpm/pnpm/issues/12230) and
 [pnpm/pnpm#12234](https://github.com/pnpm/pnpm/issues/12234) for background.
+
+## Which registries the server will touch {#allowlist}
+
+The resolver only fetches from origins the operator has configured — a
+**default-deny allowlist** made of the configured
+[mounts](configuration.md#mounts-and-defaulttarget), the declared
+[public routes](configuration.md#routes), the built-in official npm registry,
+and pnpr's own origin. A request whose `registry`/`namedRegistries` — or whose
+direct `http(s)`/`git` URL dependencies, overrides, or lockfile tarball URLs —
+point anywhere else is rejected before any server-side fetch, and every
+redirect hop is re-checked against the same allowlist. A caller can't use the
+resolver to make the server fetch from an arbitrary internal address.
+
+## Private registries {#private-registries}
+
+Clients never forward their upstream registry credentials to pnpr. Instead, a
+private registry is configured server-side as an
+[upstream mount](configuration.md#upstream-mounts) with a server-owned
+credential and an `access:` policy naming which pnpr users may resolve through
+it. The caller authenticates to pnpr with their own pnpr token; pnpr selects
+its own credential for each upstream fetch. One upstream token, held only by
+the server, serves a whole team.
+
+Tarball URLs in the resolved lockfile follow the same split:
+
+- A **public** package keeps its upstream URL — the client fetches it directly
+  from the registry or its CDN, never through pnpr.
+- A **private** package resolved through an access-bearing upstream mount is
+  emitted as that mount's `/~<mount>/` registry endpoint URL, so the client
+  fetches it back through pnpr (which enforces the mount's access policy and
+  serves it from a per-mount private cache).
+
+Because a mount endpoint URL is canonical for a client whose registry
+configuration points at it, lockfile entries stay integrity-only — the
+registry host lives in the client's `.npmrc`, not in the lockfile — and a
+project resolves to the same lockfile whether it installs through `/resolve`
+or directly against the registry.
+
+The resolution cache is **authorization-aware**: a resolution that touched
+only public routes is cached once and shared by every caller, while a
+resolution that touched private routes is keyed by the access it required and
+is only replayed for callers who still hold that access at the current
+upstream credential. Rotating an upstream credential automatically moves new
+resolutions to a fresh cache namespace.
 
 ## Enabling it
 

--- a/pnpr-docs/introduction.md
+++ b/pnpr-docs/introduction.md
@@ -6,9 +6,14 @@ slug: /
 
 **pnpr** is a pnpm-compatible npm registry server, written in Rust. It speaks the
 npm registry protocol, so any npm-compatible client (pnpm, npm, yarn) can talk to
-it. It proxies packages from a configured upstream such as `registry.npmjs.org`
-and serves them with its own authentication and access controls — roughly the
-role [verdaccio](https://verdaccio.org/) plays in the JavaScript ecosystem.
+it. It hosts your own packages and proxies upstream registries such as
+`registry.npmjs.org`, with its own authentication and access controls — roughly
+the role [verdaccio](https://verdaccio.org/) plays in the JavaScript ecosystem.
+
+Every registry origin pnpr serves is declared as a
+[registry mount](configuration.md#mounts-and-defaulttarget), and a router maps
+each package name to exactly one origin — there is no cross-origin
+fall-through, which closes dependency-confusion attacks by construction.
 
 pnpr lives in the [pnpm monorepo](https://github.com/pnpm/pnpm) under
 [`pnpr/`](https://github.com/pnpm/pnpm/tree/main/pnpr).
@@ -26,6 +31,9 @@ configuration, and APIs may change between releases.
   per-package access and publish rules.
 - **A caching proxy** — mirror an upstream registry (e.g. npmjs.org) to speed up
   installs and stay resilient to upstream outages.
+- **A credential gateway** — hold one upstream registry token server-side and
+  fan it out to a whole team through pnpr's own authentication, so clients
+  never handle the upstream credential.
 - **An install accelerator** — resolve a project's dependency graph server-side
   and hand pnpm a ready-to-use lockfile. See
   [Install acceleration](install-acceleration.md).

--- a/pnpr-docs/quick-start.md
+++ b/pnpr-docs/quick-start.md
@@ -3,16 +3,60 @@ id: quick-start
 title: Quick start
 ---
 
-## Start the server
+## Write a config
 
-Run `pnpr` with the bundled default config:
+pnpr routes packages through [registry mounts](configuration.md#mounts-and-defaulttarget):
+every origin — a locally-hosted registry, an upstream like npmjs — is declared
+explicitly, and a router maps package names to exactly one of them. Save this
+as `pnpr.yaml`:
 
-```sh
-pnpr
+```yaml
+storage: ./storage
+
+auth:
+  htpasswd:
+    file: ./htpasswd
+    # Allow one user to self-register, for the publish step below.
+    max_users: 1
+
+mounts:
+  # Packages published to this server.
+  local:
+    type: hosted
+
+  # The public npm registry.
+  npmjs:
+    type: upstream
+    url: https://registry.npmjs.org/
+    public: true
+
+  # Route your scope to the local registry, everything else to npm.
+  main:
+    type: router
+    routes:
+      - patterns: ['@mycompany/*']
+        source: local
+      - patterns: ['**']
+        source: npmjs
+
+# The bare server URL serves the router.
+defaultTarget: main
 ```
 
-It listens on `127.0.0.1:7677` and proxies `https://registry.npmjs.org/` by
-default.
+Replace `@mycompany` with your own scope. There is no fall-through between
+mounts: a `@mycompany/*` package that isn't published locally is a definitive
+404, never a request to npmjs — which is exactly what closes dependency
+confusion.
+
+## Start the server
+
+```sh
+pnpr -c ./pnpr.yaml
+```
+
+It listens on `127.0.0.1:7677`. (Running plain `pnpr` with no config works
+too, but the bundled default config is shaped for pnpm's own test registry —
+for anything real, pass your own config.)
 
 ## Point a client at it
 
@@ -25,44 +69,26 @@ pnpm config set registry http://127.0.0.1:7677/
 Now `pnpm install` fetches packages through pnpr. Packages proxied from the
 upstream are cached, so subsequent installs are served locally.
 
+Each mount is also directly addressable as a registry at
+`http://127.0.0.1:7677/~<mount>/` — for example, you can point just your scope
+at the hosted mount instead of using the router.
+
 ## Publish a package
 
-The bundled config requires authentication to publish and disables self-service
-registration. To try publishing locally, run pnpr with a config that opts into
-registration:
-
-```yaml
-storage: ./storage
-
-auth:
-  htpasswd:
-    file: ./htpasswd
-    max_users: 1
-
-uplinks:
-  npmjs:
-    url: https://registry.npmjs.org/
-
-packages:
-  '**':
-    access: $all
-    publish: $authenticated
-    unpublish: $authenticated
-    proxy: npmjs
-```
-
-Start pnpr with that file, then create a user and publish:
+Create a user and publish:
 
 ```sh
-pnpr -c ./pnpr.yaml
 pnpm login --registry http://127.0.0.1:7677/
 pnpm publish --registry http://127.0.0.1:7677/
 ```
 
+The publish routes through the router to the `local` hosted mount — publishing
+a package that routes to an upstream mount is rejected.
+
 ## Where to go next
 
 - [CLI reference](cli.md) — every flag `pnpr` accepts.
-- [Configuration](configuration.md) — write your own config: uplinks, access
+- [Configuration](configuration.md) — write your own config: mounts, access
   rules, and auth.
 - [Install acceleration](install-acceleration.md) — let pnpr resolve your
   dependency graph to speed up installs.

--- a/pnpr-docs/storage.md
+++ b/pnpr-docs/storage.md
@@ -61,16 +61,24 @@ s3:
   region: auto
   endpoint: https://abc123def456.r2.cloudflarestorage.com
 
-uplinks:
-  npmjs:
-    url: https://registry.npmjs.org/
+mounts:
+  local:
+    type: hosted
 
-packages:
-  '**':
-    access: $all
-    publish: $authenticated
-    unpublish: $authenticated
-    proxy: npmjs
+  npmjs:
+    type: upstream
+    url: https://registry.npmjs.org/
+    public: true
+
+  main:
+    type: router
+    routes:
+      - patterns: ['@mycompany/*']
+        source: local
+      - patterns: ['**']
+        source: npmjs
+
+defaultTarget: main
 ```
 
 ```sh


### PR DESCRIPTION
Updates the pnpr docs to the post-redesign state from pnpm/pnpm#12700 (authorization-aware resolver cache) and pnpm/pnpm#12747 (registry mounts as the only routing model). No legacy info or migration guides are kept — pnpr is still under active development and can change in breaking ways.

## What changed

**configuration.md** — `uplinks:` and `packages: proxy:` are gone. Documents `mounts:`/`defaultTarget:` as the only routing surface (provenance is declared, never inferred; no cross-origin fall-through), the three mount kinds with key tables — hosted (`org` namespaces, 404 on unauthorized private reads), upstream (`public` vs `auth`+`access`, per-mount cache namespaces, credential-rotation re-keying), router (the four-shape pattern language and every validation error pnpr refuses to start on) — plus `packages:` as a pure ACL layer and new `groups:`, `secret:`, and `routes: public:` sections.

**install-acceleration.md** — drops the forwarded-upstream-credentials claim (the server ignores `authHeaders` now); adds the default-deny fetch allowlist section and a "Private registries" section covering server-owned credentials, public tarballs staying on the CDN vs private ones routed through `/~<mount>/`, integrity-only lockfile entries, and the authorization-aware resolution cache.

**endpoints.md** — new "Registry bases: `/` and `/~<mount>/`" section (every registry endpoint works under a mount prefix, router no-match is a definitive 404, writes must land on a hosted mount); `authHeaders` removed from the resolve field list; search corrected to local-only.

**quick-start.md** — leads with writing a mount-shaped config and notes the bundled default is shaped for pnpm's own test registry.

**storage.md, introduction.md, cli.md** — R2 example converted to mounts, intro updated with the declared-provenance model, "verdaccio-shaped" dropped.

Everything was verified against the pnpr source at pnpm/pnpm `main` (`config.rs`, `mount.rs`, `route.rs`, `resolver.rs`, `server.rs`, and the bundled `config.yaml`), not just the PR descriptions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the CLI, quick-start, storage, and configuration guides to reflect the current YAML-based setup and mount-based routing model.
  * Clarified how packages are routed, how registry access works, and how local, upstream, and router mounts interact.
  * Expanded endpoint and install documentation with clearer behavior for publishing, login, search, token handling, and resolved package URLs.
  * Added guidance on credential handling, private cache behavior, and configuration defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->