### PR TITLE
docs: stop building duplicate next version

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -70,6 +70,7 @@ const docusaurusConfig = {
           "path": "./docs",
           "routeBasePath": "/",
           "sidebarPath": path.join(__dirname, "sidebars.json"),
+          includeCurrentVersion: false,
           lastVersion: lastDocsVersion,
         },
         "gtag": {

--- a/vercel.json
+++ b/vercel.json
@@ -48,7 +48,12 @@
     },
     {
       "source": "/next/cli/dlx",
-      "destination": "/next/cli/pnx",
+      "destination": "/cli/pnx",
+      "permanent": true
+    },
+    {
+      "source": "/next/:splat*",
+      "destination": "/:splat*",
       "permanent": true
     }
   ]


### PR DESCRIPTION
## Summary

- disable Docusaurus's unversioned current docs output, which was published at `/next`
- keep `docs/` as the source copied into the latest named major (`11.x`)
- permanently redirect existing `/next/*` URLs to the latest docs at `/*`
- redirect the legacy `/next/cli/dlx` URL directly to `/cli/pnx`

## Why

`/next` currently duplicates the complete 11.x documentation for every locale. pnpm.io publishes named major documentation lines, so the extra current version adds build work and output without serving distinct content.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm build` (all 13 locales; completed in 187 seconds)
- verified the build contains no `next` directories or `/next/` sitemap entries
- verified `vercel.json` parses as valid JSON
- `git diff --check`