### PR TITLE
docs: remove references to doctor command

### DIFF
--- a/docs/cli/doctor.md
+++ b/docs/cli/doctor.md
@@ -1,6 +1,0 @@
----
-id: doctor
-title: "pnpm doctor"
----
-
-Checks for known common issues with pnpm configuration.

--- a/sidebars.json
+++ b/sidebars.json
@@ -118,7 +118,6 @@
           "cli/setup",
           "cli/init",
           "cli/deploy",
-          "cli/doctor",
           "cli/pm",
           "cli/pkg",
           "cli/repo",


### PR DESCRIPTION
The `pnpm doctor` was removed in version `11.0.0` but it's still documented. 

https://github.com/pnpm/pnpm/issues/12172 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the `pnpm doctor` command documentation.
  * Removed the `pnpm doctor` entry from the CLI documentation navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->