### PR TITLE
Add /.well-known/security.txt (RFC 9116)

### DIFF
--- a/static/.well-known/security.txt
+++ b/static/.well-known/security.txt
@@ -1,0 +1,5 @@
+Contact: https://github.com/pnpm/pnpm/security/advisories/new
+Expires: 2027-07-14T00:00:00.000Z
+Preferred-Languages: en
+Canonical: https://pnpm.io/.well-known/security.txt
+Policy: https://github.com/pnpm/pnpm/blob/main/SECURITY.md


### PR DESCRIPTION
## What
Add `/.well-known/security.txt` so the site serves one at the location [RFC 9116](https://www.rfc-editor.org/rfc/rfc9116) defines.

## Why
https://pnpm.io/.well-known/security.txt currently returns **404**. RFC 9116 makes `/.well-known/security.txt` the standard, machine-discoverable place a security researcher (or automated tooling) looks first to learn how to report an issue. The file is added under the site's static directory (served verbatim), points `Contact` at the project's GitHub Security Advisory intake, and carries a future `Expires` per §2.5.5.

I used AI assistance to help identify this and draft the file; I verified the RFC reference and the live 404 myself and take responsibility for it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a standard security disclosure file with contact details, supported language information, validity dates, and links to security resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->