### PR TITLE
docs: update pnpr docs for registries, ordered sources, and per-registry packages maps

### DIFF
--- a/pnpr-docs/cli.md
+++ b/pnpr-docs/cli.md
@@ -19,7 +19,7 @@ pnpr [OPTIONS]
 | `--packument-ttl-secs <n>` | Seconds before a cached packument is considered stale and refetched. When omitted, the loaded config's value wins. |
 | `--osv` | Enable local [OSV](https://osv.dev/) npm vulnerability checks. Requires a local OSV npm database zip at `--osv-db` or `<cache>/osv/npm/all.zip`. |
 | `--osv-db <path>` | Path to the local OSV npm database zip or extracted JSON directory. |
-| `--disable-registry` | Disable the npm registry surface: packument and tarball reads, publish, unpublish, dist-tags, search, and login/token endpoints. Overrides `registry.enabled`. |
+| `--disable-registry` | Disable the npm registry surface (packument and tarball reads, publish, unpublish, dist-tags, and search) that is otherwise served whenever the config declares at least one registry. The health and login/token endpoints stay available. |
 | `--disable-resolver` | Disable the install-accelerator surface: `GET /-/pnpr`, `POST /-/pnpr/v0/resolve`, and `POST /-/pnpr/v0/verify-lockfile`. Overrides `resolver.enabled`. |
 | `-h, --help` | Print help. |
 | `-V, --version` | Print version. |

--- a/pnpr-docs/configuration.md
+++ b/pnpr-docs/configuration.md
@@ -14,9 +14,14 @@ to the public npm registry:
 ```yaml
 storage: ./storage
 
-mounts:
+registries:
   local:
     type: hosted
+    packages:
+      # The names this registry serves, plus their access rules.
+      '@mycompany/*':
+        access: $authenticated
+        publish: $authenticated
 
   npmjs:
     type: upstream
@@ -25,13 +30,9 @@ mounts:
 
   main:
     type: router
-    routes:
-      - patterns: ['@mycompany/*']
-        source: local
-      - patterns: ['**']
-        source: npmjs
+    sources: [local, npmjs]
 
-defaultTarget: main
+defaultRegistry: main
 ```
 
 Pass it with `-c`:
@@ -60,63 +61,112 @@ storage: ./storage
 The hosted store can instead live in an S3-compatible object store — see
 [Storage backends](storage.md).
 
-## `mounts` and `defaultTarget`
+## `registries` and `defaultRegistry`
 
-Registry mounts are pnpr's **only routing surface**. Every addressable registry
-origin is a mount, exposed as an npm registry at `https://<pnpr>/~<mount>/`.
-There are three kinds:
+The `registries:` map is pnpr's **only routing surface**. Every addressable
+registry origin is a named registry, exposed as an npm registry at
+`https://<pnpr>/~<name>/`. There are three kinds:
 
 - **`hosted`** — a registry pnpr itself is the authoritative origin for. The
   only kind that accepts writes (publish, dist-tags, unpublish).
 - **`upstream`** — exactly one external registry origin, proxied and cached.
-- **`router`** — maps package-name patterns to exactly one concrete source
-  mount, first match wins.
+- **`router`** — an ordered list of concrete source registries; a package
+  resolves to the first listed source that claims its name.
 
 The model is governed by one invariant: **provenance is declared, never
-inferred**. A package resolves to exactly one declared origin, and no
-configuration can express a cross-origin fall-through — not on "not found" and
-not on "unavailable". A router that matches no route answers a definitive 404,
-and a matched-but-unreachable source is an error, never a silent fallback to
-another origin. This closes the dependency-confusion class of attacks by
-construction.
+inferred**. Every concrete registry declares the package names it serves — its
+namespace — through its [`packages:` map](#the-packages-map), a package
+resolves to exactly one declared origin, and no configuration can express a
+cross-origin fall-through — not on "not found" and not on "unavailable". The
+namespace is enforced at the registry, on every path to it: a read of a name
+outside the namespace is a definitive 404 answered before storage or the
+upstream is consulted, and an off-namespace publish is rejected. This closes
+the dependency-confusion class of attacks by construction.
 
-`defaultTarget` names the mount that the path-less base URL
+`defaultRegistry` names the registry that the path-less base URL
 (`https://<pnpr>/`) aliases — usually a router. When omitted, the bare host
-serves no registry and clients must address a `/~<mount>/` URL.
+serves no registry and clients must address a `/~<name>/` URL.
 
-A mount name is served as the single URL path segment `/~<name>/`, so it must
-be one URL-safe segment: it cannot be empty, `.` or `..`, start with `.`, or
-contain `/`, `\`, `:`, `%`, `?`, `#`, whitespace, or control characters.
+A registry name is served as the single URL path segment `/~<name>/`, so it
+must be one URL-safe segment: it cannot be empty, `.` or `..`, start with `.`,
+or contain `/`, `\`, `:`, `%`, `?`, `#`, whitespace, or control characters.
 
-### Hosted mounts
+### The `packages` map
+
+Every concrete registry (hosted or upstream) takes an optional `packages:`
+map. Its **keys are the registry's namespace** — the package names it serves —
+and its **values are the per-package access rules**. One declaration routes,
+filters, and authorizes. When the map is omitted, the registry serves every
+name.
+
+Keys use a deliberately small pattern language, so coverage can be checked
+statically:
+
+| Pattern | Matches |
+| --- | --- |
+| `**` | Every package name. |
+| `@*/*` | Every scoped package, any scope. |
+| `@scope/*` | Every package in one scope. |
+| `foo`, `@scope/foo` | Exactly that package. |
+
+Any other wildcard is a config error rather than a silently-never-matching
+literal.
+
+The **most specific matching key wins**: an exact name beats `@scope/*`, which
+beats `@*/*`, which beats `**`. Key order carries no meaning — at most one key
+per specificity tier can match a name, so the winning rule is unique and
+reordering the map (by a formatter, or a YAML round-trip) can never change
+which rule applies. A duplicate key is a config error.
+
+Each value can set `access`, `publish`, and `unpublish`. Common values are
+`$all` (anyone), `$authenticated` (logged-in users), and `$anonymous`; a list
+can also name users and [groups](#groups). When a field is omitted, `access`
+falls back to the registry-level `access:` default, `publish` defaults to
+`$authenticated`, and `unpublish` defaults to nobody.
+
+### Hosted registries
 
 ```yaml
-mounts:
+registries:
   private:
     type: hosted
     org: mycompany
     access: $authenticated
+    packages:
+      '@mycompany/*':
+        publish: $authenticated
+        unpublish: $authenticated
+      # An explicit entry fully decides its names — this opens one
+      # package on an otherwise-private registry.
+      '@mycompany/open-sdk':
+        access: $all
 ```
 
 | Key | Description |
 | --- | --- |
-| `org` | Storage namespace for this mount's packages, so two hosted mounts can hold the same `name@version` without colliding. Omitted means the flat `storage` root. Must be a single path-safe segment. |
-| `access` | Who may read this mount's packages. Defaults to `$all`. |
+| `org` | Storage namespace for this registry's packages, so two hosted registries can hold the same `name@version` without colliding. Omitted means the flat `storage` root. Must be a single path-safe segment. |
+| `access` | The default read access for `packages:` entries that don't set their own. Defaults to `$all`. |
+| `packages` | The registry's namespace and per-package rules — see [above](#the-packages-map). Only these names can be served from or published to this registry. |
 
-Two hosted mounts cannot share an `org` namespace — that's rejected at config
-load. Publishes routed to a hosted mount land in its namespace; an unauthorized
-read of a private hosted mount returns 404 (not 403), so it doesn't leak which
-packages exist.
+Two hosted registries cannot share an `org` namespace — that's rejected at
+config load.
 
-### Upstream mounts
+The shape of a denial depends on who denied it. A caller that the
+registry-level `access:` default also denies is masked with a `404` — a
+blanket-private registry never confirms which package names exist. A caller
+denied by an explicit `packages:` entry while the default would admit them is
+rejected loudly (`401` for anonymous callers, `403` for authenticated ones),
+so clients can prompt for credentials.
 
-An upstream mount is one external origin — one URL, one credential, one cache
-namespace. It is either `public` (fetched anonymously, no credential, readable
-by anyone) or private (carries a server-owned credential and an `access:`
-policy naming who may use it):
+### Upstream registries
+
+An upstream registry is one external origin — one URL, one credential, one
+cache namespace. It is either `public` (fetched anonymously, no credential)
+or private (carries a server-owned credential and an `access:` policy naming
+who may use it):
 
 ```yaml
-mounts:
+registries:
   npmjs:
     type: upstream
     url: https://registry.npmjs.org/
@@ -129,120 +179,94 @@ mounts:
       type: bearer
       token_env: CORP_NPM_TOKEN
     access: $authenticated
+    packages:
+      '@corp/*': {}
 ```
 
 | Key | Description |
 | --- | --- |
 | `url` | Upstream registry URL. |
-| `public` | Marks an anonymous, world-readable origin (e.g. the public npm registry). A public mount sends no credential and no custom headers; declaring `auth`, `access`, or `headers` alongside `public: true` is a config error. |
+| `public` | Marks an anonymous, world-readable origin (e.g. the public npm registry). A public upstream sends no credential and no custom headers; declaring `auth`, `access`, or `headers` alongside `public: true` is a config error. |
 | `auth` | Server-owned credential for a private origin. `type` is `bearer` or `basic`; provide `token`, or `token_env: true` to read `NPM_TOKEN`, or `token_env: NAME` to read a named environment variable. |
 | `headers` | Extra request headers to send upstream. If `headers.Authorization` is set, it overrides the `auth`-derived header. |
-| `access` | Which pnpr users may reach this mount at `/~<mount>/` (and resolve through it). Required for a non-`public` upstream. |
-| `maxage` | Per-mount packument freshness window. Overrides pnpr's global packument TTL / `--packument-ttl-secs` for this mount. |
+| `access` | Which pnpr users may reach this registry at `/~<name>/` (and resolve through it). Required for a non-`public` upstream. |
+| `packages` | The names this upstream serves through pnpr — see [above](#the-packages-map). |
+| `maxage` | Per-registry packument freshness window. Overrides pnpr's global packument TTL / `--packument-ttl-secs` for this registry. |
 | `timeout` | Per-request upstream deadline. Defaults to `30s`. |
 | `max_fails` | Consecutive failures before the upstream circuit breaker opens. Defaults to `2`; `0` disables the breaker. |
 | `fail_timeout` | Cooldown before an open circuit is probed again. Defaults to `5m`. |
-| `cache` | Whether tarballs fetched from this mount are cached locally. Defaults to `true`; `false` streams verified tarballs through a temporary file. |
+| `cache` | Whether tarballs fetched from this registry are cached locally. Defaults to `true`; `false` streams verified tarballs through a temporary file. |
 
 Interval values accept strings such as `30s`, `5m`, `1h30m`, or a bare number
 of seconds.
 
-A private upstream mount is more than a proxy: it is a **pnpr-managed
-credential** for that origin. One upstream token, held by the server, is fanned
-out to a whole team through the mount's `access:` policy — clients authenticate
-to pnpr with their own tokens and never see the upstream credential. pnpr never
-forwards a client's credentials upstream, and the server-owned credential is
-only ever attached over the upstream's own scheme (an `https://` mount's token
-is never sent over plain `http://`).
+Two upstream-specific rules apply to the `packages:` map. Per-package `access`
+values are allowed even on a `public: true` upstream — `public` describes the
+*fetch* (anonymous, credential-free), while a rule's `access` gates who may
+read the name *through pnpr*. And `publish`/`unpublish` values are rejected on
+any upstream: no write can land there.
 
-Each mount gets its own cache namespace: a `public` upstream uses a stable,
-secret-free namespace shared across restarts, while a private mount's cache is
-keyed by an HMAC of the mount and its credential — so rotating the upstream
-token automatically moves to a fresh namespace, and a private mount's content
-can never be served on a public path or through another mount.
+A private upstream registry is more than a proxy: it is a **pnpr-managed
+credential** for that origin. One upstream token, held by the server, is
+fanned out to a whole team through the registry's `access:` policy — clients
+authenticate to pnpr with their own tokens and never see the upstream
+credential. Declaring a `packages:` namespace on a private upstream also
+bounds what that credential can be used for: a caller can't pull arbitrary
+public names through it. pnpr never forwards a client's credentials upstream,
+and the server-owned credential is only ever attached over the upstream's own
+scheme (an `https://` registry's token is never sent over plain `http://`).
 
-### Router mounts
+Each upstream gets its own cache namespace: a `public` upstream uses a stable,
+secret-free namespace shared across restarts, while a private upstream's cache
+is keyed by an HMAC of the registry and its credential — so rotating the
+upstream token automatically moves to a fresh namespace, and a private
+registry's content can never be served on a public path or through another
+registry.
 
-A router maps package-name patterns to concrete source mounts. Routes are
-evaluated in declared order and the **first matching route is authoritative**
-— later routes are never consulted:
+### Routers
+
+A router is an ordered `sources:` list of concrete registries. A package
+resolves to the **first listed source whose `packages:` keys claim its name**,
+authoritatively — later sources are never consulted, and a name that no source
+claims is a definitive 404:
 
 ```yaml
-mounts:
+registries:
   main:
     type: router
-    routes:
-      - patterns: ['@mycompany/*']
-        source: private
-      - patterns: ['@partner/sdk']
-        source: corp
-      - patterns: ['**']
-        source: npmjs
+    sources: [private, corp, npmjs]
 ```
 
-The pattern language is deliberately small so that route coverage can be
-checked statically:
+A source with no `packages:` map claims every name — the catch-all — and must
+be listed last. A router can order competing claims, but it can never assign a
+name to a registry that doesn't claim it: the namespace lives on the concrete
+registry, and is enforced there on every path.
 
-| Pattern | Matches |
-| --- | --- |
-| `**` | Every package name. |
-| `@*/*` | Every scoped package, any scope. |
-| `@scope/*` | Every package in one scope. |
-| `foo`, `@scope/foo` | Exactly that package. |
-
-Any other wildcard is a config error rather than a silently-never-matching
-literal.
-
-Because route order is load-bearing — a misordered router is the one way a
+Because source order is load-bearing — a misordered router is the one way a
 mistake could send a private scope to a public origin — pnpr **refuses to
 start** (and fails a config reload) on an invalid router:
 
-- a route that is fully shadowed by earlier routes (including a `**` catch-all
-  that isn't last);
-- a single pattern already covered by an earlier route's pattern;
-- a duplicate pattern;
-- a source that is undefined, the router itself, or another router (routes
-  must target a hosted or upstream mount — no nesting, no cycles);
-- a router or route with no patterns.
-
-## `packages`
-
-`packages:` is a pure **access-control layer** — routing a package to its
-origin is the mount graph's job. Rules are matched top to bottom by glob; the
-first matching rule wins. Each entry can set `access`, `publish`, and
-`unpublish`, and the rule is enforced on every mount-served read and write,
-hosted or upstream:
-
-```yaml
-packages:
-  '@mycompany/*':
-    access: $authenticated
-    publish: $authenticated
-    unpublish: $authenticated
-
-  '**':
-    access: $all
-    publish: $authenticated
-```
-
-Common access values are `$all` (anyone), `$authenticated` (logged-in users),
-and `$anonymous`; a list can also name users and [groups](#groups).
-
-When a key is omitted, `access` defaults to `$all`, `publish` defaults to
-`$authenticated`, and `unpublish` defaults to nobody.
+- a source that is unreachable — everything it claims is already covered by
+  earlier sources (including a catch-all that isn't last);
+- two sources claiming an identical pattern (genuinely ambiguous provenance,
+  rejected in either order);
+- a duplicate source;
+- a source that is undefined, the router itself, or another router (sources
+  must be hosted or upstream registries — no nesting, no cycles);
+- a router with no sources.
 
 ## `groups`
 
 Static group/team memberships. Every access list accepts group names anywhere
-it accepts usernames — the per-package `packages:` rules and the mount-level
-`access:` lists alike:
+it accepts usernames — the per-package `packages:` rules and the
+registry-level `access:` lists alike:
 
 ```yaml
 groups:
   platform: alice bob
   frontend: [carol, dave]
 
-mounts:
+registries:
   corp:
     type: upstream
     url: https://npm.corp.example.com/
@@ -284,33 +308,40 @@ secret: ${PNPR_SECRET}
 ```
 
 The HMAC key for pnpr's private cache namespaces — private resolution-cache
-entries and private per-mount cache directories are keyed with it, so on-disk
-paths reveal neither mount names nor credentials. It must be at least 16 bytes.
-When omitted, a fresh random secret is generated per process, which means
-private cache entries only survive for that process's lifetime — set an
-explicit secret to keep private caches warm across restarts.
+entries and private per-registry cache directories are keyed with it, so
+on-disk paths reveal neither registry names nor credentials. It must be at
+least 16 bytes. When omitted, a fresh random secret is generated per process,
+which means private cache entries only survive for that process's lifetime —
+set an explicit secret to keep private caches warm across restarts.
 
-## `registry` and `resolver`
+## The registry surface and `resolver`
 
-pnpr exposes two configurable HTTP surfaces:
+pnpr exposes two HTTP surfaces:
+
+- The **npm registry surface** — packument and tarball reads, publish,
+  unpublish, dist-tags, and search, on the path-less base and on every
+  `/~<name>/` endpoint. It has no config toggle: it is served exactly when at
+  least one registry is declared under `registries:`. The CLI flag
+  `--disable-registry` turns it off for one process.
+- The **resolver surface** — the pnpr install-accelerator routes
+  (`GET /-/pnpr`, `POST /-/pnpr/v0/resolve`, and
+  `POST /-/pnpr/v0/verify-lockfile`):
 
 ```yaml
-registry:
-  enabled: true
-
 resolver:
   enabled: true
 ```
 
-- **`registry`** mounts the npm-compatible registry routes: packument and
-  tarball reads, publish, unpublish, dist-tags, search, and login/token
-  endpoints — on the path-less base and on every `/~<mount>/` endpoint.
-- **`resolver`** mounts the pnpr install-accelerator routes:
-  `GET /-/pnpr`, `POST /-/pnpr/v0/resolve`, and
-  `POST /-/pnpr/v0/verify-lockfile`.
+The resolver is enabled by default; the CLI flag `--disable-resolver`
+overrides the setting.
 
-Both are enabled by default. At least one must stay enabled. The CLI flags
-`--disable-registry` and `--disable-resolver` override these settings.
+Something must be served: a config with no registries (or the registry
+surface disabled by flag) and the resolver disabled is a startup error.
+
+The health endpoint (`/-/ping`) and the account endpoints (login, whoami, and
+token management) are always served, whichever surfaces are enabled — so
+`pnpm login` works even against a resolver-only server. See
+[HTTP endpoints](endpoints.md).
 
 ## `routes`
 

--- a/pnpr-docs/endpoints.md
+++ b/pnpr-docs/endpoints.md
@@ -3,16 +3,18 @@ id: endpoints
 title: HTTP endpoints
 ---
 
-pnpr exposes one always-on health endpoint plus two configurable surfaces:
+pnpr exposes a set of always-on endpoints (health, user accounts, and tokens)
+plus two surfaces:
 
-- **Registry surface** (`registry.enabled`) - npm-compatible package, auth, and
-  publish endpoints.
+- **Registry surface** - npm-compatible package and publish endpoints. Served
+  exactly when at least one registry is declared under
+  [`registries:`](configuration.md#registries-and-defaultregistry);
+  `--disable-registry` turns it off for one process.
 - **Resolver surface** (`resolver.enabled`) - pnpr install-accelerator
   endpoints under `/-/pnpr`.
 
-Both surfaces are enabled by default. See
-[Configuration](configuration.md#registry-and-resolver) for the config keys and
-[CLI reference](cli.md) for the command-line overrides.
+See [Configuration](configuration.md#the-registry-surface-and-resolver) for
+the config keys and [CLI reference](cli.md) for the command-line overrides.
 
 ## Always available
 
@@ -20,34 +22,44 @@ Both surfaces are enabled by default. See
 | --- | --- | --- |
 | `GET` | `/-/ping` | Health check. Returns `{}`. |
 
-## Registry bases: `/` and `/~<mount>/`
+The [user and token endpoints](#user-and-token-endpoints) below are also
+always available, whichever surfaces are enabled.
 
-Every [registry mount](configuration.md#mounts-and-defaulttarget) is served as
-a full npm registry at `/~<mount>/` — packument and tarball reads, version
+## Registry bases: `/` and `/~<name>/`
+
+Every [registry](configuration.md#registries-and-defaultregistry) is served as
+a full npm registry at `/~<name>/` — packument and tarball reads, version
 manifests, dist-tags, search, publish, unpublish, and the login/whoami
-endpoints all work under a mount prefix. The `~` prefix keeps mount names out
-of the package-name namespace (a package name can never begin with `~`).
+endpoints all work under a registry prefix. The `~` prefix keeps registry
+names out of the package-name namespace (a package name can never begin with
+`~`).
 
-The path-less base (`/`) aliases the mount named by `defaultTarget`; with no
-`defaultTarget` configured, the bare host serves no registry and only the
-`/~<mount>/` bases answer.
+The path-less base (`/`) aliases the registry named by `defaultRegistry`; with
+no `defaultRegistry` configured, the bare host serves no registry and only the
+`/~<name>/` bases answer.
 
-Every request routes through the mount graph:
+Every request routes through the registry graph:
 
-- A request to a **router** mount is answered by the first route whose pattern
-  matches the package. A router that matches no route is a definitive `404` —
-  there is no fall-through to another origin. A matched source that is
-  unavailable is an error, never a `404`.
-- **Writes** (publish, dist-tags, unpublish) must resolve to a hosted mount; a
-  write that routes to an upstream mount is rejected.
-- The matching `packages:` rule's ACL is enforced on every mount-served read
+- A request to a **router** is answered by the first listed source whose
+  declared [`packages:`](configuration.md#the-packages-map) claim the name. A
+  name that no source claims is a definitive `404` — there is no fall-through
+  to another origin. A matched source that is unavailable is an error, never a
+  `404`.
+- A registry's declared namespace is enforced **on every path to it**: a read
+  of a name outside the namespace is a definitive `404` answered before
+  storage or the upstream is consulted — through a router, on the path-less
+  base, and at the registry's own `/~<name>/` URL alike — and an off-namespace
+  publish is rejected.
+- **Writes** (publish, dist-tags, unpublish) must resolve to a hosted
+  registry; a write that routes to an upstream is rejected.
+- The serving registry's matching `packages:` rule is enforced on every read
   and write.
 - Served `dist.tarball` URLs are rewritten onto the configured `public_url`
   and stay canonical for the base the client addressed (path-less or
-  `/~<mount>/`), so lockfiles don't bake in a mount name.
+  `/~<name>/`), so lockfiles don't bake in a registry name.
 
 The endpoint tables below show path-less shapes; each is equally available
-under a `/~<mount>/` prefix.
+under a `/~<name>/` prefix.
 
 ## Resolver endpoints
 
@@ -70,7 +82,7 @@ The resolver endpoints are mounted when `resolver.enabled` is true. The
 Every registry the request would make pnpr fetch from — the `registry` and
 `namedRegistries` origins, plus any direct `http(s)`/`git` URL in a dependency
 spec, an override, or an input-lockfile tarball — must be on the server's fetch
-allowlist (the configured mounts, declared public routes, the built-in npm
+allowlist (the configured registries, declared public routes, the built-in npm
 registry, and pnpr's own origin). An off-allowlist origin is rejected up front,
 before any server-side fetch. Upstream credentials are never taken from the
 client: pnpr selects its own server-owned credential per route (see
@@ -88,8 +100,9 @@ The `resolve` response is an NDJSON stream:
 
 ## Registry read endpoints
 
-These endpoints are mounted when `registry.enabled` is true. Package reads are
-checked against the matching package rule's `access` list.
+These endpoints are mounted when the registry surface is served. Package reads
+are checked against the serving registry's matching
+[`packages:`](configuration.md#the-packages-map) rule.
 
 | Method | Path | Description |
 | --- | --- | --- |
@@ -111,11 +124,11 @@ denied.
 
 ## Registry write endpoints
 
-These endpoints are mounted when `registry.enabled` is true. `PUT` and
+These endpoints are mounted when the registry surface is served. `PUT` and
 `DELETE` requests require credentials. A read-only bearer token cannot use
 write methods, and CIDR-restricted bearer tokens are checked against the peer
-socket address. Every write routes through the mount graph and must land on a
-hosted mount.
+socket address. Every write routes through the registry graph and must land on
+a hosted registry.
 
 | Method | Path | Description |
 | --- | --- | --- |
@@ -131,9 +144,10 @@ hosted mount.
 
 ## User and token endpoints
 
-These endpoints are mounted when `registry.enabled` is true. They are global —
-served identically on the path-less base and under any `/~<mount>/` prefix, so
-`pnpm login` against a mount URL works.
+These endpoints are **always mounted**, whichever surfaces are enabled, and
+they are global — served identically on the path-less base and under any
+`/~<name>/` prefix. `pnpm login` therefore works against any pnpr URL,
+including a resolver-only server that exposes no registry surface.
 
 | Method | Path | Description |
 | --- | --- | --- |

--- a/pnpr-docs/install-acceleration.md
+++ b/pnpr-docs/install-acceleration.md
@@ -69,7 +69,7 @@ See [pnpm/pnpm#12230](https://github.com/pnpm/pnpm/issues/12230) and
 
 The resolver only fetches from origins the operator has configured — a
 **default-deny allowlist** made of the configured
-[mounts](configuration.md#mounts-and-defaulttarget), the declared
+[registries](configuration.md#registries-and-defaultregistry), the declared
 [public routes](configuration.md#routes), the built-in official npm registry,
 and pnpr's own origin. A request whose `registry`/`namedRegistries` — or whose
 direct `http(s)`/`git` URL dependencies, overrides, or lockfile tarball URLs —
@@ -81,7 +81,7 @@ resolver to make the server fetch from an arbitrary internal address.
 
 Clients never forward their upstream registry credentials to pnpr. Instead, a
 private registry is configured server-side as an
-[upstream mount](configuration.md#upstream-mounts) with a server-owned
+[upstream registry](configuration.md#upstream-registries) with a server-owned
 credential and an `access:` policy naming which pnpr users may resolve through
 it. The caller authenticates to pnpr with their own pnpr token; pnpr selects
 its own credential for each upstream fetch. One upstream token, held only by
@@ -91,16 +91,16 @@ Tarball URLs in the resolved lockfile follow the same split:
 
 - A **public** package keeps its upstream URL — the client fetches it directly
   from the registry or its CDN, never through pnpr.
-- A **private** package resolved through an access-bearing upstream mount is
-  emitted as that mount's `/~<mount>/` registry endpoint URL, so the client
-  fetches it back through pnpr (which enforces the mount's access policy and
-  serves it from a per-mount private cache).
+- A **private** package resolved through an access-bearing upstream registry
+  is emitted as that registry's `/~<name>/` endpoint URL, so the client
+  fetches it back through pnpr (which enforces the registry's access policy
+  and serves it from a per-registry private cache).
 
-Because a mount endpoint URL is canonical for a client whose registry
+Because a registry endpoint URL is canonical for a client whose registry
 configuration points at it, lockfile entries stay integrity-only — the
 registry host lives in the client's `.npmrc`, not in the lockfile — and a
 project resolves to the same lockfile whether it installs through `/resolve`
-or directly against the registry.
+or directly against the registry endpoint.
 
 The resolution cache is **authorization-aware**: a resolution that touched
 only public routes is cached once and shared by every caller, while a
@@ -119,6 +119,8 @@ pnprServer: http://127.0.0.1:7677
 
 pnpm will offload resolution to that server during `pnpm install`. The resolver
 `POST` endpoints require a valid pnpr `Authorization` header. pnpm forwards the
-auth configured for the `pnprServer` URL; if the same pnpr server is also your
-registry, a normal `pnpm login --registry <server-url>` writes the token pnpm
-uses for both registry and resolver requests.
+auth configured for the `pnprServer` URL, and a normal
+`pnpm login --registry <server-url>` writes the token pnpm uses for both
+registry and resolver requests. The login and token endpoints are always
+served, so this works even against a resolver-only pnpr server that exposes no
+registry surface.

--- a/pnpr-docs/introduction.md
+++ b/pnpr-docs/introduction.md
@@ -10,10 +10,11 @@ it. It hosts your own packages and proxies upstream registries such as
 `registry.npmjs.org`, with its own authentication and access controls — roughly
 the role [verdaccio](https://verdaccio.org/) plays in the JavaScript ecosystem.
 
-Every registry origin pnpr serves is declared as a
-[registry mount](configuration.md#mounts-and-defaulttarget), and a router maps
-each package name to exactly one origin — there is no cross-origin
-fall-through, which closes dependency-confusion attacks by construction.
+Every registry origin pnpr serves is a declared
+[registry](configuration.md#registries-and-defaultregistry) that claims the
+package names it serves, and a router resolves each package name to exactly
+one origin — there is no cross-origin fall-through, which closes
+dependency-confusion attacks by construction.
 
 pnpr lives in the [pnpm monorepo](https://github.com/pnpm/pnpm) under
 [`pnpr/`](https://github.com/pnpm/pnpm/tree/main/pnpr).

--- a/pnpr-docs/quick-start.md
+++ b/pnpr-docs/quick-start.md
@@ -5,10 +5,11 @@ title: Quick start
 
 ## Write a config
 
-pnpr routes packages through [registry mounts](configuration.md#mounts-and-defaulttarget):
-every origin — a locally-hosted registry, an upstream like npmjs — is declared
-explicitly, and a router maps package names to exactly one of them. Save this
-as `pnpr.yaml`:
+pnpr routes packages through declared
+[registries](configuration.md#registries-and-defaultregistry): every origin —
+a locally-hosted registry, an upstream like npmjs — is declared explicitly and
+claims the package names it serves, and a router resolves each name to exactly
+one of them. Save this as `pnpr.yaml`:
 
 ```yaml
 storage: ./storage
@@ -19,34 +20,36 @@ auth:
     # Allow one user to self-register, for the publish step below.
     max_users: 1
 
-mounts:
-  # Packages published to this server.
+registries:
+  # Packages published to this server. The `packages:` map is this
+  # registry's namespace: only these names can live here.
   local:
     type: hosted
+    packages:
+      '@mycompany/*':
+        publish: $authenticated
 
-  # The public npm registry.
+  # The public npm registry. No `packages:` map — it serves every name,
+  # so it must be the last source in the router below.
   npmjs:
     type: upstream
     url: https://registry.npmjs.org/
     public: true
 
-  # Route your scope to the local registry, everything else to npm.
+  # A package resolves to the first source that claims its name:
+  # your scope goes to the local registry, everything else to npm.
   main:
     type: router
-    routes:
-      - patterns: ['@mycompany/*']
-        source: local
-      - patterns: ['**']
-        source: npmjs
+    sources: [local, npmjs]
 
 # The bare server URL serves the router.
-defaultTarget: main
+defaultRegistry: main
 ```
 
 Replace `@mycompany` with your own scope. There is no fall-through between
-mounts: a `@mycompany/*` package that isn't published locally is a definitive
-404, never a request to npmjs — which is exactly what closes dependency
-confusion.
+registries: a `@mycompany/*` package that isn't published locally is a
+definitive 404, never a request to npmjs — which is exactly what closes
+dependency confusion.
 
 ## Start the server
 
@@ -69,9 +72,9 @@ pnpm config set registry http://127.0.0.1:7677/
 Now `pnpm install` fetches packages through pnpr. Packages proxied from the
 upstream are cached, so subsequent installs are served locally.
 
-Each mount is also directly addressable as a registry at
-`http://127.0.0.1:7677/~<mount>/` — for example, you can point just your scope
-at the hosted mount instead of using the router.
+Each registry is also directly addressable at
+`http://127.0.0.1:7677/~<name>/` — for example, you can point just your scope
+at the hosted registry instead of using the router.
 
 ## Publish a package
 
@@ -82,13 +85,14 @@ pnpm login --registry http://127.0.0.1:7677/
 pnpm publish --registry http://127.0.0.1:7677/
 ```
 
-The publish routes through the router to the `local` hosted mount — publishing
-a package that routes to an upstream mount is rejected.
+The publish routes through the router to the `local` hosted registry —
+publishing a package that resolves to an upstream, or whose name no registry
+claims, is rejected.
 
 ## Where to go next
 
 - [CLI reference](cli.md) — every flag `pnpr` accepts.
-- [Configuration](configuration.md) — write your own config: mounts, access
-  rules, and auth.
+- [Configuration](configuration.md) — write your own config: registries,
+  access rules, and auth.
 - [Install acceleration](install-acceleration.md) — let pnpr resolve your
   dependency graph to speed up installs.

--- a/pnpr-docs/storage.md
+++ b/pnpr-docs/storage.md
@@ -61,9 +61,12 @@ s3:
   region: auto
   endpoint: https://abc123def456.r2.cloudflarestorage.com
 
-mounts:
+registries:
   local:
     type: hosted
+    packages:
+      '@mycompany/*':
+        publish: $authenticated
 
   npmjs:
     type: upstream
@@ -72,13 +75,9 @@ mounts:
 
   main:
     type: router
-    routes:
-      - patterns: ['@mycompany/*']
-        source: local
-      - patterns: ['**']
-        source: npmjs
+    sources: [local, npmjs]
 
-defaultTarget: main
+defaultRegistry: main
 ```
 
 ```sh


### PR DESCRIPTION
Updates the pnpr docs for the redesigned configuration model shipped in pnpm/pnpm#12773, pnpm/pnpm#12778, and pnpm/pnpm#12787. pnpr is pre-1.0, so the docs describe the new design outright — no mention of the old keys and no migration notes.

- **`configuration.md`** — `mounts:`/`defaultTarget:` → `registries:`/`defaultRegistry:` throughout. New *The `packages` map* section: keys are the registry's declared namespace (same four-shape pattern language), values are per-package `access`/`publish`/`unpublish` rules, the most specific matching key wins and key order carries no meaning. Routers are documented as ordered `sources:` lists (first source whose packages claim the name wins; a map-less catch-all must be last) with the updated validation matrix. Hosted registries document the tiered denial shapes (404 mask vs loud 401/403); upstreams document the two map rules (per-package `access` allowed on `public: true`, write rules rejected). The top-level `packages:` ACL section and the `registry:` toggle are gone, replaced by *The registry surface and `resolver`*: the npm-registry surface is served iff at least one registry is declared, `--disable-registry` overrides per process, and a nothing-to-serve config is a startup error.
- **`endpoints.md`** — registry-surface gating described as derived from `registries:`; the user/token endpoints are documented as always mounted on every tier (so `pnpm login` works against a resolver-only server); routing bullets updated for `sources:` dispatch and namespace enforcement on every path.
- **`quick-start.md`**, **`storage.md`** — example configs rewritten to the new shape.
- **`cli.md`** — `--disable-registry` reworded.
- **`install-acceleration.md`** — terminology/anchors updated; notes that login works even against a resolver-only server.
- **`introduction.md`** — overview sentence updated.

Verified: the site builds cleanly and every new cross-reference anchor exists in the generated HTML; the `'@corp/*': {}` example shape matches the pnpr config test suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup, configuration, and endpoint docs to use the new registry-based terminology and examples.
  * Clarified which endpoints are always available, which depend on registry/resolver settings, and how login/token access behaves.
  * Expanded guidance on package routing, private registries, and publish/read rules, including clearer behavior for undeclared packages and namespace handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->