### PR TITLE
fix: correct Zoltan Kochan's X handle URL

### DIFF
--- a/blog/authors.yml
+++ b/blog/authors.yml
@@ -1,7 +1,7 @@
 zkochan:
   name: Zoltan Kochan
   title: Lead maintainer of pnpm
-  url: https://x.com/ZoltanKochan
+  url: https://x.com/zkochan
   image_url: "https://pbs.twimg.com/profile_images/2005604765028245504/SudRBVMH_400x400.jpg"
   socials:
     x: zkochan


### PR DESCRIPTION
The author URL for Zoltan Kochan pointed to `https://x.com/ZoltanKochan`, but the correct handle is `zkochan` (matching the `socials.x` field just below it). Updated the URL for consistency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the author’s social media profile link to the correct lowercase address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->