### PR TITLE
docs: copy pnpm-workspace.yaml before pnpm install in Docker

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -60,11 +60,20 @@ Or let pnpm install Node.js automatically from [`devEngines.runtime`](./package_
 ```dockerfile
 FROM ghcr.io/pnpm/pnpm:11
 WORKDIR /app
-COPY package.json pnpm-lock.yaml ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN pnpm install --frozen-lockfile
 COPY . .
 CMD ["pnpm", "start"]
 ```
+
+:::note
+
+`pnpm-workspace.yaml` is the [per-project configuration file](./settings.md), so it
+must be copied in before `pnpm install` runs. Without it the install still succeeds,
+but silently ignores every setting it contains — `nodeLinker`, `hoistPattern`,
+`overrides`, `allowBuilds` and so on. Omit it if your project does not have one.
+
+:::
 
 ### When to use this image
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -68,10 +68,12 @@ CMD ["pnpm", "start"]
 
 :::note
 
-`pnpm-workspace.yaml` is the [per-project configuration file](./settings.md), so it
-must be copied in before `pnpm install` runs. Without it the install still succeeds,
-but silently ignores every setting it contains — `nodeLinker`, `hoistPattern`,
-`overrides`, `allowBuilds` and so on. Omit it if your project does not have one.
+If your project has a `pnpm-workspace.yaml` — the
+[per-project configuration file](./settings.md) — copy it in before `pnpm install`
+runs. Without it the install still succeeds, but silently ignores every setting the
+file contains: `nodeLinker`, `hoistPattern`, `overrides`, `allowBuilds` and so on. In
+a workspace it also declares `packages`, so the install resolves the wrong set of
+projects. Drop it from the `COPY` line only if your project does not have one.
 
 :::
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -33,7 +33,7 @@ The following changes are not automatable and need human attention:
 - **`ignorePatchFailures`** has been removed. Failed patches now always throw; fix the patch or remove the dependency.
 - **`executionEnv.nodeVersion`** in a workspace subpackage's `package.json#pnpm` is removed. Declare the runtime in that subpackage's `devEngines.runtime` instead.
 - **`npm_config_*` environment variables** are no longer read. Rename them to `pnpm_config_*` wherever they are set (CI configs, shell profiles, Docker images).
-- **Docker images must copy `pnpm-workspace.yaml`.** Because settings moved out of `package.json#pnpm` and `.npmrc` into `pnpm-workspace.yaml`, a Dockerfile that only copies `package.json` and `pnpm-lock.yaml` before `pnpm install` now installs with none of them applied — without failing. Add it to the `COPY` step (see [Working with Docker](./docker.md)).
+- **Docker images need to copy `pnpm-workspace.yaml`** if your project has one — and after this migration most do, since that is where settings now live. A Dockerfile that copies only `package.json` and `pnpm-lock.yaml` before `pnpm install` applies none of those settings, and does not fail. Add it to the `COPY` step (see [Working with Docker](./docker.md)).
 - **`pnpm link <pkg-name>`** no longer resolves packages from the global store. Use a relative or absolute path (`pnpm link ./foo`).
 - **`pnpm install -g`** (with no arguments) is no longer supported. Use `pnpm add -g <pkg>` instead.
 - **`pnpm server`** has been removed with no replacement.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -33,6 +33,7 @@ The following changes are not automatable and need human attention:
 - **`ignorePatchFailures`** has been removed. Failed patches now always throw; fix the patch or remove the dependency.
 - **`executionEnv.nodeVersion`** in a workspace subpackage's `package.json#pnpm` is removed. Declare the runtime in that subpackage's `devEngines.runtime` instead.
 - **`npm_config_*` environment variables** are no longer read. Rename them to `pnpm_config_*` wherever they are set (CI configs, shell profiles, Docker images).
+- **Docker images must copy `pnpm-workspace.yaml`.** Because settings moved out of `package.json#pnpm` and `.npmrc` into `pnpm-workspace.yaml`, a Dockerfile that only copies `package.json` and `pnpm-lock.yaml` before `pnpm install` now installs with none of them applied — without failing. Add it to the `COPY` step (see [Working with Docker](./docker.md)).
 - **`pnpm link <pkg-name>`** no longer resolves packages from the global store. Use a relative or absolute path (`pnpm link ./foo`).
 - **`pnpm install -g`** (with no arguments) is no longer supported. Use `pnpm add -g <pkg>` instead.
 - **`pnpm server`** has been removed with no replacement.


### PR DESCRIPTION
### What

The v11 Dockerfile example in `docs/docker.md` copies only `package.json` and `pnpm-lock.yaml` before `pnpm install`:

```dockerfile
COPY package.json pnpm-lock.yaml ./
RUN pnpm install --frozen-lockfile
```

Since v11, `pnpm-workspace.yaml` is the per-project configuration file — [`docs/settings.md`](https://pnpm.io/settings) says settings moved out of `package.json#pnpm` and out of `.npmrc` into it. So this install runs with `nodeLinker`, `hoistPattern`, `overrides`, `allowBuilds` and everything else **not applied**.

It does not fail. The image builds, the container starts, and the dependency tree is quietly not the one the project configured — which makes it easy to miss after upgrading, especially since the `pnpm-v10-to-v11` codemod *creates* `pnpm-workspace.yaml` for projects that previously had none.

### Changes

- `docs/docker.md` — add `pnpm-workspace.yaml` to the `COPY` step, with a note on why and a caveat for projects that do not have one.
- `docs/migration.md` — add it as a manual follow-up, next to the existing `npm_config_*` item that already points at Docker images.

Only the one example that copies files selectively is affected; the `COPY . .` and `pnpm fetch` recipes elsewhere on the page are already fine.

### Notes

Happy to switch the example to a `pnpm-workspace.yaml*` glob instead if you would rather it stay copy-pasteable for projects without the file — I went with the plain form to match the surrounding style, and covered that case in the note.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated Docker setup guidance to copy `pnpm-workspace.yaml` into the image before running `pnpm install --frozen-lockfile`.
  - Clarified that without copying the workspace file first, pnpm may silently ignore workspace settings (from `package.json#pnpm`/`.npmrc`) during installation.
  - Added a Docker migration note for upgrades to version 11.
  - Noted that the workspace file can be omitted if the project doesn’t use `pnpm-workspace.yaml`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->