### PR TITLE
Add details about `pnpm store prune` removing pnpm versions

### DIFF
--- a/docs/cli/self-update.md
+++ b/docs/cli/self-update.md
@@ -30,6 +30,8 @@ When the project's `package.json` has a `packageManager` field set to pnpm (or a
 
 If the project does not pin pnpm, or the pin is being ignored via [`pmOnFail: ignore`](../settings.md#pmonfail), `self-update` installs the resolved pnpm version globally and links it to `PNPM_HOME` so it becomes the active pnpm binary on your system.
 
+Running [`pnpm store prune`](./store.md#prune) removes previously installed versions (outside of a 5-minute safety window), keeping only the one currently in use.
+
 ## Installing pnpm v12 (the Rust port)
 
 Since v11.10.0, `pnpm self-update` (and `packageManager` version-switching) can install and link **pnpm v12**, the Rust port. It is published under both the `pnpm` and `@pnpm/exe` names on the `next-12` dist-tag:

--- a/docs/cli/self-update.md
+++ b/docs/cli/self-update.md
@@ -30,7 +30,7 @@ When the project's `package.json` has a `packageManager` field set to pnpm (or a
 
 If the project does not pin pnpm, or the pin is being ignored via [`pmOnFail: ignore`](../settings.md#pmonfail), `self-update` installs the resolved pnpm version globally and links it to `PNPM_HOME` so it becomes the active pnpm binary on your system.
 
-Running [`pnpm store prune`](./store.md#prune) removes previously installed versions (outside of a 5-minute safety window), keeping only the one currently in use.
+Running [`pnpm store prune`](./store.md#prune) removes previously installed global versions once they are no longer linked (after a newer install replaces them) while keeping the version currently in use. Install directories created within a 5-minute safety window are skipped.
 
 ## Installing pnpm v12 (the Rust port)
 

--- a/docs/cli/store.md
+++ b/docs/cli/store.md
@@ -47,7 +47,9 @@ briefly slowing down the installation process.
 
 After pruning, pnpm displays the total size of removed files.
 
-When the [global virtual store] is enabled, `pnpm store prune` also performs mark-and-sweep garbage collection on the global virtual store's `links/` directory. Projects using the store are registered via symlinks in `{storeDir}/v11/projects/`, allowing pnpm to track active usage and safely remove unused packages from the global virtual store.
+When the [global virtual store] is enabled, `pnpm store prune` also performs mark-and-sweep garbage collection on the global virtual store's `links/` directory. Projects using the store are registered via symlinks in `{storeDir}/v11/projects/`, allowing pnpm to track active usage and safely remove unused packages from the global virtual store. If no projects are registered, this step is skipped and nothing in `links/` is removed.
+
+The global virtual store is also where pnpm caches the alternate pnpm versions it downloads when switching to the version pinned in a project's `packageManager`/`devEngines.packageManager` field, or when running [`pnpm with`](./with.md). These cached versions live under `links/` and are never referenced from a project's `node_modules`. The mark-and-sweep therefore always treats them as unreferenced, so **`pnpm store prune` removes every cached pnpm version** from the global virtual store (if at least one project is registered). Any removed version is re-downloaded automatically the next time a project requests it.
 
 [global virtual store]: ../settings.md#enableglobalvirtualstore
 

--- a/docs/cli/with.md
+++ b/docs/cli/with.md
@@ -13,6 +13,8 @@ pnpm with <version|current> <args...>
 
 The downloaded pnpm is installed using the same mechanism as [`pnpm self-update`](./self-update.md) and cached in the global virtual store for reuse on subsequent runs.
 
+These cached versions live in the store's `links/` directory and are not referenced by any project, so [`pnpm store prune`](./store.md#prune) removes them. Any removed version is re-downloaded automatically the next time a project requests it.
+
 ## Examples
 
 Run the globally installed pnpm, ignoring the version pinned in the manifest:


### PR DESCRIPTION
`pnpm store prune` removes all installed pnpm versions except the one currently in use.

Fixes https://github.com/pnpm/pnpm/issues/12836


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that `pnpm self-update` outside a project (or when the pnpm pin is ignored) now includes `pnpm store prune`, removing older pnpm versions except for a brief safety window.
  * Expanded `pnpm store prune` to explain global virtual store garbage collection and that unreferenced cached pnpm versions are removed and will be re-downloaded when needed.
  * Updated `pnpm with` docs to describe where cached reusable pnpm versions are stored, how `pnpm store prune` affects them, and re-download behavior on next use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->