### PR TITLE
docs: document pnpm 11.11 through 11.14

### DIFF
--- a/blog/releases/11.11-11.14.md
+++ b/blog/releases/11.11-11.14.md
@@ -1,0 +1,147 @@
+---
+title: pnpm 11.11-11.14
+authors: zkochan
+tags: [release]
+date: 2026-07-18
+---
+
+pnpm 11.11 through 11.14 add native workspace release management (`pnpm change`, `pnpm lane`, and a bare `pnpm version -r`), a `pnpm doctor` command that diagnoses your installation end to end, the `pnpm access` and `pnpm team` commands for managing packages and organizations on the registry, convergence overrides, and scheme-carrying `peerDependencies` specifiers. They also fix a path-traversal vulnerability, cut peak memory during cold-cache resolution by roughly 30%, and resolve a peer dependency deadlock.
+
+<!-- truncate -->
+
+## Minor Changes
+
+### Native workspace release management
+
+pnpm can now version and release a workspace on its own, without a separate release tool ([#12952](https://github.com/pnpm/pnpm/issues/12952)). The new [`pnpm change`](/cli/change) command records **change intents** — changesets-compatible `.changeset/*.md` files naming the affected packages, their bump types, and a summary that becomes the changelog entry:
+
+```sh
+pnpm change
+pnpm change status   # show the pending release plan
+```
+
+At release time, the bare `pnpm version -r` consumes them, bumping versions across the workspace with dependent propagation through `workspace:` ranges, writing changelogs, and recording what it consumed in a committed ledger (`.changeset/ledger.yaml`) that keeps cherry-picks and merge-backs between release branches safe.
+
+Packages can be moved onto per-package **release lanes** with [`pnpm lane`](/cli/lane), releasing `X.Y.Z-lane.N` prereleases from the same runs that release stable versions of everything else:
+
+```sh
+pnpm lane alpha --filter @example/cli   # move onto a lane
+pnpm lane main --filter @example/cli    # graduate back to stable
+```
+
+Configuration lives under the new `versioning` key of `pnpm-workspace.yaml` — `fixed`, `ignore`, `maxBump`, `lanes`, `epics`, and `changelog`. Release changelogs default to `registry` storage: no `CHANGELOG.md` is committed, and each release's section is composed at publish time and packed into the published tarball. Set `versioning.changelog.storage: repository` to keep committed changelog files instead.
+
+11.13 also added [`versioning.epics`](/settings#versioningepics), which ties a group of member packages to a lead package, constraining every member's major version to a band derived from the lead's: while the lead is on major `M`, members live in `M*100` … `M*100+99`. When a release plan takes the lead to a new stable major, every member re-bases to the band floor in the same plan.
+
+See [Release management](/versioning) for the whole workflow.
+
+### `pnpm doctor`
+
+The new [`pnpm doctor`](/cli/doctor) command diagnoses the pnpm installation and the environment it runs in: the versions and install method, whether the global bin directory is on `PATH`, whether the store and cache are writable, which link strategies (reflink, hardlink, symlink) the store's filesystem supports, registry connectivity, and an offline `file:` install that exercises the resolve/store/link path end to end.
+
+```
+✓ Versions: pnpm 11.14.0, Node.js 22.20.0
+✓ Install method: pnpm
+✓ Global bin directory: /Users/example/Library/pnpm/bin
+✓ Cache directory: /Users/example/Library/Caches/pnpm
+✓ Store directory: /Users/example/Library/pnpm/store/v10
+✓ Filesystem: available: reflink, hardlink, symlink
+✓ Registry connectivity: https://registry.npmjs.org/ (128ms)
+✓ Install smoke test: offline "file:" install linked its dependency
+
+All checks passed
+```
+
+Each check reports how to fix what it finds, and the command exits non-zero when any check fails. Use `--offline` to skip the checks that need network access, `--json` for machine-readable output, and `--benchmark` to time the filesystem and install checks.
+
+### `pnpm access` and `pnpm team`
+
+[`pnpm access`](/cli/access) manages package access and visibility on the registry — listing packages and collaborators, getting and setting package status and MFA requirements, and granting or revoking team access:
+
+```sh
+pnpm access list packages @myorg
+pnpm access set status=public @myorg/pkg
+pnpm access grant read-write @myorg:developers @myorg/pkg
+```
+
+[`pnpm team`](/cli/team) manages organization teams and memberships, with `create`, `destroy`, `add`, `rm`, and `ls` subcommands:
+
+```sh
+pnpm team create @myorg:developers
+pnpm team add @myorg:developers alice
+pnpm team ls @myorg
+```
+
+### Convergence overrides
+
+A new [override selector form with an empty range](/settings#convergence-overrides) — `"pkg@": "<version>"` — rewrites a dependency edge only when its exact version satisfies the edge's declared range, so compatible consumers converge on one version while incompatible consumers keep their own resolution, now and for any dependent added in the future ([#12794](https://github.com/pnpm/pnpm/issues/12794)):
+
+```yaml
+overrides:
+  "form-data@": 4.0.6
+```
+
+The value must be an exact version. When a full resolution detects that every declared range also admits a newer version, pnpm warns that the override is stale and names the version to converge on. Previously an empty range in an override selector was undocumented and behaved like a bare (unscoped) override.
+
+### `peerDependencies` accept scheme-carrying specifiers
+
+[`peerDependencies`](/package_json#peerdependencies) now accept dependency specifiers that carry a scheme — a named-registry spec (`<registry>:<version>`), an `npm:` alias, or a `file:`/git/URL spec — instead of rejecting them with `ERR_PNPM_INVALID_PEER_DEPENDENCY_SPECIFICATION` ([#13095](https://github.com/pnpm/pnpm/issues/13095)). Such a peer is matched against the semver range carried by the specifier (`work:5.x.x` is checked as `5.x.x`, `npm:bar@^5` as `^5`), or against `*` when it carries no version, while the original specifier still selects the package to auto-install. Bare `name@version` values, which are almost always a mistake, are still rejected.
+
+### RegExp script selectors and `--sequential` for `pnpm run`
+
+[`pnpm run`](/cli/run#running-multiple-scripts) again supports executing multiple scripts matching a RegExp (e.g. `pnpm run "/^build:.*/"`), now running matched scripts in deterministic lexicographical order. The `--sequential` (`-s`) option is restored as well, forcing `workspaceConcurrency` to 1 so matched scripts run one by one across and within packages.
+
+### Portable delegation for custom fetchers
+
+Custom fetchers exported from a pnpmfile can now [delegate by returning a `{ delegate: <resolution> }` envelope](/pnpmfile#delegating-to-the-built-in-fetchers): pnpm rewrites the package's resolution to the delegated shape and runs the built-in fetcher on it. This is the portable delegation form that also works in pacquet, where `cafs` and `fetchers` cannot be passed to the hook.
+
+### Other minor changes
+
+- [`allowBuilds`](/settings#allowbuilds) entries for git-hosted packages can now match by repository URL without pinning the resolved commit hash, so trusted git repositories keep running their build scripts after branch updates without approving each new commit. Package-name-only rules still do not approve git-hosted artifacts.
+- [`registries`](/settings#registries) and [`namedRegistries`](/settings#namedregistries) can now be configured in the global `config.yaml` file.
+
+## Security
+
+- Fixed a path traversal vulnerability where a dependency whose manifest `name` was a scoped path traversal (e.g. `@x/../../../<path>`) could be written outside `node_modules` to an attacker-controlled location during `pnpm install`, even with `--ignore-scripts`.
+- Prevented a crafted `pnpm-lock.yaml` from writing package content outside the virtual store. Dependency path keys that reconstruct to a path-traversal sequence are now rejected by the isolated linker and the Plug'n'Play resolver map, and traversals in the version-derived path segment are rejected under the global virtual store.
+- Updated `adm-zip` to prevent crafted ZIP archives from causing excessive memory allocation.
+- `${...}` environment-variable placeholders in the `httpProxy`, `httpsProxy`, `noProxy`, `proxy`, and `noproxy` settings are no longer expanded when these settings come from a project's `pnpm-workspace.yaml`.
+- `pnpm publish` no longer prints credentials when the target registry is configured with inline `user:pass@` credentials.
+- `pnpm runtime set <name> <version>` now validates its arguments, so an unsupported name or a comma can no longer be misread as a list of packages.
+- Broken-lockfile errors no longer include snippets of the lockfile's contents.
+- Rejected symlinked `pnpm-lock.yaml` files when reading or writing the env lockfile document.
+- `pnpm self-update` now honors `trustPolicy=no-downgrade`, and checks that the version it installed can run before making it the active pnpm.
+
+## Patch Changes
+
+- Reduced peak memory usage during cold-cache dependency resolution by roughly 30%, back in line with pnpm 10. The memoized metadata cache no longer retains each package's raw registry response body for the whole resolution phase.
+- Fixed an out-of-memory regression when workspace projects concurrently resolve a package with large registry metadata ([#13077](https://github.com/pnpm/pnpm/issues/13077)).
+- Fixed a deadlock in peer dependency resolution: `pnpm install` hung forever when a peer dependency cycle spanned a project's own dependencies and auto-installed peer providers, for example when installing `electron-builder@26.15.3` ([#12921](https://github.com/pnpm/pnpm/issues/12921)).
+- Fixed peer dependency auto-install picking a version the peer range rejects. Peers are now deduplicated onto the highest preferred version that satisfies the declared range, and when none does, the range is resolved from the registry.
+- Fixed peer dependency resolution with `autoInstallPeers` when a workspace package depends on a version of a package that a transitive dependency's self-contained closure also provides for itself ([#4993](https://github.com/pnpm/pnpm/issues/4993)).
+- Fixed `pnpm install` failing with `ERR_PNPM_LOCKFILE_IS_SYMLINK` when `pnpm-lock.yaml` is a symlink, as build sandboxes such as Bazel and Nix stage it ([#13073](https://github.com/pnpm/pnpm/issues/13073)). An install that leaves the lockfile unchanged no longer rewrites it, so `--frozen-lockfile` no longer needs to write at all.
+- Fixed frozen installs incorrectly treating equivalent Git dependency specifiers as a stale lockfile ([#13039](https://github.com/pnpm/pnpm/issues/13039)).
+- Fixed `pnpm update` rewriting exact version pins that use the `=` operator (for example `=3.5.1`) to a caret range.
+- Fixed `pnpm update` removing transitive lockfile entries when `dedupePeerDependents` is disabled and the selected package is absent ([#12456](https://github.com/pnpm/pnpm/issues/12456)).
+- Failed instead of silently removing an optional dependency's locked entries from `pnpm-lock.yaml` when the registry cannot resolve it ([#12853](https://github.com/pnpm/pnpm/issues/12853)).
+- Retried package metadata requests when a registry or proxy returns `304 Not Modified` to an unconditional request, and recovered from a metadata cache entry that disappears after a `304` ([#12882](https://github.com/pnpm/pnpm/issues/12882)).
+- Fixed the dependency status check wrongly reporting "up to date" when a `package.json`, `.pnpmfile.cjs`, or patch file was edited in the same second as the previous install, on filesystems that record mtimes at whole-second resolution.
+- `pnpm deploy` now supports workspaces that use catalogs, and local `file:` tarball dependencies keep their package name in the generated deploy lockfile.
+- `pnpm pack` now respects workspace-root `.npmignore` and `.gitignore` files, and no longer applies workspace-root ignore rules when a workspace package has its own `.npmignore`.
+- `pnpm publish` again sends the package's README to the registry as metadata, and `--otp` is now sent correctly for both `pnpm publish --otp` and `pnpm publish --batch --otp`.
+- `pnpm outdated` no longer checks the registry for dependencies resolved from local `link:`, `file:`, or `workspace:` references ([#12827](https://github.com/pnpm/pnpm/issues/12827)).
+- `pnpm list` and `pnpm why` no longer crash with `EMFILE: too many open files` when a project has a large number of unsaved dependencies.
+- `pnpm cache delete` now removes a package's metadata from every metadata cache directory ([#12753](https://github.com/pnpm/pnpm/issues/12753)).
+- Fixed orphaned child processes on Windows when pnpm exits on an error while commands spawned by `pnpm exec` or `pnpm dlx` are still running ([#12406](https://github.com/pnpm/pnpm/issues/12406)).
+- Kept the interactive `minimumReleaseAge` approval prompt visible during `pnpm install`, so the install no longer hangs on a question the user cannot see ([#13019](https://github.com/pnpm/pnpm/issues/13019)).
+- A `tokenHelper` set in the global pnpm `auth.ini` is no longer rejected as project-level configuration, and a helper that hangs is now killed after 60 seconds instead of leaving the command waiting forever.
+- `pnpm add -g`, `pnpm update -g`, `pnpm setup`, and the self-updater no longer fail with `ERR_PNPM_MISSING_TIME` when `trustPolicy: no-downgrade` or `resolutionMode: time-based` is set in the global config ([#12883](https://github.com/pnpm/pnpm/issues/12883)).
+- A project pinned to a broken pnpm release via `packageManager` or `devEngines.packageManager` now reports which release is broken and what to do about it, instead of failing inside the installer.
+- The published `pnpm` package no longer declares `dependencies` or `devDependencies`, so `npm install` of the tarball no longer tries to resolve internal-only packages ([#12955](https://github.com/pnpm/pnpm/issues/12955)).
+- Fixed an injected workspace dependency incorrectly staying as `file:` instead of deduping back to `link:` ([#10433](https://github.com/pnpm/pnpm/issues/10433)).
+- `pnpm owner ls` now reports authentication and authorization failures as dedicated errors that include the registry's response body.
+- Options that follow `create`, `exec`, or `test` appearing as a subcommand of another command are now parsed instead of being silently treated as positional parameters.
+- The changed-packages filter (`--filter "...[<since>]"`) no longer allows an option-like `<since>` value to be interpreted as a git option, and the repository root is resolved to the nearest `.git` entry so the filter works in a git worktree.
+- `verify-deps-before-run` no longer spawns a `pnpm install` when pnpm is executed in a directory that has no `package.json`.
+- `pnpm stage list` now stops paginating after a fail-safe cap of 1000 pages.
+- Registered the `pn` alias in generated shell completion scripts, and fixed standalone installer downgrades from pnpm v12 to v11.

--- a/docs/cli/access.md
+++ b/docs/cli/access.md
@@ -1,0 +1,106 @@
+---
+id: access
+title: pnpm access
+---
+
+Added in: v11.11.0
+
+Manages package access and visibility on the registry.
+
+```sh
+pnpm access list packages [<user>|<scope>|<scope:team>]
+pnpm access list collaborators <package> [<user>]
+pnpm access get status <package>
+pnpm access set status=public|private <package>
+pnpm access set mfa=none|publish|automation <package>
+pnpm access grant <read-only|read-write> <scope:team> <package>
+pnpm access revoke <scope:team> <package>
+```
+
+## Subcommands
+
+### list packages
+
+List the packages a user, scope, or team can access. With no argument, your own packages are listed.
+
+```sh
+pnpm access list packages
+pnpm access list packages alice
+pnpm access list packages @myorg
+pnpm access list packages @myorg:developers
+```
+
+The argument type is inferred from its shape: a value containing `:` is a team, a value starting with `@` is an organization, and anything else is a user.
+
+`ls` is accepted as an alias, so `pnpm access ls` is equivalent to `pnpm access list packages`.
+
+### list collaborators
+
+List the collaborators on a package, optionally filtered to a single user.
+
+```sh
+pnpm access list collaborators @myorg/pkg
+pnpm access list collaborators @myorg/pkg alice
+```
+
+### get status
+
+Show whether a package is public or restricted.
+
+```sh
+pnpm access get status @myorg/pkg
+```
+
+### set status
+
+Set the package visibility.
+
+```sh
+pnpm access set status=public @myorg/pkg
+pnpm access set status=private @myorg/pkg
+```
+
+Only scoped packages can change visibility. Unscoped packages are always public, and attempting to change one fails with `ERR_PNPM_ACCESS_SET_STATUS_UNSCOPED`.
+
+### set mfa
+
+Set the two-factor authentication requirement for publishing a package.
+
+```sh
+pnpm access set mfa=none @myorg/pkg
+pnpm access set mfa=publish @myorg/pkg
+pnpm access set mfa=automation @myorg/pkg
+```
+
+`none` disables the requirement, while `publish` and `automation` both require two-factor authentication for publishing.
+
+### grant
+
+Grant a team read-only or read-write access to a package.
+
+```sh
+pnpm access grant read-only @myorg:developers @myorg/pkg
+pnpm access grant read-write @myorg:developers @myorg/pkg
+```
+
+### revoke
+
+Revoke a team's access to a package.
+
+```sh
+pnpm access revoke @myorg:developers @myorg/pkg
+```
+
+## Options
+
+### --registry &lt;url\&gt;
+
+The base URL of the npm registry to use for the operation. Per-scope and named registries (configured via [`registries`](../settings.md#registries) and [`namedRegistries`](../settings.md#namedregistries)) are respected for the package being modified.
+
+### --json
+
+Output results in JSON format. Applies to `list packages`, `list collaborators`, and `get status`.
+
+### --otp &lt;code\&gt;
+
+When the registry requires two-factor authentication, this option supplies a one-time password. It applies to the subcommands that modify state: `set status`, `set mfa`, `grant`, and `revoke`.

--- a/docs/cli/change.md
+++ b/docs/cli/change.md
@@ -1,0 +1,91 @@
+---
+id: change
+title: pnpm change
+---
+
+Added in: v11.13.0
+
+Records a change intent: which packages a change affects, the bump type for each, and a summary that becomes the changelog entry. The intent file is written to `.changeset/` in the [changesets](https://github.com/changesets/changesets) format.
+
+```sh
+pnpm change [--bump <type>] [--summary <text>] [<pkg>...]
+pnpm change status
+```
+
+Change intents are consumed later by [`pnpm version -r`](./version.md#recursive-releases). See [Release management](../versioning.md) for the whole workflow.
+
+## Usage
+
+Run without arguments to record an intent interactively:
+
+```sh
+pnpm change
+```
+
+You are asked three questions:
+
+1. **Which packages does this change affect?** Packages changed since the merge base with `main` (or `master`) are preselected.
+2. **Which packages should have a major bump?**, then the same for `minor`. Anything left over is bumped as `patch`.
+3. **Summary of the change**, which becomes the changelog entry.
+
+The result is a file such as `.changeset/calm-cats-resolve.md`:
+
+```markdown
+---
+"@example/core": minor
+"@example/cli": patch
+---
+
+Added a `--watch` flag to the build command.
+```
+
+Commit this file along with your change.
+
+Passing package names together with `--bump` and `--summary` records an intent without prompting, which is useful in scripts:
+
+```sh
+pnpm change --bump patch --summary "Fixed a crash on empty input" @example/core
+```
+
+## Subcommands
+
+### status
+
+Show the pending change intents and the release plan they produce.
+
+```sh
+pnpm change status
+```
+
+```
+Pending change intents:
+  .changeset/calm-cats-resolve.md
+
+Release plan:
+  @example/core: 1.2.0 → 1.3.0 (minor, via intent)
+  @example/cli: 0.4.1 → 0.4.2 (patch, via intent+dependencies)
+```
+
+The cause of each bump is one of `intent` (a change intent named the package), `dependencies` (a dependent was pulled in by propagation), `fixed` (a [fixed group](../versioning.md#fixed-groups) companion), or `epic` (an [epic](../versioning.md#epics) re-base).
+
+## Options
+
+### --bump &lt;type\&gt;
+
+The bump type for the named packages: `none`, `patch`, `minor`, or `major`. `none` records an explicit decline — the change needs no release.
+
+### --summary &lt;text\&gt;
+
+The summary for the changelog entry. Together with package names, this runs the command non-interactively.
+
+## Referencing packages by directory
+
+When two workspace projects publish the same name, a package can be referenced by its workspace-relative directory instead, with a `./` prefix:
+
+```markdown
+---
+"./packages/cli": minor
+---
+```
+
+This is the one additive extension pnpm makes to the changesets format. `pnpm change` writes it automatically when a name is ambiguous.

--- a/docs/cli/doctor.md
+++ b/docs/cli/doctor.md
@@ -1,0 +1,94 @@
+---
+id: doctor
+title: pnpm doctor
+---
+
+Added in: v11.14.0
+
+Runs diagnostics on the pnpm installation and the environment it runs in.
+
+```sh
+pnpm doctor [--offline] [--benchmark] [--json]
+```
+
+Each check reports how to fix what it finds, and the command exits with a non-zero code when any check fails. Warnings do not fail the command.
+
+```
+✓ Versions: pnpm 11.14.0, Node.js 22.20.0
+✓ Install method: pnpm
+✓ Global bin directory: /Users/example/Library/pnpm/bin
+✓ Cache directory: /Users/example/Library/Caches/pnpm
+✓ Store directory: /Users/example/Library/pnpm/store/v10
+✓ Filesystem: available: reflink, hardlink, symlink
+✓ Registry connectivity: https://registry.npmjs.org/ (128ms)
+✓ Install smoke test: offline "file:" install linked its dependency
+
+All checks passed
+```
+
+## Checks
+
+### Versions
+
+Reports the running pnpm and Node.js versions.
+
+### Install method
+
+Reports how pnpm was installed — as the `pnpm` package or the `@pnpm/exe` standalone build — and warns when pnpm is being run by Corepack, which manages the pnpm version itself and makes `pnpm self-update` unavailable.
+
+### Global bin directory
+
+Checks that the directory pnpm links global executables into is on `PATH` and writable. If it is missing from `PATH`, the fix is to run [`pnpm setup`](./setup.md).
+
+### Cache directory
+
+Checks that the [cache directory](../settings.md#cachedir) is writable.
+
+### Store directory
+
+Checks that the [store directory](../settings.md#storedir) is writable. Skipped when no store directory is configured.
+
+### Filesystem
+
+Probes which link strategies work from the store's volume: reflink (copy-on-write), hardlink, and symlink. This is what determines how packages land in `node_modules` and how fast an install is — a reflink or hardlink is near-free, a plain copy is not.
+
+If neither reflink nor hardlink works, the check warns that installs will fall back to copying, and suggests putting the store on the same filesystem as your projects.
+
+### Registry connectivity
+
+Pings the configured registry with a 15-second timeout and reports the round-trip time. Fails if the registry cannot be reached or answers with an error status, which usually points at network, proxy, or auth configuration.
+
+Skipped with `--offline`.
+
+### Install smoke test
+
+Installs a throwaway package as a `file:` dependency, entirely offline, in a temporary directory. This exercises the resolve, store, and link path end to end and confirms the running binary can actually perform an install.
+
+This check is always offline by construction, so `--offline` does not skip it.
+
+## Options
+
+### --offline
+
+Skip the checks that need network access.
+
+### --benchmark
+
+Also time the filesystem and install checks, reporting the duration alongside each result.
+
+### --json
+
+Report the results as JSON. The output is an object with a single `checks` array, each entry having `title`, `status` (`pass`, `warn`, or `fail`), and optionally `detail`, `fix`, and `durationMs`.
+
+```json
+{
+  "checks": [
+    {
+      "title": "Filesystem",
+      "status": "pass",
+      "detail": "available: reflink, hardlink, symlink",
+      "durationMs": 3
+    }
+  ]
+}
+```

--- a/docs/cli/lane.md
+++ b/docs/cli/lane.md
@@ -1,0 +1,72 @@
+---
+id: lane
+title: pnpm lane
+---
+
+Added in: v11.13.0
+
+Manages per-package release lanes. A lane is a parallel release track: while a package is on one, the bare [`pnpm version -r`](./version.md#recursive-releases) releases it as `X.Y.Z-<lane>.N` prereleases while the rest of the workspace keeps releasing stable versions. Moving a package back to the main lane releases its accumulated stable version on the next run.
+
+```sh
+pnpm lane
+pnpm lane <name> --filter <pattern>
+pnpm lane main --filter <pattern>
+```
+
+Membership lives under the [`versioning.lanes`](../settings.md#versioninglanes) key of `pnpm-workspace.yaml`; this command is a convenience editor for that key.
+
+## Usage
+
+### Show lane membership
+
+```sh
+pnpm lane
+```
+
+```
+Lanes:
+  alpha:
+    @example/cli
+    @example/napi
+```
+
+If no package has been assigned a lane, this prints `All packages are on the main lane.`
+
+### Move packages onto a lane
+
+```sh
+pnpm lane alpha --filter @example/cli
+```
+
+`--filter` is required — it selects the packages to move. Lane names may contain only alphanumerics and hyphens, and cannot be purely numeric.
+
+### Move packages back to the main lane
+
+```sh
+pnpm lane main --filter @example/cli
+```
+
+`main` is the reserved name of the default lane. Every package is on it unless assigned elsewhere, and packages on it release stable versions. Graduating a package releases the stable version its prereleases were building toward on the next `pnpm version -r` run.
+
+## Versions on a lane
+
+A package on a lane releases `X.Y.Z-<lane>.N`, where `X.Y.Z` is the stable version the lane is building toward and `N` counts up from `0`:
+
+| Current version | Pending intent | Lane | New version |
+| --- | --- | --- | --- |
+| `2.0.0` | minor | `alpha` | `2.1.0-alpha.0` |
+| `2.1.0-alpha.0` | patch | `alpha` | `2.1.0-alpha.1` |
+| `2.1.0-alpha.1` | major | `alpha` | `3.0.0-alpha.0` |
+| `3.0.0-alpha.0` | — | `main` | `3.0.0` |
+
+`N` restarts at `0` whenever the stable target changes. When a bump escalates the target — a `major` intent while the lane was building a minor — the target is recomputed and the counter resets.
+
+Packages in the same [fixed group](../versioning.md#fixed-groups) must move between lanes together.
+
+## Options
+
+### --filter &lt;package_selector\&gt;
+
+Select the packages to move between lanes. Required when assigning a lane.
+
+[Read more about filtering.](../filtering.md)

--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -37,6 +37,14 @@ Run all scripts that start with `watch:`:
 pnpm run "/^watch:.*/"
 ```
 
+The selector must be written as a regular expression literal — that is, wrapped in slashes — and quoted, so the shell does not mangle it. A plain string is always treated as a literal script name, and a script whose name matches the argument exactly takes precedence over regex matching.
+
+Matching is not anchored, so `"/build:.*/"` also matches `prebuild:web`. Anchor the pattern with `^` and `$` when you need an exact prefix.
+
+Matched scripts run in lexicographical order, so the selection is deterministic regardless of the order the scripts appear in `package.json`. To run them strictly one at a time, add [`--sequential`](#--sequential--s).
+
+Regular expression flags are not supported: `pnpm run "/^build:.*/i"` fails with `ERR_PNPM_UNSUPPORTED_SCRIPT_COMMAND_FORMAT`.
+
 ## Details
 
 In addition to the shell’s pre-existing `PATH`, `pnpm run` includes
@@ -112,6 +120,24 @@ Completely disregard concurrency and topological sorting, running a given script
 immediately in all matching packages with prefixed streaming output. This is the
 preferred flag for long-running processes over many packages, for instance, a
 lengthy build process.
+
+### --sequential, -s
+
+Added in: v11.14.0
+
+Run the selected scripts one by one. This forces [`--workspace-concurrency`](./recursive.md#--workspace-concurrency) to `1`, so scripts matched by a [regex selector](#running-multiple-scripts) never overlap — neither across workspace packages nor within a single package.
+
+```sh
+pnpm run --sequential "/^build:.*/"
+```
+
+In a recursive run this serializes scripts across workspace projects as well as within each one. `--sequential` takes precedence over `--parallel`: concurrency is pinned to `1` whenever it is set, regardless of the order the two flags appear in.
+
+:::note
+
+For `pnpm run`, `-s` is the shorthand for `--sequential`. Everywhere else in the CLI, `-s` remains the shorthand for `--reporter=silent`. The long form `--silent` is unaffected in all commands.
+
+:::
 
 ### --stream
 

--- a/docs/cli/team.md
+++ b/docs/cli/team.md
@@ -1,0 +1,81 @@
+---
+id: team
+title: pnpm team
+---
+
+Added in: v11.13.0
+
+Manages organization teams and team memberships on the registry.
+
+```sh
+pnpm team create <scope:team> [--otp <code>]
+pnpm team destroy <scope:team> [--otp <code>]
+pnpm team add <scope:team> <user> [--otp <code>]
+pnpm team rm <scope:team> <user> [--otp <code>]
+pnpm team ls <scope|scope:team>
+```
+
+Team references are always written with a leading `@`: `@myorg` for an organization and `@myorg:developers` for a team within it.
+
+## Subcommands
+
+### create
+
+Create a new team in an organization.
+
+```sh
+pnpm team create @myorg:developers
+```
+
+### destroy
+
+Destroy an existing team.
+
+```sh
+pnpm team destroy @myorg:developers
+```
+
+### add
+
+Add a user to an existing team.
+
+```sh
+pnpm team add @myorg:developers alice
+```
+
+### rm
+
+Remove a user from an existing team.
+
+```sh
+pnpm team rm @myorg:developers alice
+```
+
+### ls
+
+List the teams in an organization, or the members of a team.
+
+```sh
+pnpm team ls @myorg
+pnpm team ls @myorg:developers
+```
+
+Aliases: `list`. If no subcommand is given and the first argument looks like a scope or team, `ls` is assumed, so `pnpm team @myorg` is equivalent to `pnpm team ls @myorg`.
+
+## Options
+
+### --registry &lt;url\&gt;
+
+The base URL of the npm registry to use for the operation. A registry configured for the organization's scope (via [`registries`](../settings.md#registries)) is respected.
+
+### --otp &lt;code\&gt;
+
+When the registry requires two-factor authentication, this option supplies a one-time password. It applies to `create`, `destroy`, `add`, and `rm`.
+
+### --parseable
+
+Print the results of `ls` as bare names, one per line, without headers or indentation.
+
+### --json
+
+Print the results of `ls` as a JSON array of names. Takes precedence over `--parseable`.

--- a/docs/cli/version.md
+++ b/docs/cli/version.md
@@ -10,6 +10,7 @@ Bump the package version.
 ```sh
 pnpm version <newversion>
 pnpm version <major|minor|patch|premajor|preminor|prepatch|prerelease|from-git>
+pnpm version -r [--dry-run]
 ```
 
 `<newversion>` can be any of the bump types above or an explicit semver version (e.g. `1.2.3`). Workspaces and the `workspace:` protocol are supported, so cross-references between workspace packages are updated correctly.
@@ -25,6 +26,28 @@ pnpm version major
 pnpm version 2.0.0
 pnpm version prerelease --preid beta
 ```
+
+## Recursive releases
+
+Added in: v11.13.0
+
+Run with `-r` and **no version argument** to consume the pending change intents recorded by [`pnpm change`](./change.md):
+
+```sh
+pnpm version -r
+```
+
+This assembles a release plan from the `.changeset/*.md` intent files and applies it: every package named by an intent is bumped, and so is every package that depends on it through a `workspace:` range. It then writes changelogs and records the consumed intents in `.changeset/ledger.yaml`.
+
+Preview the plan without touching anything:
+
+```sh
+pnpm version -r --dry-run
+```
+
+Narrow it to part of the workspace with `--filter`. The selection is expanded until it settles, so fixed-group companions and dependents whose ranges the bump invalidates are pulled in automatically.
+
+The working tree must be clean unless `--dry-run` or `--no-git-checks` is passed. See [Release management](../versioning.md) for the full workflow.
 
 ## Options
 

--- a/docs/package_json.md
+++ b/docs/package_json.md
@@ -203,6 +203,37 @@ With these changes, we say that `button` is an "injected dependency" of `card` a
 
 Because injected dependencies produce copies of their workspace source directory, these copies must be updated somehow whenever the code is modified; otherwise, the new state will not be reflected for consumers. When building multiple projects with a command such as `pnpm --recursive run build`, this update must occur after each injected package is rebuilt but before its consumers are rebuilt. For simple use cases, it can be accomplished by invoking `pnpm install` again, perhaps using a `package.json` lifecycle script such as `"prepare": "pnpm run build"` to rebuild that one project.  Third party tools such as [pnpm-sync](https://www.npmjs.com/package/pnpm-sync-lib) and [pnpm-sync-dependencies-meta-injected](https://www.npmjs.com/package/pnpm-sync-dependencies-meta-injected) provide a more robust and efficient solution for updating injected dependencies, as well as watch mode support.
 
+## peerDependencies
+
+Peer dependency values are normally semver ranges (`^1.0.0`), or a [`workspace:`](./workspaces.md#workspace-protocol-workspace) or [`catalog:`](./catalogs.md) specifier.
+
+Since v11.14.0, a peer dependency may also be declared with a specifier that carries a scheme:
+
+```json
+{
+  "peerDependencies": {
+    "lib-a": "work:5.x.x",
+    "lib-b": "npm:other-lib@^5",
+    "lib-c": "file:../lib-c",
+    "lib-d": "git+https://example.com/lib-d.git"
+  }
+}
+```
+
+Accepted forms are a [named-registry](./settings.md#namedregistries) spec (`<registry>:<version>`), an `npm:` alias, and a `file:`, git, or URL spec.
+
+Such a specifier is matched against the semver range it carries — `work:5.x.x` is checked as `5.x.x` and `npm:other-lib@^5` as `^5`. A specifier that carries no version, such as `file:../lib-c`, is matched against `*`, so any version satisfies it. Meanwhile the original specifier is what selects the package when [`autoInstallPeers`](./settings.md#autoinstallpeers) installs a missing peer, so the peer is fetched from the aliased name, registry, or source you named.
+
+Bare `name@version` values are still rejected with `ERR_PNPM_INVALID_PEER_DEPENDENCY_SPECIFICATION`, as they are almost always a mistake:
+
+```json
+{
+  "peerDependencies": {
+    "lib-a": "lib-a@1.2.3"
+  }
+}
+```
+
 ## peerDependenciesMeta
 
 This field lists some extra information related to the dependencies listed in

--- a/docs/pnpmfile.md
+++ b/docs/pnpmfile.md
@@ -344,7 +344,7 @@ Determines whether this fetcher can fetch a package with the given resolution.
 
 **Returns:** `true` if this fetcher can handle fetching this package, `false` otherwise.
 
-##### `fetch(cafs, resolution, opts, fetchers): FetchResult | Promise<FetchResult>`
+##### `fetch(cafs, resolution, opts, fetchers): FetchResult | CustomFetcherDelegation | Promise<FetchResult | CustomFetcherDelegation>`
 
 Fetches package files and returns metadata about the fetched package.
 
@@ -363,15 +363,43 @@ Fetches package files and returns metadata about the fetched package.
   - `directory` - Fetcher for local directories
   - `git` - Fetcher for git repositories
 
-**Returns:** Object with:
+**Returns:** either a fetch result, or a [delegation envelope](#delegating-to-the-built-in-fetchers).
+
+A fetch result is an object with:
 - `filesIndex` - Map of relative file paths to their physical locations. For remote packages, these are paths in pnpm's content-addressable store (CAFS). For local packages (when `local: true`), these are absolute paths to files on disk.
 - `manifest` - Optional. The package.json from the fetched package. If not provided, pnpm will read it from disk when needed. Providing it avoids an extra file I/O operation and is recommended when you have the manifest data readily available (e.g., already parsed during fetch).
 - `requiresBuild` - Boolean indicating whether the package has build scripts that need to be executed. Set to `true` if the package has `preinstall`, `install`, or `postinstall` scripts, or contains `binding.gyp` or `.hooks/` files. Standard fetchers determine this automatically using the manifest and file list.
 - `local` - Optional. Set to `true` to load the package directly from disk without copying to pnpm's store. When `true`, `filesIndex` should contain absolute paths to files on disk, and pnpm will hardlink them to `node_modules` instead of copying. This is how the directory fetcher handles local dependencies (e.g., `file:../my-package`).
 
-:::tip Delegating to Standard Fetchers
+#### Delegating to the built-in fetchers
 
-Custom fetchers can delegate to pnpm's built-in fetchers using the `fetchers` parameter.
+Added in: v11.12.0
+
+Rather than fetching the package itself, a custom fetcher may hand the work back to pnpm. There are two ways to do this.
+
+**Return a `{ delegate }` envelope.** Instead of a fetch result, return an object with a single `delegate` key holding the resolution pnpm should fetch instead. pnpm rewrites the package's resolution to that shape and runs its built-in fetch path on it:
+
+```js title=".pnpmfile.cjs"
+const customFetcher = {
+  canFetch: (pkgId, resolution) => resolution.type === 'custom:url',
+  fetch: (cafs, resolution) => ({
+    delegate: {
+      tarball: resolution.customUrl,
+      integrity: resolution.integrity,
+    },
+  }),
+}
+
+module.exports = { fetchers: [customFetcher] }
+```
+
+The delegated resolution must be a complete, fetchable shape (for example `{ tarball, integrity }`). Delegation is single-step: a `delegate` that is itself custom-typed is rejected.
+
+**Call `fetchers.*` directly.** The `fetchers` argument gives you pnpm's standard fetchers, so you can transform the resolution and invoke one yourself.
+
+:::tip Prefer the envelope for portability
+
+The `{ delegate }` envelope is the only delegation form that works in both pnpm and [pacquet](https://github.com/pnpm/pnpm/tree/main/pacquet) (the Rust port of pnpm). pacquet invokes pnpmfile fetchers over IPC, where `cafs` and `fetchers` cannot exist and both arrive as `null`. A fetcher that should run on either stack must return the envelope rather than calling `fetchers.*`.
 
 :::
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -77,6 +77,34 @@ overrides:
 
 This feature is especially useful with `optionalDependencies`, where most optional packages can be safely skipped.
 
+#### Convergence overrides
+
+Added in: v11.13.0
+
+A selector with an **empty range** — `"pkg@"` — is a convergence override. Unlike a regular override, which rewrites every matching edge unconditionally, a convergence override rewrites a dependency edge only when its version satisfies the range that edge declares:
+
+```yaml title="pnpm-workspace.yaml"
+overrides:
+  "form-data@": 4.0.6
+```
+
+With the above, a dependency that declares `form-data: "^4.0.5"` is pinned to `4.0.6`, while one that declares `^3.0.0` keeps its own resolution. This lets compatible consumers converge on a single version — now and for any dependent added in the future — without forcing an incompatible version on the rest of the graph.
+
+Rules:
+
+- The value must be an **exact version**. A range, a dist-tag, or a `-` removal fails with `ERR_PNPM_INVALID_CONVERGENCE_OVERRIDE`. A `catalog:` reference is allowed as long as the catalog entry resolves to an exact version.
+- Only plain semver edges participate. Edges declared with `workspace:`, `catalog:`, `npm:`, a dist-tag, or a git/URL specifier have no meaningful "satisfies" relation and are left untouched.
+- Convergence overrides cannot be combined with a parent selector: `"parent>pkg@"` is rejected.
+- A regular override always wins over a convergence override for the same edge.
+
+When a full resolution finds that every declared range also admits a newer version, pnpm warns that the override is stale and names the version to converge on instead.
+
+:::note
+
+Before v11.13.0, an empty range in an override selector was undocumented and behaved like a bare (unscoped) override.
+
+:::
+
 #### Overriding peer dependencies
 
 Overrides also apply to `peerDependencies`. The behavior depends on the type of version specifier used in the override:
@@ -374,6 +402,8 @@ registries:
   "@internal": https://nexus.corp.com/
 ```
 
+Since v11.11.0, this setting may also be defined in the [global configuration file](./cli/config.md) (`config.yaml`), which is useful for registries that should apply to every project on the machine rather than to a single repository.
+
 ### namedRegistries
 
 Added in: v11.1.0
@@ -394,6 +424,8 @@ namedRegistries:
 The `gh:` alias is built in and points at the [GitHub Packages npm registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-npm-registry) (`https://npm.pkg.github.com/`) by default. Override it under `namedRegistries` for GitHub Enterprise Server.
 
 Authentication is picked up from the existing per-URL `.npmrc` entries (e.g. `//npm.pkg.github.com/:_authToken=...`), so no separate auth mechanism is required.
+
+Since v11.11.0, this setting may also be defined in the [global configuration file](./cli/config.md) (`config.yaml`), so an alias like `work:` can be shared across every project on the machine.
 
 ## Dependency Hoisting Settings
 
@@ -1357,6 +1389,20 @@ allowBuilds:
   nx@21.6.0: false
 ```
 
+**Git-hosted packages:** a package name on its own never approves builds for a git or tarball dependency — the name alone does not identify the artifact. Approve one either by its exact resolved path (including the commit) or, since v11.11.0, by its repository URL:
+
+```yaml
+allowBuilds:
+  # Approves any commit from this repository
+  'foo@git+ssh://git@example.com/org/foo.git': true
+  # Approves only this exact commit
+  'bar@git+https://github.com/org/bar.git#abc123': true
+```
+
+The repository form lets a trusted git dependency keep running its build scripts across branch updates without re-approving each new commit. The key is the package name, followed by `@` and the git URL, with no `#<ref>` suffix. Matching is exact, so `git+ssh://` and `git+https://` URLs for the same repository are separate keys.
+
+Denials by package name are not restricted this way: `foo: false` blocks `foo` whether it comes from the registry or from git.
+
 **Default behavior:** Packages not listed in `allowBuilds` are disallowed by default and are treated as unreviewed. By default, an error is printed ([`strictDepBuilds`](#strictdepbuilds) defaults to `true`). If `strictDepBuilds` is set to `false`, a warning is printed instead.
 
 During install, dependencies with ignored builds that are not yet listed in `allowBuilds` are automatically added to `pnpm-workspace.yaml` with a placeholder value, so you can manually set them to `true` or `false`. The [`--allow-build`](./cli/add.md) flag on `pnpm add` and `pnpm approve-builds` writes its entries here as well.
@@ -1458,6 +1504,106 @@ nodeDownloadMirrors:
   release: https://npmmirror.com/mirrors/node/
   rc: https://npmmirror.com/mirrors/node-rc/
   nightly: https://npmmirror.com/mirrors/node-nightly/
+```
+
+## Versioning Settings
+
+Added in: v11.13.0
+
+These settings configure pnpm's native workspace release management, driven by [`pnpm change`](./cli/change.md) and the bare [`pnpm version -r`](./cli/version.md#recursive-releases). See [Release management](./versioning.md) for the workflow they belong to.
+
+Where two workspace projects publish the same name, a project may be referenced by its `./`-prefixed workspace-relative directory instead of its name in `versioning.fixed`, `versioning.ignore`, and the keys of `versioning.lanes`.
+
+### versioning.fixed
+
+* Default: **[]**
+* Type: **string[][]**
+
+Groups of packages that always release together at one shared version. The shared version is the highest current version in the group, bumped by the largest bump any member needs.
+
+```yaml title="pnpm-workspace.yaml"
+versioning:
+  fixed:
+    - ['@example/cli', '@example/napi']
+```
+
+A fixed group must move between lanes together, and must sit entirely inside or entirely outside an epic.
+
+### versioning.ignore
+
+* Default: **[]**
+* Type: **string[]**
+
+Packages permanently excluded from versioning and dependent propagation. A change intent that requests a real bump for an ignored package fails.
+
+```yaml title="pnpm-workspace.yaml"
+versioning:
+  ignore:
+    - '@example/internal'
+```
+
+### versioning.maxBump
+
+* Default: **undefined** (no cap)
+* Type: **'patch'**, **'minor'**, **'major'**
+
+Caps the bump a release from the current checkout may apply. It is enforced on the final assembled release plan, after dependent propagation and fixed-group resolution, so a patch-only maintenance branch cannot accidentally ship a minor.
+
+```yaml title="pnpm-workspace.yaml"
+versioning:
+  maxBump: patch
+```
+
+### versioning.lanes
+
+* Default: **{}**
+* Type: **Record&lt;string, string&gt;**
+
+Maps a package to the release lane it is on. A lane is a parallel release track that emits `X.Y.Z-<lane>.N` prereleases; every unlisted package is on the reserved default lane, `main`, and releases stable versions.
+
+```yaml title="pnpm-workspace.yaml"
+versioning:
+  lanes:
+    '@example/cli': alpha
+```
+
+Lane names may contain only alphanumerics and hyphens, and cannot be purely numeric. `main` is reserved and cannot be assigned — remove the entry instead, or use [`pnpm lane main --filter <pkg>`](./cli/lane.md).
+
+### versioning.epics
+
+* Default: **[]**
+* Type: **Array&lt;\{ lead: string, packages: string[] \}&gt;**
+
+Ties a group of member packages to a lead package, constraining every member's major version to a band derived from the lead's major: while the lead is on major `M`, members live in `M*100` … `M*100+99`.
+
+```yaml title="pnpm-workspace.yaml"
+versioning:
+  epics:
+    - lead: '@example/app'
+      packages:
+        - './packages/**'
+        - '!./packages/private-*'
+```
+
+`lead` is a package name or a `./`-prefixed workspace directory. `packages` is matched with pnpm's package selectors — name globs, `./`-prefixed directory globs, and `!`-prefixed negations — evaluated in order, last match wins. A package can belong to at most one epic.
+
+See [Epics](./versioning.md#epics) for how the band is enforced and re-based.
+
+### versioning.changelog.storage
+
+* Default: **'registry'**
+* Type: **'registry'**, **'repository'**
+
+Where release changelogs live.
+
+With `registry`, no `CHANGELOG.md` is committed: each release's section is composed at publish time and packed into the published tarball on top of the previously published version's changelog.
+
+With `repository`, a `CHANGELOG.md` is committed in every package.
+
+```yaml title="pnpm-workspace.yaml"
+versioning:
+  changelog:
+    storage: repository
 ```
 
 ## Other Settings

--- a/docs/using-changesets.md
+++ b/docs/using-changesets.md
@@ -3,6 +3,12 @@ id: using-changesets
 title: Using Changesets with pnpm
 ---
 
+:::tip
+
+Since v11.13.0, pnpm can manage workspace releases natively, without the Changesets CLI. It reads and writes the same `.changeset/*.md` files. See [Release management](./versioning.md).
+
+:::
+
 :::note
 
 At the time of writing this documentation, the latest pnpm version was

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,0 +1,118 @@
+---
+id: versioning
+title: Release management
+---
+
+Added in: v11.13.0
+
+pnpm can version and release a workspace on its own, without a separate release tool. The workflow has two halves:
+
+1. As you work, [`pnpm change`](./cli/change.md) records **change intents** — small markdown files in `.changeset/` saying which packages a change affects, how each should be bumped, and a summary that becomes the changelog entry. These are committed alongside the change.
+2. At release time, the bare [`pnpm version -r`](./cli/version.md#recursive-releases) consumes the pending intents: it bumps versions across the workspace, propagates to dependents, writes changelogs, and records what it consumed in a committed ledger.
+
+Intent files use the [changesets](https://github.com/changesets/changesets) format, so an existing `.changeset/` directory keeps working. See [Using Changesets with pnpm](./using-changesets.md) if you would rather keep using the Changesets CLI.
+
+## Recording a change
+
+```sh
+pnpm change
+```
+
+This prompts for the affected packages, their bump types, and a summary, then writes a file like `.changeset/calm-cats-resolve.md`:
+
+```markdown
+---
+"@example/core": minor
+---
+
+Added a `--watch` flag to the build command.
+```
+
+To see what the pending intents would produce:
+
+```sh
+pnpm change status
+```
+
+## Releasing
+
+```sh
+pnpm version -r
+```
+
+This applies the release plan: every package named by an intent is bumped, and so is every package that depends on it through a `workspace:` range. Preview it first with `--dry-run`, and narrow it with `--filter`.
+
+Because a recursive run can bump many packages to different versions, no git commit or tag is created — there is no single version to tag. Commit the result yourself, then publish with `pnpm publish -r`.
+
+## Configuration
+
+Release behavior is configured under the `versioning` key of `pnpm-workspace.yaml`:
+
+```yaml title="pnpm-workspace.yaml"
+versioning:
+  fixed:
+    - ['@example/cli', '@example/napi']
+  ignore:
+    - '@example/internal'
+  maxBump: minor
+  lanes:
+    '@example/cli': alpha
+  changelog:
+    storage: repository
+```
+
+Every key is described in [Versioning Settings](./settings.md#versioning-settings).
+
+Where two workspace projects publish the same name, a project can be referenced by its workspace-relative directory instead of its name, with a `./` prefix (e.g. `"./packages/cli"`). This works in intent files and in `versioning.lanes`, `versioning.fixed`, and `versioning.ignore`.
+
+### Fixed groups
+
+Packages listed together in `versioning.fixed` always release at one shared version — the highest current version in the group, bumped by the largest bump any member needs. A fixed group must move between lanes together, and must sit entirely inside or entirely outside an epic.
+
+### Lanes
+
+A lane is a parallel release track. While a package is on one, it releases `X.Y.Z-<lane>.N` prereleases from the same runs that release stable versions of everything on the main lane. This lets a rewrite or a major-version line bake in public while the rest of the workspace keeps shipping.
+
+```sh
+pnpm lane alpha --filter @example/cli   # move onto the alpha lane
+pnpm lane main --filter @example/cli    # graduate back to stable
+pnpm lane                               # show membership
+```
+
+See [`pnpm lane`](./cli/lane.md) for how the prerelease versions are computed.
+
+### Epics
+
+An epic ties a group of member packages to a lead package, constraining every member's major version to a band derived from the lead's major: while the lead is on major `M`, members live in `M*100` … `M*100+99`.
+
+```yaml title="pnpm-workspace.yaml"
+versioning:
+  epics:
+    - lead: '@example/app'
+      packages:
+        - './packages/**'
+        - '!./packages/private-*'
+```
+
+With the lead on `11.x`, members occupy majors `1100`–`1199`. Members move independently inside the band — patch, minor, and even a `major` intent that stays in-band. A bump that would carry a member past the band ceiling is rejected until the lead advances its own major. When a release plan takes the lead to a new stable major, every member re-bases to the band floor in the same plan.
+
+Membership is matched with pnpm's package selectors: name globs, `./`-prefixed directory globs, and `!`-prefixed negations. Selectors are evaluated in order and the last one to match decides, so a later include can re-admit a package an earlier negation excluded. The lead is never a member of its own band.
+
+## Changelogs
+
+By default (`versioning.changelog.storage: registry`) no `CHANGELOG.md` is committed. Each release's section is composed at publish time and packed into the published tarball on top of the previously published version's changelog. Consumed change intents are garbage-collected by a later `pnpm version -r` only once the registry confirms the version was published with its section.
+
+Set `versioning.changelog.storage: repository` to keep committed `CHANGELOG.md` files in every package instead.
+
+## The ledger
+
+`pnpm version -r` records every consumed intent in `.changeset/ledger.yaml`, a committed, append-only file:
+
+```yaml
+"@example/core@1.3.0":
+  dir: packages/core
+  intents:
+    - calm-cats-resolve
+```
+
+Consumption is tracked per project: an intent file is deleted only once every project it names has released. This is what makes cherry-picks and merge-backs between release branches safe — a release branch that has already consumed an intent will not consume it again when the commit is merged forward, and a package on a lane can half-consume an intent whose prose still has a stable release to compose.

--- a/sidebars.json
+++ b/sidebars.json
@@ -99,7 +99,9 @@
           "cli/whoami",
           "cli/self-update",
           "cli/with",
+          "cli/change",
           "cli/version",
+          "cli/lane",
           "cli/publish",
           "cli/stage",
           "cli/pack",
@@ -108,6 +110,8 @@
           "cli/unpublish",
           "cli/dist-tag",
           "cli/owner",
+          "cli/access",
+          "cli/team",
           "cli/star",
           "cli/ping",
           "cli/recursive",
@@ -118,6 +122,7 @@
           "cli/setup",
           "cli/init",
           "cli/deploy",
+          "cli/doctor",
           "cli/pm",
           "cli/pkg",
           "cli/repo",
@@ -144,7 +149,8 @@
       "git_branch_lockfiles",
       "finders",
       "global-packages",
-      "global-virtual-store"
+      "global-virtual-store",
+      "versioning"
     ],
     "Recipes": [
       "using-changesets",

--- a/sidebars.json
+++ b/sidebars.json
@@ -74,6 +74,35 @@
       },
       {
         "type": "category",
+        "label": "Releasing",
+        "items": [
+          "cli/change",
+          "cli/lane",
+          "cli/version",
+          "cli/publish",
+          "cli/stage",
+          "cli/pack",
+          "cli/dist-tag",
+          "cli/deprecate",
+          "cli/unpublish"
+        ]
+      },
+      {
+        "type": "category",
+        "label": "Registry",
+        "items": [
+          "cli/login",
+          "cli/logout",
+          "cli/whoami",
+          "cli/access",
+          "cli/owner",
+          "cli/team",
+          "cli/star",
+          "cli/ping"
+        ]
+      },
+      {
+        "type": "category",
         "label": "Manage environments",
         "items": [
           "cli/runtime",
@@ -94,26 +123,9 @@
         "type": "category",
         "label": "Misc.",
         "items": [
-          "cli/login",
-          "cli/logout",
-          "cli/whoami",
           "cli/self-update",
           "cli/with",
-          "cli/change",
-          "cli/version",
-          "cli/lane",
-          "cli/publish",
-          "cli/stage",
-          "cli/pack",
           "cli/pack-app",
-          "cli/deprecate",
-          "cli/unpublish",
-          "cli/dist-tag",
-          "cli/owner",
-          "cli/access",
-          "cli/team",
-          "cli/star",
-          "cli/ping",
           "cli/recursive",
           "cli/store",
           "cli/root",

--- a/versioned_sidebars/version-11.x-sidebars.json
+++ b/versioned_sidebars/version-11.x-sidebars.json
@@ -295,7 +295,15 @@
             },
             {
               "type": "doc",
+              "id": "cli/change"
+            },
+            {
+              "type": "doc",
               "id": "cli/version"
+            },
+            {
+              "type": "doc",
+              "id": "cli/lane"
             },
             {
               "type": "doc",
@@ -328,6 +336,14 @@
             {
               "type": "doc",
               "id": "cli/owner"
+            },
+            {
+              "type": "doc",
+              "id": "cli/access"
+            },
+            {
+              "type": "doc",
+              "id": "cli/team"
             },
             {
               "type": "doc",
@@ -468,6 +484,10 @@
         {
           "type": "doc",
           "id": "global-virtual-store"
+        },
+        {
+          "type": "doc",
+          "id": "versioning"
         }
       ]
     },

--- a/versioned_sidebars/version-11.x-sidebars.json
+++ b/versioned_sidebars/version-11.x-sidebars.json
@@ -220,6 +220,88 @@
           ]
         },
         {
+          "collapsed": true,
+          "type": "category",
+          "label": "Releasing",
+          "items": [
+            {
+              "type": "doc",
+              "id": "cli/change"
+            },
+            {
+              "type": "doc",
+              "id": "cli/lane"
+            },
+            {
+              "type": "doc",
+              "id": "cli/version"
+            },
+            {
+              "type": "doc",
+              "id": "cli/publish"
+            },
+            {
+              "type": "doc",
+              "id": "cli/stage"
+            },
+            {
+              "type": "doc",
+              "id": "cli/pack"
+            },
+            {
+              "type": "doc",
+              "id": "cli/dist-tag"
+            },
+            {
+              "type": "doc",
+              "id": "cli/deprecate"
+            },
+            {
+              "type": "doc",
+              "id": "cli/unpublish"
+            }
+          ]
+        },
+        {
+          "collapsed": true,
+          "type": "category",
+          "label": "Registry",
+          "items": [
+            {
+              "type": "doc",
+              "id": "cli/login"
+            },
+            {
+              "type": "doc",
+              "id": "cli/logout"
+            },
+            {
+              "type": "doc",
+              "id": "cli/whoami"
+            },
+            {
+              "type": "doc",
+              "id": "cli/access"
+            },
+            {
+              "type": "doc",
+              "id": "cli/owner"
+            },
+            {
+              "type": "doc",
+              "id": "cli/team"
+            },
+            {
+              "type": "doc",
+              "id": "cli/star"
+            },
+            {
+              "type": "doc",
+              "id": "cli/ping"
+            }
+          ]
+        },
+        {
           "type": "category",
           "label": "Manage environments",
           "items": [
@@ -275,18 +357,6 @@
           "items": [
             {
               "type": "doc",
-              "id": "cli/login"
-            },
-            {
-              "type": "doc",
-              "id": "cli/logout"
-            },
-            {
-              "type": "doc",
-              "id": "cli/whoami"
-            },
-            {
-              "type": "doc",
               "id": "cli/self-update"
             },
             {
@@ -295,63 +365,7 @@
             },
             {
               "type": "doc",
-              "id": "cli/change"
-            },
-            {
-              "type": "doc",
-              "id": "cli/version"
-            },
-            {
-              "type": "doc",
-              "id": "cli/lane"
-            },
-            {
-              "type": "doc",
-              "id": "cli/publish"
-            },
-            {
-              "type": "doc",
-              "id": "cli/stage"
-            },
-            {
-              "type": "doc",
-              "id": "cli/pack"
-            },
-            {
-              "type": "doc",
               "id": "cli/pack-app"
-            },
-            {
-              "type": "doc",
-              "id": "cli/deprecate"
-            },
-            {
-              "type": "doc",
-              "id": "cli/unpublish"
-            },
-            {
-              "type": "doc",
-              "id": "cli/dist-tag"
-            },
-            {
-              "type": "doc",
-              "id": "cli/owner"
-            },
-            {
-              "type": "doc",
-              "id": "cli/access"
-            },
-            {
-              "type": "doc",
-              "id": "cli/team"
-            },
-            {
-              "type": "doc",
-              "id": "cli/star"
-            },
-            {
-              "type": "doc",
-              "id": "cli/ping"
             },
             {
               "type": "doc",
@@ -368,6 +382,10 @@
             {
               "type": "doc",
               "id": "cli/bin"
+            },
+            {
+              "type": "doc",
+              "id": "cli/prefix"
             },
             {
               "type": "doc",


### PR DESCRIPTION
Documents the user-facing changes from pnpm 11.11, 11.12, 11.13 and 11.14.

Each change was verified against the implementation in `pnpm/pnpm` at v11.14.0 (help text, option types, error codes, matching logic) rather than written from the changelog prose alone.

## New pages

| Page | Version |
| --- | --- |
| [`pnpm access`](docs/cli/access.md) | 11.11 |
| [`pnpm team`](docs/cli/team.md) | 11.13 |
| [`pnpm change`](docs/cli/change.md) | 11.13 |
| [`pnpm lane`](docs/cli/lane.md) | 11.13 |
| [`pnpm doctor`](docs/cli/doctor.md) | 11.14 |
| [Release management](docs/versioning.md) | 11.13 |

`versioning.md` is a feature page tying the release-management work together: change intents, dependent propagation, fixed groups, lanes, epics, changelog storage, and the consumed-intents ledger.

## Updated pages

- **`cli/run.md`** — RegExp script selectors (ordering, anchoring, no flags) and the restored `--sequential` / `-s`
- **`cli/version.md`** — the bare `pnpm version -r` form that consumes change intents
- **`settings.md`** — convergence overrides, a new `Versioning Settings` category, `allowBuilds` matching git repositories by URL, and `registries` / `namedRegistries` in the global config
- **`package_json.md`** — a new `peerDependencies` section covering scheme-carrying specifiers
- **`pnpmfile.md`** — the `{ delegate }` envelope for custom fetchers
- **`using-changesets.md`** — pointer to the native release workflow

Plus a combined release blog post for 11.11–11.14, and sidebar entries in both `sidebars.json` and `versioned_sidebars/version-11.x-sidebars.json`.

## Notes

- **`doctor` is restored.** It was removed in #837 because the old v10 command no longer existed; 11.14 adds it back as a full diagnostic command, so the page returns with new content.
- **`-s` changed meaning for `pnpm run` only** — it is now `--sequential` rather than the universal `--reporter=silent`. Called out in a note, since it is a silent behavioral break for existing `pnpm run -s` users.
- `versioned_docs/version-11.x/` is gitignored and regenerated from `docs/` by `copy-docs`, so only the versioned sidebar is touched.

## Verification

`pnpm build` passes. All new pages generate, and the only broken link reported is the pre-existing `/cli/pn` in the 11.0 post. Anchors were checked against the built HTML, since Docusaurus is configured with `onBrokenLinks: "log"` and does not validate anchors.
