### PR TITLE
docs: update pnpr docs for teams, staged publishing, and team endpoints

### DIFF
--- a/pnpr-docs/configuration.md
+++ b/pnpr-docs/configuration.md
@@ -118,11 +118,35 @@ per specificity tier can match a name, so the winning rule is unique and
 reordering the map (by a formatter, or a YAML round-trip) can never change
 which rule applies. A duplicate key is a config error.
 
-Each value can set `access`, `publish`, and `unpublish`. Common values are
-`$all` (anyone), `$authenticated` (logged-in users), and `$anonymous`; a list
-can also name users and [groups](#groups). When a field is omitted, `access`
-falls back to the registry-level `access:` default, `publish` defaults to
-`$authenticated`, and `unpublish` defaults to nobody.
+Each value can set `access`, `publish`, and `unpublish`. When a field is
+omitted, `access` falls back to the registry-level `access:` default, `publish`
+defaults to `$authenticated`, and `unpublish` defaults to nobody.
+
+Every one of those fields takes either a single access token or a YAML list of
+them, and the grammar is deliberately small:
+
+| Token | Admits |
+| --- | --- |
+| `$all` | Anyone, authenticated or not. |
+| `$authenticated` | Any logged-in user. |
+| `$anonymous` | Callers with no credentials. |
+| `team:<name>` | The members of a [team](#teams) declared on this registry. |
+| `alice` | Exactly that username. Any bare token is a username. |
+
+Tokens are validated at config load and every near-miss is rejected loudly,
+rather than being read as a username that happens to admit nobody:
+
+- `$` is reserved for the three built-ins — any other `$token` is an error.
+- `all`, `authenticated`, `anonymous`, and `@`-prefixed spellings like `@all`
+  are errors suggesting the `$` form.
+- `team:` is the only typed prefix; any other `<kind>:` prefix is an error.
+  (htpasswd forbids `:` in usernames, which is what frees the character.)
+- `team:<name>` must resolve to a team the **same registry** declares — an
+  undeclared name is a config error, so a typo can't silently grant to nobody.
+- One entry is one token: an entry containing whitespace is an error, so write
+  `[alice, bob]` rather than `alice bob`.
+- The empty string is an error. To admit nobody, write `[]`; to take the
+  default, omit the field.
 
 ### Hosted registries
 
@@ -145,7 +169,8 @@ registries:
 | Key | Description |
 | --- | --- |
 | `org` | Storage namespace for this registry's packages, so two hosted registries can hold the same `name@version` without colliding. Omitted means the flat `storage` root. Must be a single path-safe segment. |
-| `access` | The default read access for `packages:` entries that don't set their own. Defaults to `$all`. |
+| `access` | The default read access for `packages:` entries that don't set their own. Defaults to `$all`. This is the only access field settable registry-wide — `publish` and `unpublish` belong to `packages:` entries. |
+| `teams` | Named user sets for this registry, referenced from its access lists as `team:<name>` — see [Teams](#teams). |
 | `packages` | The registry's namespace and per-package rules — see [above](#the-packages-map). Only these names can be served from or published to this registry. |
 
 Two hosted registries cannot share an `org` namespace — that's rejected at
@@ -190,11 +215,12 @@ registries:
 | `auth` | Server-owned credential for a private origin. `type` is `bearer` or `basic`; provide `token`, or `token_env: true` to read `NPM_TOKEN`, or `token_env: NAME` to read a named environment variable. |
 | `headers` | Extra request headers to send upstream. If `headers.Authorization` is set, it overrides the `auth`-derived header. |
 | `access` | Which pnpr users may reach this registry at `/~<name>/` (and resolve through it). Required for a non-`public` upstream. |
+| `teams` | Named user sets for this registry, referenced from its access lists as `team:<name>` — see [Teams](#teams). |
 | `packages` | The names this upstream serves through pnpr — see [above](#the-packages-map). |
 | `maxage` | Per-registry packument freshness window. Overrides pnpr's global packument TTL / `--packument-ttl-secs` for this registry. |
 | `timeout` | Per-request upstream deadline. Defaults to `30s`. |
-| `max_fails` | Consecutive failures before the upstream circuit breaker opens. Defaults to `2`; `0` disables the breaker. |
-| `fail_timeout` | Cooldown before an open circuit is probed again. Defaults to `5m`. |
+| `maxFails` | Consecutive failures before the upstream circuit breaker opens. Defaults to `2`; `0` disables the breaker. |
+| `failTimeout` | Cooldown before an open circuit is probed again. Defaults to `5m`. |
 | `cache` | Whether tarballs fetched from this registry are cached locally. Defaults to `true`; `false` streams verified tarballs through a temporary file. |
 
 Interval values accept strings such as `30s`, `5m`, `1h30m`, or a bare number
@@ -255,17 +281,13 @@ start** (and fails a config reload) on an invalid router:
   must be hosted or upstream registries — no nesting, no cycles);
 - a router with no sources.
 
-## `groups`
+## Teams {#teams}
 
-Static group/team memberships. Every access list accepts group names anywhere
-it accepts usernames — the per-package `packages:` rules and the
-registry-level `access:` lists alike:
+A team is a named list of usernames, declared on the registry that uses it and
+referenced from that registry's access lists as `team:<name>` — in the
+registry-level `access:` default and the per-package `packages:` rules alike:
 
 ```yaml
-groups:
-  platform: alice bob
-  frontend: [carol, dave]
-
 registries:
   corp:
     type: upstream
@@ -273,8 +295,45 @@ registries:
     auth:
       type: bearer
       token_env: CORP_NPM_TOKEN
-    access: platform
+    teams:
+      platform: [alice, bob]
+      frontend: [carol, dave]
+    access: team:platform
+    packages:
+      '@corp/ui':
+        access: [team:platform, team:frontend]
 ```
+
+Teams are **registry-scoped**: a registry can only reference teams it declares
+itself, never another registry's. To share one roster between registries, use a
+YAML anchor:
+
+```yaml
+registries:
+  private:
+    type: hosted
+    teams: &corpTeams
+      platform: [alice, bob]
+    access: team:platform
+
+  corp:
+    type: upstream
+    url: https://npm.corp.example.com/
+    teams: *corpTeams
+    access: team:platform
+```
+
+A team's members are plain usernames. A team cannot contain another team — an
+entry with a `:` in it is a config error.
+
+A team is only ever reached through the `team:` prefix: a bare `platform` in an
+access list names the **user** `platform`, even when a team of that name
+exists. Keeping the two apart means someone who can register a username can
+never inherit a team's grants by choosing its name.
+
+Because teams live in the config, they are served read-only over npm's
+team endpoints, and any attempt to create or modify one through the API is
+refused — see [Team endpoints](endpoints.md#team-endpoints).
 
 ## `auth`
 

--- a/pnpr-docs/endpoints.md
+++ b/pnpr-docs/endpoints.md
@@ -6,10 +6,11 @@ title: HTTP endpoints
 pnpr exposes a set of always-on endpoints (health, user accounts, and tokens)
 plus two surfaces:
 
-- **Registry surface** - npm-compatible package and publish endpoints. Served
-  exactly when at least one registry is declared under
+- **Registry surface** - npm-compatible package, publish, staged-publish, and
+  team endpoints. Served exactly when at least one registry is declared under
   [`registries:`](configuration.md#registries-and-defaultregistry);
-  `--disable-registry` turns it off for one process.
+  `--disable-registry` turns it off for one process. On a resolver-only server
+  these routes aren't mounted at all — they answer `404`, not `403`.
 - **Resolver surface** (`resolver.enabled`) - pnpr install-accelerator
   endpoints under `/-/pnpr`.
 
@@ -141,6 +142,80 @@ a hosted registry.
 | `DELETE` | `/@scope/{name}/-/{filename}/-rev/{rev}` | Remove a scoped tarball. Requires `unpublish`. |
 | `PUT` | `/-/package/{package}/dist-tags/{tag}` | Add or update a dist-tag. Body is a JSON string version, for example `"1.0.0"`. Requires `publish`. |
 | `DELETE` | `/-/package/{package}/dist-tags/{tag}` | Remove a dist-tag. Requires `publish`. |
+
+Publishing a version that already exists is a `409`. On the S3 backend, where
+several stateless replicas can write to one bucket, concurrent writers are
+resolved by conditional writes rather than last-write-wins: a packument update
+that loses its race is retried, and a write that repeatedly conflicts surfaces
+as a `409` instead of silently discarding another writer's update. See
+[Storage backends](storage.md#concurrent-writers).
+
+## Staged publishing endpoints
+
+These implement the server half of [`pnpm stage`](/cli/stage) — npm's
+[staged publishing](https://docs.npmjs.com/staged-publishing) workflow. A
+staged version is validated and authorized exactly like a direct publish, but
+held back instead of made visible: it isn't installable, and nothing is written
+under the package's name until it is approved. That lets CI upload a release
+without a human present and defer proof-of-presence (2FA) to whoever approves
+it later, and it doubles as a review gate — the held tarball can be downloaded
+and audited before it goes live.
+
+A stage id is a v4 UUID drawn from the OS CSPRNG, so the id itself acts as an
+unguessable handle. Held records live under a reserved `.staged/` namespace in
+the hosted store (both the filesystem and S3 backends), and a record is only
+visible through the same base it was created with — one staged through
+`/~<name>/` is not addressable on the path-less base, and vice versa.
+
+| Method | Path | Description |
+| --- | --- | --- |
+| `POST` | `/-/stage/package/{name}` | Stage a publish. Body is the same npm publish document a `PUT /{name}` publish carries, `_attachments` included. Use a percent-encoded scoped name, for example `@scope%2Fname`. Returns `201` with `{"ok":true,"stageId":"<uuid>"}`. Requires `publish`. |
+| `GET` | `/-/stage` | List held records, oldest first. Accepts `page` (zero-based, defaults to `0`), `perPage` (defaults to `100`, clamped to `1`–`100`), and `package` (exact name filter). Returns `{"items":[...],"page":...,"perPage":...,"total":...}`. |
+| `GET` | `/-/stage/{id}` | One held record. Requires `publish` on the record's package. |
+| `GET` | `/-/stage/{id}/tarball` | The held tarball as `application/octet-stream`, for inspection before approval. Requires `publish`. |
+| `POST` | `/-/stage/{id}/approve` | Publish the held document and drop the record. Empty body; returns `201` with `{"ok":true}`. Requires `publish`. |
+| `DELETE` | `/-/stage/{id}` | Reject: delete the record and its tarball without publishing. Returns `204`. Requires `publish`. |
+
+Each record carries `id`, `packageName`, `version`, `tag`, `createdAt`,
+`actor`, `actorType`, and `shasum`.
+
+Version conflicts are deliberately **not** checked at staging time — they're
+checked at approval, against the registry as it stands then. Approving a
+version that landed in the meantime returns `409` and **leaves the record in
+place**, so it can still be inspected or rejected. Access rules are likewise
+re-evaluated at approval, not frozen at staging time.
+
+`GET /-/stage` filters rather than refuses: it always answers `200`, listing
+only the records the caller could publish, so an anonymous caller sees an empty
+list instead of a `401`. Every other stage endpoint denies loudly — `401` for
+anonymous callers, `403` for authenticated ones — matching the publish
+endpoint rather than masking as a `404`.
+
+## Team endpoints
+
+pnpr serves npm's team-management read endpoints over the teams declared in
+its config, in the shape [`pnpm team`](/cli/team) consumes. Teams are
+[registry-scoped configuration](configuration.md#teams), so these are
+**read-only views**: the listings are served, and every mutation is refused.
+
+| Method | Path | Description |
+| --- | --- | --- |
+| `GET` | `/-/org/{scope}/team` | Teams declared by the registry that serves `@{scope}`. Returns a JSON array of `{"name": ...}`. The scope may be written with or without a leading `@`. |
+| `GET` | `/-/team/{scope}/{team}/user` | Members of one team, as a JSON array of `{"name": ...}`. |
+| `PUT` | `/-/org/{scope}/team` | Create a team — always `403`. |
+| `DELETE` | `/-/team/{scope}/{team}` | Destroy a team — always `403`. |
+| `PUT` | `/-/team/{scope}/{team}/user` | Add a member — always `403`. |
+| `DELETE` | `/-/team/{scope}/{team}/user` | Remove a member — always `403`. |
+
+A refused mutation carries the error code `teams_config_managed`: teams are
+declared in the pnpr configuration, so changing one means updating the config,
+not calling the API.
+
+Reads resolve `@{scope}` to a hosted registry the same way a package read in
+that scope would, then check that registry's default `access:` list. Unlike
+the stage endpoints, a denial here is **masked as `404`** — team and member
+names must not become an existence probe for a private registry. A registry
+that declares no teams returns an empty array.
 
 ## User and token endpoints
 

--- a/pnpr-docs/endpoints.md
+++ b/pnpr-docs/endpoints.md
@@ -145,21 +145,30 @@ a hosted registry.
 
 Publishing a version that already exists is a `409`. On the S3 backend, where
 several stateless replicas can write to one bucket, concurrent writers are
-resolved by conditional writes rather than last-write-wins: a packument update
-that loses its race is retried, and a write that repeatedly conflicts surfaces
-as a `409` instead of silently discarding another writer's update. See
+resolved by conditional writes rather than last-write-wins. A publish or
+partial unpublish computed from a packument that another replica has since
+changed is rejected with a `409`; a dist-tag write instead replays its mutation
+against the fresh packument, and reports `409` only if it keeps losing. Either
+way no writer's update is silently discarded. See
 [Storage backends](storage.md#concurrent-writers).
 
 ## Staged publishing endpoints
 
 These implement the server half of [`pnpm stage`](/cli/stage) — npm's
-[staged publishing](https://docs.npmjs.com/staged-publishing) workflow. A
-staged version is validated and authorized exactly like a direct publish, but
-held back instead of made visible: it isn't installable, and nothing is written
-under the package's name until it is approved. That lets CI upload a release
-without a human present and defer proof-of-presence (2FA) to whoever approves
-it later, and it doubles as a review gate — the held tarball can be downloaded
-and audited before it goes live.
+[staged publishing](https://docs.npmjs.com/staged-publishing) workflow, where a
+version is uploaded first and promoted later. A staged version is held back
+rather than made visible: it isn't installable, and nothing is written under
+the package's name until it is approved. That lets an unattended CI job upload
+a release for a human to promote, and it doubles as a review gate — the held
+tarball can be downloaded and audited before it goes live.
+
+The two phases check different things. **Staging** validates the publish
+document and requires the `publish` right on the package, exactly as a direct
+publish does, but does not check whether the version already exists.
+**Approval** re-checks the `publish` right against the rules as they stand
+then, and is where a version conflict is caught. pnpr raises no
+one-time-password challenge of its own at either point — the `--otp` flag on
+`pnpm stage approve` is for registries that do.
 
 A stage id is a v4 UUID drawn from the OS CSPRNG, so the id itself acts as an
 unguessable handle. Held records live under a reserved `.staged/` namespace in
@@ -179,11 +188,8 @@ visible through the same base it was created with — one staged through
 Each record carries `id`, `packageName`, `version`, `tag`, `createdAt`,
 `actor`, `actorType`, and `shasum`.
 
-Version conflicts are deliberately **not** checked at staging time — they're
-checked at approval, against the registry as it stands then. Approving a
-version that landed in the meantime returns `409` and **leaves the record in
-place**, so it can still be inspected or rejected. Access rules are likewise
-re-evaluated at approval, not frozen at staging time.
+Approving a version that landed meanwhile returns `409` and **leaves the record
+in place**, so it can still be inspected or rejected.
 
 `GET /-/stage` filters rather than refuses: it always answers `200`, listing
 only the records the caller could publish, so an anonymous caller sees an empty

--- a/pnpr-docs/storage.md
+++ b/pnpr-docs/storage.md
@@ -6,7 +6,9 @@ title: Storage backends (S3 / R2)
 pnpr keeps two kinds of data:
 
 - **Hosted** — the source of truth: packages published to this server plus
-  anything served in static mode. Lives under `storage`.
+  anything served in static mode. Lives under `storage`. Packages awaiting
+  approval through [staged publishing](endpoints.md#staged-publishing-endpoints)
+  are held here too, under a reserved `.staged/` namespace.
 - **Cache** — the disposable mirror of upstream registries plus the resolver
   cache, lockfile-verdict cache, and S3 upload staging scratch. Lives under
   `cache` (defaults to `<storage>/.pnpr-cache`).
@@ -49,6 +51,29 @@ s3:
 | `secretAccessKey` | no | Secret key. Falls back to `AWS_SECRET_ACCESS_KEY` when unset. |
 | `forcePathStyle` | no | Use path-style addressing (`endpoint/bucket/key`) instead of virtual-hosted (`bucket.endpoint/key`). MinIO typically needs `true`; AWS and R2 work with the default. |
 | `allowHttp` | no | Allow plain-HTTP endpoints — needed for a local MinIO over `http://`. Defaults to HTTPS-only. |
+
+## Concurrent writers {#concurrent-writers}
+
+Several stateless pnpr replicas can share one bucket. Because a replica's
+in-process package lock only serializes that replica, writes to the hosted
+store are made safe across replicas at the object-store level rather than by
+locking:
+
+- **Packument updates** — publish, partial unpublish, and dist-tag writes read
+  the packument together with its object-store version and write back
+  conditionally, so an update computed from a stale copy is rejected instead of
+  overwriting a newer one. Dist-tag writes retry on conflict, since their
+  mutation can simply be replayed against the fresh packument. A write that
+  keeps losing surfaces as an HTTP `409` rather than silently discarding
+  another writer's update.
+- **Tarballs** — finalizing a tarball is compare-and-swap. A byte-identical
+  object is tolerated, but an object with different bytes left by a concurrent
+  publisher of the same `name@version` is never overwritten; the losing publish
+  gets a `409` before it writes any packument.
+
+This applies to the S3 backend. The local filesystem backend keeps its
+single-process behavior, since the shared-store race is specific to replicas
+sharing one object store.
 
 ## A complete Cloudflare R2 example
 


### PR DESCRIPTION
Reconciles the pnpr docs with the server changes that landed since they were last updated (2026-07-04).

## Config

- **`groups:` → registry-scoped `teams:`** ([#12790](https://github.com/pnpm/pnpm/pull/12790)). Teams are declared on the registry that uses them and referenced as `team:<name>`; a YAML anchor covers sharing one roster. The top-level `groups:` block no longer exists.
- **Access-token grammar** is now documented as a table plus its validation rules — notably that a bare token is always a username and never a team, so `access: platform` grants the *user* `platform` even when a team of that name exists.
- Added the `teams` key to the hosted and upstream registry tables.

## Endpoints

- **Staged publishing** ([#12922](https://github.com/pnpm/pnpm/pull/12922)) — the server half of [`pnpm stage`](https://pnpm.io/cli/stage), which was already documented on the CLI side. The two pages are now linked.
- **Team endpoints** ([#12789](https://github.com/pnpm/pnpm/pull/12789)) — read-only views over the config-declared teams; every mutation is a 403.
- **Conditional writes on S3** ([#12832](https://github.com/pnpm/pnpm/pull/12832)) — multi-replica safety and the 409 a conflicting writer sees.

## Drive-by fix

The upstream circuit-breaker keys are `maxFails` and `failTimeout`, not `max_fails` and `fail_timeout`. `UpstreamFile` is `rename_all = "camelCase"` with `deny_unknown_fields`, so the documented spellings were a hard startup error, not a silently-ignored key:

```
Invalid config: unknown field `max_fails`, expected one of url, public, auth,
headers, maxage, timeout, maxFails, failTimeout, cache, access, teams, packages
```

This predates the changes above and is unrelated to them.

## Verification

Checked against a real `pnpr` binary rather than only by reading the source:

- Every documented grammar rule exercised, including that a bare token matching a team name resolves as a username.
- Full staged-publish round trip: stage → package 404 while held → list → tarball → approve → package 200 → record dropped.
- Team endpoints hit live for their exact JSON shapes and the 403 on mutation.
- Every YAML example in the diff parses and boots.
- English Docusaurus build passes with no broken links or anchors from any pnpr page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified registry package authorization rules, token grammar/validation behavior, and registry-scoped team configuration (including access defaults).
  * Expanded registry endpoint documentation, including staged publishing workflows, approval-time conflict handling, and visibility/status code semantics.
  * Added/defined read-only npm team endpoint behavior with privacy-preserving denial responses and empty results when no teams exist.
  * Documented hosted storage details for staged packages and replica-safe concurrent publishing on S3 backends.
  * Updated upstream registry configuration fields, including circuit-breaker setting name casing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->