### PR TITLE
docs: document pnpm 11.15 through 11.19

### DIFF
--- a/blog/releases/11.15-11.19.md
+++ b/blog/releases/11.15-11.19.md
@@ -1,0 +1,107 @@
+---
+title: pnpm 11.15-11.19
+authors: zkochan
+tags: [release]
+date: 2026-07-31
+---
+
+pnpm 11.15 through 11.19 teach `pnpm update` and `pnpm outdated` to update GitHub Actions, let `pnpm update` write changesets for the bumps it makes, introduce cleaner `update` and `audit` settings sections, add `publishConfig.name` for publishing a package under a different name, harden `pnpm self-update` against project-supplied configuration, make web-based login work without a TTY, and accept `=` as a `save-prefix`. They also cut peak resolution memory by several times on large workspaces and speed up repeat installs after compatible dependency changes.
+
+<!-- truncate -->
+
+## Minor Changes
+
+### Updating GitHub Actions
+
+`pnpm outdated` and `pnpm update` can now check and update the GitHub Actions referenced by your repository's workflow files. The check is opt-in for every command: pass `--include-github-actions`, or set [`update.githubActions`](/settings#updategithubactions) to `true` in `pnpm-workspace.yaml` to enable it by default. Updated actions are pinned to exact commit hashes, with their release tags preserved in comments:
+
+```yaml
+- uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+```
+
+Actions whose refs cannot be read — for example, an action in a private repository — are skipped with a warning instead of failing the command. For actions hosted on a GitHub Enterprise Server, the new [`update.githubActionsServer`](/settings#updategithubactionsserver) setting (or the `GITHUB_SERVER_URL` environment variable) sets the base URL of the GitHub server ([#13220](https://github.com/pnpm/pnpm/issues/13220)).
+
+See [Updating GitHub Actions](/cli/update#updating-github-actions).
+
+### Changesets from `pnpm update`
+
+`pnpm update` gained a [`--changeset`](/cli/update#--changeset) flag ([`update.changeset`](/settings#updatechangeset) enables it by default; `--no-changeset` overrides the setting for one run). After the update completes, pnpm writes a `.changeset/pnpm-update-<suffix>.md` file declaring a `patch` bump for every workspace package whose `dependencies` or `optionalDependencies` were changed by the update and a `major` bump when `peerDependencies` changed, including packages that consume an updated catalog entry via the `catalog:` protocol. Private packages, packages without a name, and packages listed in the `ignore` array of `.changeset/config.json` are skipped.
+
+### New `update` and `audit` settings sections
+
+`pnpm-workspace.yaml` now has [`update`](/settings#update) and [`audit`](/cli/audit#configuration) settings sections, superseding the awkwardly named `updateConfig`, `auditConfig`, and top-level `auditLevel` settings:
+
+```yaml
+update:
+  ignoreDeps: # was updateConfig.ignoreDependencies
+    - webpack
+    - "@babel/*"
+
+audit:
+  level: high # was auditLevel
+  ignore: # was auditConfig.ignoreGhsas
+    - GHSA-xxxx-yyyy-zzzz
+```
+
+The deprecated settings keep working until the next major version. When both a new section value and its deprecated counterpart are set, the new section takes precedence and a warning is printed.
+
+### `publishConfig.name`
+
+[`publishConfig.name`](/package_json#publishconfigname) publishes a package under a different name than the one its manifest carries in the workspace ([#13345](https://github.com/pnpm/pnpm/issues/13345)). It is for a project whose published name is already taken by a sibling project, which otherwise has to be renamed by a build step just before publishing. Only the published artifact is renamed — dependents, `pnpm-lock.yaml`, and release tooling keep addressing the project by its manifest name — and the new name reaches the packed manifest, the tarball filename, and everything that addresses the package at the registry.
+
+### `pnpm self-update` ignores project settings
+
+[`pnpm self-update`](/cli/self-update#project-settings-are-ignored) no longer takes any instruction from the project it is run in:
+
+- pnpm is fetched through the same trusted registry and auth configuration used when switching pnpm versions, so a project `.npmrc` or `pnpm-workspace.yaml` can no longer redirect the download or attach credentials to it, and the project's default `.pnpmfile.(c|m)js` is no longer loaded.
+- The project's `minimumReleaseAge`, `trustPolicy`, and `ci` settings no longer affect `self-update`. They still govern the project's own dependencies; for `self-update` these values come from the built-in default, your global config, a `PNPM_CONFIG_*` environment variable, or a command-line flag. This fixes `self-update` failing inside a workspace that raises the release-age cutoff, and stops a repository from either waiving the cooldown or keeping you on an outdated pnpm by raising it.
+
+When `self-update` refuses a version that is younger than the cutoff, an interactive run now offers to update anyway; non-interactive runs still fail, and CI never prompts.
+
+### Web-based login without a TTY
+
+`pnpm login` no longer requires an interactive terminal when the registry supports web-based login: without a TTY it prints the authentication URL (skipping the QR code and the "Press ENTER to open the URL in your browser" prompt) and polls the registry until the browser approval completes. Only the classic username/password login still fails with `ERR_PNPM_LOGIN_NON_INTERACTIVE` in a non-interactive terminal.
+
+### `save-prefix` accepts `=`
+
+The [`savePrefix`](/settings#saveprefix) setting now accepts `=`: newly added dependencies are saved with an explicit `=` operator (`=1.2.3`) instead of the setting being silently treated as the default `^`. `pnpm update` also keeps the explicit `=` operator of an exact version pin: a dependency saved as `=3.5.1` now updates to `=3.5.2` instead of the bare `3.5.2`.
+
+### Other minor changes
+
+- The first release of a package now [publishes the version written in its manifest verbatim](/versioning#first-releases), instead of bumping off it. A newly added package seeded at `1100.0.0` with a `minor` changeset is published as `1100.0.0` rather than skipping straight to `1100.1.0`.
+- `pnpm setup` now appends `PNPM_HOME` and the global bin directory to the GitHub Actions environment files (`GITHUB_ENV` and `GITHUB_PATH`), so later steps in the same job can run `pnpm add --global` and other global commands ([#9191](https://github.com/pnpm/pnpm/issues/9191)).
+- [`allowBuilds`](/settings#allowbuilds) entries can now approve git-hosted packages that pnpm downloads as a tarball, such as `github:` dependencies, by their repository URL without the resolved commit hash — matching the hashless `git+` matching already supported for cloned git dependencies. GitLab and Bitbucket tarball downloads are matched the same way.
+- Optional peer dependencies declared only via `peerDependenciesMeta` (for example `debug`'s `supports-color` peer) are now resolved from a satisfying version already present in the dependency graph, the same way explicitly declared optional peer dependencies are. Previously an unrelated dependency change could rewrite such peer resolutions across the whole lockfile.
+- Fixed an installed optional dependency being left without one of its own required dependencies, which made importing the parent fail with `MODULE_NOT_FOUND`. A dependency is now only skipped when every path to it is optional, or when the package that pulls it in was itself skipped ([#13286](https://github.com/pnpm/pnpm/issues/13286)).
+
+## Security
+
+- The token poll for web-based authentication no longer reads the body of non-OK or still-pending responses, and caps the token response body it does read at 64 KiB, so a malicious or compromised registry cannot exhaust memory through the poll ([#12721](https://github.com/pnpm/pnpm/issues/12721)).
+- Updated `adm-zip` to prevent crafted ZIP archives from causing excessive memory allocation.
+
+## Patch Changes
+
+- Fixed `pnpm install` running out of memory while resolving large dependency graphs ([#8441](https://github.com/pnpm/pnpm/issues/8441)). Registry documents kept in memory during resolution are now condensed down to the fields installation actually reads, which reduces peak resolution memory by several times on workspaces with more than a thousand packages.
+- Sped up installs after compatible catalog or direct dependency range changes by retaining the locked version without resolving the dependency graph again, and after safe `overrides` changes by reusing unambiguous compatible resolutions instead of running a full lockfile resolution.
+- `pnpm install` now detects a `supportedArchitectures` change and re-evaluates previously skipped platform-specific optional dependencies, instead of reporting the project as up to date.
+- `overrides` now also govern peers that pnpm auto-installs, so an auto-installed peer can no longer bring in a second copy of the very package an override pinned ([#13320](https://github.com/pnpm/pnpm/issues/13320)).
+- An auto-installed optional peer is no longer hoisted at a version the workspace root's own dependency on that package excludes ([#13320](https://github.com/pnpm/pnpm/issues/13320)), and under `resolvePeersFromWorkspaceRoot`, a root dependency declared with `link:`, `file:`, or a path form of `workspace:` now satisfies another project's missing peer at the linked package's own version instead of being hoisted as a broken path ([#13373](https://github.com/pnpm/pnpm/issues/13373)).
+- The root project's `pnpm:devPreinstall` script runs before resolution and linking again, as it did in pnpm 11.12 and earlier, so workspaces that use the hook to prepare state the install depends on are no longer linked against files that were never created ([#13313](https://github.com/pnpm/pnpm/issues/13313)).
+- Installs through a pnpr server now apply the project's whole verification policy (`minimumReleaseAgeExclude`, `trustPolicy*`, `trustLockfile`), honor `--frozen-lockfile`, resolve `catalog:` references in dependencies and overrides, and no longer crash in workspaces with `minimumReleaseAge` active ([#13275](https://github.com/pnpm/pnpm/issues/13275), [#13232](https://github.com/pnpm/pnpm/issues/13232)).
+- Prevented `minimumReleaseAge` from replacing `latest` with a SemVer-greater version than the registry tag target ([#13034](https://github.com/pnpm/pnpm/issues/13034)), and the install summary no longer prints `(X is available)` when the registry's `latest` tag is still held back by the policy ([#11698](https://github.com/pnpm/pnpm/issues/11698)).
+- Local directory dependencies (`file:` directories and injected workspace packages) now get a global-virtual-store slot of their own per project, instead of sharing one slot across every project that depends on a directory of the same name ([#13335](https://github.com/pnpm/pnpm/issues/13335)). Failed builds of scoped packages under `enableGlobalVirtualStore` are also cleaned up correctly.
+- Preserved a workspace dependency's `link:` entry when a run does not target it — e.g. `pnpm update <other-pkg>` or a plain install after a root/catalog dependency change — with `injectWorkspacePackages`, instead of spuriously rewriting it to a peer-suffixed `file:` protocol ([#10433](https://github.com/pnpm/pnpm/issues/10433)).
+- Workspace dependencies declared with a relative path (e.g. `"foo": "workspace:../foo"`) are no longer silently dropped from the workspace projects graph, so `--filter` selection and the topological order of recursive commands take them into account.
+- `pnpm update --workspace` no longer links dependencies the user never named: registry-only dependencies listed in `update.ignoreDeps` keep their specifiers, and selectors that match no direct dependency no longer fall back to linking every workspace dependency.
+- `pnpm update --interactive` now measures its table in terminal columns rather than characters, so wide characters (CJK, most emoji) no longer break the layout or abort the command ([#13357](https://github.com/pnpm/pnpm/issues/13357)). Its `Workspace` column also names every project a shared update applies to and falls back to a project's path when it has no usable `name`.
+- Fixed `pnpm add --save-exact`/`--save-prefix` and `pnpm update` writing a package's version with the `peerDependencies` range's prefix whenever the same package also appeared in `peerDependencies` ([#13108](https://github.com/pnpm/pnpm/issues/13108)).
+- Fixed `pnpm licenses list` to report every version when the same package is installed under multiple aliases ([#13438](https://github.com/pnpm/pnpm/issues/13438)).
+- Fixed `pnpm login`, `pnpm adduser`, and `pnpm logout` against a registry hosted under a URL subpath when the configured URL has no trailing slash.
+- When the authentication URL cannot be rendered as a QR code, web-based login now displays the URL alone with a warning instead of aborting.
+- `pnpm setup` now removes leftover v10-layout shims at the top of `PNPM_HOME`, so `pnpm self-update` no longer warns about a v10 installation layout after PATH has been migrated ([#12496](https://github.com/pnpm/pnpm/issues/12496)).
+- The `pnpm version` command now supports the `from-git` argument, and `pnpm version -r` no longer writes a versioning-ledger entry the next run fails to read when a release consumed no intents.
+- Fixed `pnpm dedupe` updating valid catalog resolutions when another matching version exists in the lockfile, prevented `pnpm dedupe --check` from removing an incompatible `node_modules` directory, and sorted its snapshot output for stable diffs.
+- `pnpm -r run "/pattern/" --no-bail` no longer exits zero when one of a project's matched scripts fails and a later one passes.
+- Fixed empty `bundledDependencies` arrays causing nondeterministic lockfile changes ([#13123](https://github.com/pnpm/pnpm/issues/13123)).
+- Restored the store block a first install prints, naming how packages were materialized and where the stores live ([#13315](https://github.com/pnpm/pnpm/issues/13315)).
+- Stripped Unicode formatting characters from registry- and manifest-derived terminal output.

--- a/docs/cli/audit.md
+++ b/docs/cli/audit.md
@@ -17,12 +17,12 @@ overrides:
 
 Or alternatively, run `pnpm audit --fix`.
 
-If you want to tolerate some vulnerabilities as they don't affect your project, you may use the [`auditConfig.ignoreGhsas`] setting.
+If you want to tolerate some vulnerabilities as they don't affect your project, you may use the [`audit.ignore`] setting.
 
-Since v11, `pnpm audit` queries the registry's `/-/npm/v1/security/advisories/bulk` endpoint. The response does not include CVE identifiers, so advisories are filtered by GitHub advisory ID (GHSA) instead. If you previously listed CVEs under `auditConfig.ignoreCves`, replace each entry with the corresponding `GHSA-xxxx-xxxx-xxxx` value (shown in the `More info` column of `pnpm audit` output) under `auditConfig.ignoreGhsas`.
+Since v11, `pnpm audit` queries the registry's `/-/npm/v1/security/advisories/bulk` endpoint. The response does not include CVE identifiers, so advisories are filtered by GitHub advisory ID (GHSA) instead. If you previously listed CVEs under `auditConfig.ignoreCves`, replace each entry with the corresponding `GHSA-xxxx-xxxx-xxxx` value (shown in the `More info` column of `pnpm audit` output) under [`audit.ignore`].
 
 [overrides]: ../settings.md#overrides
-[`auditConfig.ignoreGhsas`]: #auditconfigignoreghsas
+[`audit.ignore`]: #auditignore
 
 ## Commands
 
@@ -47,7 +47,7 @@ The command exits with code `1` if any package has an invalid signature, or if a
 
 Only print advisories with severity greater than or equal to `<severity>`.
 
-This can also be set via `auditLevel` in `pnpm-workspace.yaml`.
+This can also be set via [`audit.level`](#auditlevel) in `pnpm-workspace.yaml`.
 
 ### --fix
 
@@ -100,21 +100,41 @@ Ignore a vulnerability by its GitHub advisory ID (GHSA). Before v11 this flag ac
 
 ## Configuration
 
-### auditConfig
+`pnpm audit` is configured in the `audit` section of `pnpm-workspace.yaml` (added in v11.16.0):
 
-#### auditConfig.ignoreGhsas
+```yaml
+audit:
+  level: high
+  ignore:
+    - GHSA-42xw-2xvc-qx8m
+```
+
+### audit.level
+
+* Default: **low**
+* Type: **low**, **moderate**, **high**, **critical**
+
+Only print advisories with severity greater than or equal to this level. Same as the [`--audit-level`](#--audit-level-severity) flag.
+
+### audit.ignore
 
 A list of GHSA codes that will be ignored by the [`pnpm audit`] command.
 
 ```yaml
-auditConfig:
-  ignoreGhsas:
+audit:
+  ignore:
     - GHSA-42xw-2xvc-qx8m
     - GHSA-4w2v-q235-vp99
     - GHSA-cph5-m8f7-6c5x
     - GHSA-vh95-rmgr-6w4m
 ```
 
+:::info
+
+Before v11.16.0, these settings were named `auditLevel` and `auditConfig.ignoreGhsas`. The deprecated names keep working until the next major version; when both are set, the `audit` section takes precedence and a warning is printed.
+
 Before v11, `auditConfig.ignoreCves` was used to filter advisories by CVE identifier. That setting is no longer recognized.
+
+:::
 
 [`pnpm audit`]: #

--- a/docs/cli/audit.md
+++ b/docs/cli/audit.md
@@ -118,7 +118,7 @@ Only print advisories with severity greater than or equal to this level. Same as
 
 ### audit.ignore
 
-A list of GHSA codes that will be ignored by the [`pnpm audit`] command.
+A list of GHSA codes that will be ignored by the `pnpm audit` command.
 
 ```yaml
 audit:
@@ -136,5 +136,3 @@ Before v11.16.0, these settings were named `auditLevel` and `auditConfig.ignoreG
 Before v11, `auditConfig.ignoreCves` was used to filter advisories by CVE identifier. That setting is no longer recognized.
 
 :::
-
-[`pnpm audit`]: #

--- a/docs/cli/login.md
+++ b/docs/cli/login.md
@@ -15,6 +15,8 @@ pnpm login [--registry <url>] [--scope <scope>]
 
 Supports web-based login with QR code as well as classic username/password authentication.
 
+Since v11.19.0, web-based login no longer requires an interactive terminal: without a TTY, `pnpm login` prints the authentication URL (skipping the QR code and the prompt to open the URL in a browser) and polls the registry until the browser approval completes. Only the classic username/password login still fails with `ERR_PNPM_LOGIN_NON_INTERACTIVE` in a non-interactive terminal.
+
 Auth tokens are written to [`<pnpm config>/auth.ini`](../npmrc.md#auth-file-locations).
 
 ## Options

--- a/docs/cli/outdated.md
+++ b/docs/cli/outdated.md
@@ -57,3 +57,9 @@ Doesn't check `optionalDependencies`.
 ### --sort-by
 
 Specifies the order in which the output results are sorted. Currently only the value `name` is accepted.
+
+### --include-github-actions
+
+Added in: v11.16.0
+
+Also check the GitHub Actions referenced by the repository's workflow files for updates. Can be enabled by default by setting [`update.githubActions`](../settings.md#updategithubactions) to `true` in `pnpm-workspace.yaml`. See [Updating GitHub Actions](./update.md#updating-github-actions).

--- a/docs/cli/outdated.md
+++ b/docs/cli/outdated.md
@@ -62,4 +62,4 @@ Specifies the order in which the output results are sorted. Currently only the v
 
 Added in: v11.16.0
 
-Also check the GitHub Actions referenced by the repository's workflow files for updates. Can be enabled by default by setting [`update.githubActions`](../settings.md#updategithubactions) to `true` in `pnpm-workspace.yaml`. See [Updating GitHub Actions](./update.md#updating-github-actions).
+Also check the GitHub Actions referenced by the repository's workflow files for updates. You can enable this by default by setting [`update.githubActions`](../settings.md#updategithubactions) to `true` in `pnpm-workspace.yaml`. See [Updating GitHub Actions](./update.md#updating-github-actions).

--- a/docs/cli/self-update.md
+++ b/docs/cli/self-update.md
@@ -30,6 +30,15 @@ When the project's `package.json` has a `packageManager` field set to pnpm (or a
 
 If the project does not pin pnpm, or the pin is being ignored via [`pmOnFail: ignore`](../settings.md#pmonfail), `self-update` installs the resolved pnpm version globally and links it to `PNPM_HOME` so it becomes the active pnpm binary on your system.
 
+## Project settings are ignored
+
+Since v11.18.0, `pnpm self-update` takes no instruction from the project it is run in:
+
+* pnpm is fetched through the same trusted registry and auth configuration used when switching pnpm versions, so a project's `.npmrc` or `pnpm-workspace.yaml` cannot redirect the download or attach credentials to it, and the project's default `.pnpmfile.(c|m)js` is not loaded. Pnpmfiles from trusted sources (the [`pnpmfile`](../pnpmfile.md#pnpmfile) setting, the global pnpmfile, config dependencies) still apply.
+* The project's [`minimumReleaseAge`](../settings.md#minimumreleaseage), [`trustPolicy`](../settings.md#trustpolicy), and `ci` settings do not affect `self-update`. They still govern the project's own dependencies; for `self-update`, these values come from the built-in default, your global config, a `PNPM_CONFIG_*` environment variable, or a command-line flag. This stops a repository from either waiving the release-age cooldown or keeping you on an outdated pnpm by raising it, and from weakening the trust check that guards the pnpm download.
+
+When `self-update` refuses a version that is younger than the `minimumReleaseAge` cutoff, an interactive run offers to update anyway; non-interactive runs still fail. CI never prompts, even on a runner that attaches a TTY.
+
 ## Installing pnpm v12 (the Rust port)
 
 Since v11.10.0, `pnpm self-update` (and `packageManager` version-switching) can install and link **pnpm v12**, the Rust port. It is published under both the `pnpm` and `@pnpm/exe` names on the `next-12` dist-tag:

--- a/docs/cli/setup.md
+++ b/docs/cli/setup.md
@@ -11,6 +11,8 @@ Setup does the following actions:
 * adds the pnpm home directory to the `PATH` by updating the shell configuration file
 * copies the pnpm executable to the pnpm home directory
 
+Since v11.18.0, when running on GitHub Actions, `pnpm setup` also appends `PNPM_HOME` and the global bin directory to the GitHub Actions environment files (`GITHUB_ENV` and `GITHUB_PATH`), so later steps in the same job can run `pnpm add --global` and other global commands.
+
 :::tip
 
 After upgrading to pnpm v11, run `pnpm setup` to update your shell configuration. In v11, globally installed binaries are stored in a `bin` subdirectory of `PNPM_HOME`.

--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -41,6 +41,20 @@ Patterns may also be combined, so the next command will update all `babel` packa
 pnpm update "@babel/*" "\!@babel/core"
 ```
 
+## Updating GitHub Actions
+
+Added in: v11.16.0
+
+`pnpm update` and [`pnpm outdated`](./outdated.md) can also check and update the GitHub Actions referenced by the repository's workflow files. This is opt-in for every command: pass [`--include-github-actions`](#--include-github-actions), or set [`update.githubActions`](../settings.md#updategithubactions) to `true` in `pnpm-workspace.yaml` to enable it by default.
+
+Updated actions are pinned to exact commit hashes, with their release tags preserved in comments:
+
+```yaml
+- uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+```
+
+Checking for updates runs `git ls-remote` against every referenced repository. Actions whose refs cannot be read — for example, an action in a private repository — are skipped with a warning. If the actions are hosted on a different GitHub server (such as a GitHub Enterprise Server), set [`update.githubActionsServer`](../settings.md#updategithubactionsserver).
+
 ## Options
 
 ### --recursive, -r
@@ -98,6 +112,20 @@ Show outdated dependencies and select which ones to update.
 ### --no-save
 
 Don't update the ranges in `package.json`.
+
+### --changeset
+
+Added in: v11.16.0
+
+After the update completes, write a [change intent](../versioning.md) — a changesets-compatible `.changeset/*.md` file — declaring a `patch` bump for every workspace package whose `dependencies` or `optionalDependencies` were changed by the update, and a `major` bump when its `peerDependencies` changed. Packages that consume an updated catalog entry via the `catalog:` protocol are included. Private packages, packages without a name, and packages listed in the `ignore` array of `.changeset/config.json` are skipped. If `.changeset/config.json` does not exist, a warning is printed and no changeset is generated.
+
+Set [`update.changeset`](../settings.md#updatechangeset) to `true` in `pnpm-workspace.yaml` to enable this behavior by default, and use `--no-changeset` to override the setting for one update.
+
+### --include-github-actions
+
+Added in: v11.16.0
+
+Also update the GitHub Actions referenced by the repository's workflow files. See [Updating GitHub Actions](#updating-github-actions).
 
 ### --filter &lt;package_selector\>
 

--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -45,7 +45,7 @@ pnpm update "@babel/*" "\!@babel/core"
 
 Added in: v11.16.0
 
-`pnpm update` and [`pnpm outdated`](./outdated.md) can also check and update the GitHub Actions referenced by the repository's workflow files. This is opt-in for every command: pass [`--include-github-actions`](#--include-github-actions), or set [`update.githubActions`](../settings.md#updategithubactions) to `true` in `pnpm-workspace.yaml` to enable it by default.
+[`pnpm outdated`](./outdated.md) can check the GitHub Actions referenced by the repository's workflow files for updates, and `pnpm update` can update them. This is opt-in for every command: pass [`--include-github-actions`](#--include-github-actions), or set [`update.githubActions`](../settings.md#updategithubactions) to `true` in `pnpm-workspace.yaml` to enable it by default.
 
 Updated actions are pinned to exact commit hashes, with their release tags preserved in comments:
 
@@ -53,7 +53,7 @@ Updated actions are pinned to exact commit hashes, with their release tags prese
 - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 ```
 
-Checking for updates runs `git ls-remote` against every referenced repository. Actions whose refs cannot be read — for example, an action in a private repository — are skipped with a warning. If the actions are hosted on a different GitHub server (such as a GitHub Enterprise Server), set [`update.githubActionsServer`](../settings.md#updategithubactionsserver).
+Checking for updates runs `git ls-remote` against every referenced repository. Actions whose refs cannot be read — for example, an action in a private repository — are skipped with a warning. If the actions are hosted on a different GitHub server (such as a GitHub Enterprise Server), set [`update.githubActionsServer`](../settings.md#updategithubactionsserver) (added in v11.17.0).
 
 ## Options
 

--- a/docs/package_json.md
+++ b/docs/package_json.md
@@ -286,6 +286,7 @@ The following fields may be overridden:
 * cpu
 * os
 * `engines` (Added in v10.22.0)
+* [`name`](#publishconfigname) (Added in v11.18.0)
 
 To override a field, add the publish version of the field to `publishConfig`.
 

--- a/docs/package_json.md
+++ b/docs/package_json.md
@@ -314,6 +314,24 @@ Will be published as:
 }
 ```
 
+### publishConfig.name
+
+Added in: v11.18.0
+
+Publishes the package under a different name than the one its manifest carries in the workspace. This is for a project whose published name is already taken by a sibling project, which otherwise has to be renamed by a build step just before publishing.
+
+```json
+{
+  "name": "foo-v2",
+  "version": "2.0.0",
+  "publishConfig": {
+    "name": "foo"
+  }
+}
+```
+
+Only the published artifact is renamed — dependents, `pnpm-lock.yaml`, and release tooling keep addressing the project by its manifest name. The new name reaches the packed manifest, the tarball filename, and everything that addresses the package at the registry: the already-published check of `pnpm publish -r`, its registry selection, and the release-planning probes of `pnpm change status` and `pnpm version -r`.
+
 ### publishConfig.executableFiles
 
 By default, for portability reasons, no files except those listed in the bin field will be marked as executable in the resulting package archive. The `executableFiles` field lets you declare additional files that must have the executable flag (+x) set even if they aren't directly accessible through the bin field.

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -225,7 +225,7 @@ Added in: v11.17.0
 * Default: the `GITHUB_SERVER_URL` environment variable, falling back to **https://github.com**
 * Type: **URL**
 
-The base URL of the GitHub server that hosts the repositories of the GitHub Actions referenced by the workflow files (for example, a GitHub Enterprise Server). The URL must use the `https://` or `http://` protocol.
+The base URL of the GitHub server that hosts the repositories of the GitHub Actions referenced by the workflow files (for example, a GitHub Enterprise Server). The URL must use the `https://` or `http://` protocol. Only use `http://` for a trusted server on a trusted network: the refs used to pin actions to commit hashes are fetched over this URL, and unencrypted traffic can be tampered with.
 
 :::info
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -202,12 +202,16 @@ Patterns are also supported, so you may ignore any packages from a scope: `@babe
 
 #### update.changeset
 
+Added in: v11.16.0
+
 * Default: **false**
 * Type: **Boolean**
 
 When `true`, `pnpm update` writes a [change intent](./versioning.md) after updating workspace manifests, declaring a `patch` bump for every workspace package whose `dependencies` or `optionalDependencies` were changed by the update and a `major` bump when its `peerDependencies` changed. Same as passing [`--changeset`](./cli/update.md#--changeset); pass `--no-changeset` to override the setting for a single run.
 
 #### update.githubActions
+
+Added in: v11.16.0
 
 * Default: **false**
 * Type: **Boolean**

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -182,19 +182,52 @@ allowedDeprecatedVersions:
 
 With the above configuration pnpm will not print deprecation warnings about any version of `request` and about v1 of `express`.
 
-### updateConfig
+### update
 
-#### updateConfig.ignoreDependencies
+Added in: v11.16.0
 
-Sometimes you can't update a dependency. For instance, the latest version of the dependency started to use ESM but your project is not yet in ESM. Annoyingly, such a package will be always printed out by the `pnpm outdated` command and updated, when running `pnpm update --latest`. However, you may list packages that you don't want to upgrade in the `ignoreDependencies` field:
+Settings in this section tune the [`pnpm update`](./cli/update.md) and [`pnpm outdated`](./cli/outdated.md) commands.
+
+#### update.ignoreDeps
+
+Sometimes you can't update a dependency. For instance, the latest version of the dependency started to use ESM but your project is not yet in ESM. Annoyingly, such a package will be always printed out by the `pnpm outdated` command and updated, when running `pnpm update --latest`. However, you may list packages that you don't want to upgrade in the `ignoreDeps` field:
 
 ```yaml
-updateConfig:
-  ignoreDependencies:
+update:
+  ignoreDeps:
   - load-json-file
 ```
 
 Patterns are also supported, so you may ignore any packages from a scope: `@babel/*`.
+
+#### update.changeset
+
+* Default: **false**
+* Type: **Boolean**
+
+When `true`, `pnpm update` writes a [change intent](./versioning.md) after updating workspace manifests, declaring a `patch` bump for every workspace package whose `dependencies` or `optionalDependencies` were changed by the update and a `major` bump when its `peerDependencies` changed. Same as passing [`--changeset`](./cli/update.md#--changeset); pass `--no-changeset` to override the setting for a single run.
+
+#### update.githubActions
+
+* Default: **false**
+* Type: **Boolean**
+
+When `true`, `pnpm update` and `pnpm outdated` also check the GitHub Actions referenced by the repository's workflow files. Same as passing [`--include-github-actions`](./cli/update.md#--include-github-actions). See [Updating GitHub Actions](./cli/update.md#updating-github-actions).
+
+#### update.githubActionsServer
+
+Added in: v11.17.0
+
+* Default: the `GITHUB_SERVER_URL` environment variable, falling back to **https://github.com**
+* Type: **URL**
+
+The base URL of the GitHub server that hosts the repositories of the GitHub Actions referenced by the workflow files (for example, a GitHub Enterprise Server). The URL must use the `https://` or `http://` protocol.
+
+:::info
+
+Before v11.16.0, `update.ignoreDeps` was named `updateConfig.ignoreDependencies`. The deprecated `updateConfig` setting keeps working until the next major version; when both are set, the `update` section takes precedence and a warning is printed.
+
+:::
 
 ### supportedArchitectures
 
@@ -1401,6 +1434,8 @@ allowBuilds:
 
 The repository form lets a trusted git dependency keep running its build scripts across branch updates without re-approving each new commit. The key is the package name, followed by `@` and the git URL, with no `#<ref>` suffix. Matching is exact, so `git+ssh://` and `git+https://` URLs for the same repository are separate keys.
 
+Since v11.19.0, the repository form also approves git-hosted packages that pnpm downloads as a tarball rather than clones — such as `github:` dependencies, which are fetched from `codeload.github.com`. A `foo@git+https://github.com/org/foo.git` entry approves `foo` whether pnpm clones the repository or downloads a tarball. GitLab and Bitbucket tarball downloads are matched the same way. Approving or denying a specific resolved commit by its full tarball dep path continues to work.
+
 Denials by package name are not restricted this way: `foo: false` blocks `foo` whether it comes from the registry or from git.
 
 **Default behavior:** Packages not listed in `allowBuilds` are disallowed by default and are treated as unreviewed. By default, an error is printed ([`strictDepBuilds`](#strictdepbuilds) defaults to `true`). If `strictDepBuilds` is set to `false`, a warning is printed instead.
@@ -1611,7 +1646,7 @@ versioning:
 ### savePrefix
 
 * Default: **'^'**
-* Type: **'^'**, **'~'**, **''**
+* Type: **'^'**, **'~'**, **''**, **'='**
 
 Configure how versions of packages installed to a `package.json` file get
 prefixed.
@@ -1620,6 +1655,10 @@ For example, if a package has version `1.2.3`, by default its version is set to
 `^1.2.3` which allows minor upgrades for that package, but after
 `pnpm config set save-prefix='~'` it would be set to `~1.2.3` which only allows
 patch upgrades.
+
+Since v11.19.0, `=` is also accepted: newly added dependencies are saved with an
+explicit `=` operator (`=1.2.3`), which pins the exact version. `pnpm update`
+keeps the `=` operator when it updates such a pin.
 
 This setting is ignored when the added package has a range specified. For
 instance, `pnpm add foo@2` will set the version of `foo` in `package.json` to

--- a/docs/using-changesets.md
+++ b/docs/using-changesets.md
@@ -7,6 +7,8 @@ title: Using Changesets with pnpm
 
 Since v11.13.0, pnpm can manage workspace releases natively, without the Changesets CLI. It reads and writes the same `.changeset/*.md` files. See [Release management](./versioning.md).
 
+Since v11.16.0, [`pnpm update --changeset`](./cli/update.md#--changeset) can also write a changeset for the dependency bumps an update makes.
+
 :::
 
 :::note

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -44,6 +44,10 @@ This applies the release plan: every package named by an intent is bumped, and s
 
 Because a recursive run can bump many packages to different versions, no git commit or tag is created — there is no single version to tag. Commit the result yourself, then publish with `pnpm publish -r`.
 
+### First releases
+
+Since v11.16.0, the first release of a package publishes the version written in its manifest verbatim, instead of bumping off it. `pnpm version -r` and `pnpm change status` check the registry for each release's current version; when that version is not yet published, the package debuts at it and its pending change intents apply only from the next release. A newly added package seeded at `1100.0.0` with a `minor` intent is therefore published as `1100.0.0` rather than skipping straight to `1100.1.0`.
+
 ## Configuration
 
 Release behavior is configured under the `versioning` key of `pnpm-workspace.yaml`:


### PR DESCRIPTION
Documents the changes from pnpm releases 11.15 through 11.19.

**Settings (`docs/settings.md`)**
- Replaces the `updateConfig` section with the new `update` section (v11.16): `update.ignoreDeps`, `update.changeset`, `update.githubActions`, and `update.githubActionsServer` (v11.17), with a note that the deprecated `updateConfig` name keeps working until the next major.
- `savePrefix` documents the `=` value (v11.19).
- `allowBuilds` documents hashless matching of git-hosted packages downloaded as tarballs — `github:`, GitLab, Bitbucket (v11.19).

**CLI pages**
- `update`: new "Updating GitHub Actions" section (opt-in, commit-hash pinning, private-repo skip, Enterprise Server setting), plus the `--changeset`/`--no-changeset` and `--include-github-actions` options.
- `outdated`: `--include-github-actions` option.
- `audit`: Configuration section now documents `audit.level` and `audit.ignore`, with `auditLevel`/`auditConfig.ignoreGhsas` noted as deprecated.
- `self-update`: new "Project settings are ignored" section covering the v11.18 hardening.
- `setup`: appends `PNPM_HOME` and the global bin dir to `GITHUB_ENV`/`GITHUB_PATH` on GitHub Actions (v11.18).
- `login`: web-based login without a TTY (v11.19).

**Other pages**
- `package_json`: new `publishConfig.name` section (v11.18).
- `versioning`: new "First releases" subsection — a package's first release publishes its manifest version verbatim (v11.16).
- `using-changesets`: cross-link to `pnpm update --changeset`.

Also adds a combined release blog post for 11.15–11.19, with a Security section and a curated patch-changes list.

Purely behavioral fixes (peer resolution details, memory/speed improvements, pnpr fixes) are covered in the blog post only, since the existing docs already describe the intended behavior.

The site builds cleanly; the only broken links reported are four pre-existing ones on translated copies of the 11.0 blog post.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added GitHub Actions update support to `pnpm update` and `pnpm outdated`.
  - Added `pnpm update --changeset` for generating changesets from dependency updates.
  - Added non-interactive browser-based login support.
  - Added `publishConfig.name`, exact-version save settings, and expanded update configuration.

- **Security & Reliability**
  - Hardened `pnpm self-update` behavior and trusted configuration handling.
  - Added GHSA-based audit filtering and severity controls.

- **Documentation**
  - Updated guidance for setup, versioning, publishing, changesets, and GitHub Actions workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->