### PR TITLE
docs: document pnpm 12 and label the docs version "11 & 12"

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -7,6 +7,12 @@ title: Installation
 
 If you don't use the standalone script or `@pnpm/exe` to install pnpm, then you need to have Node.js (at least v22) to be installed on your system.
 
+:::info
+
+Looking for pnpm 12? It is currently in beta and installed differently from pnpm 11. See [Installing the pnpm 12 beta](#installing-the-pnpm-12-beta).
+
+:::
+
 ## Using a standalone script
 
 You may install pnpm even if you don't have Node.js installed, using the following scripts.
@@ -38,7 +44,9 @@ Add-MpPreference -ExclusionPath $(pnpm store path)
 
 :::warning Not supported on Intel macOS
 
-The standalone script does not run on Intel Macs (`darwin-x64`). Use [npm](#using-npm), [Corepack](#using-corepack), or [Homebrew](#using-homebrew) instead. See [#11423](https://github.com/pnpm/pnpm/issues/11423) for context.
+On pnpm 11, the standalone script does not run on Intel Macs (`darwin-x64`). Use [npm](#using-npm), [Corepack](#using-corepack), or [Homebrew](#using-homebrew) instead. See [#11423](https://github.com/pnpm/pnpm/issues/11423) for context.
+
+pnpm 12 ships an Intel macOS build again, so this limitation doesn't apply to it.
 
 :::
 
@@ -116,11 +124,17 @@ corepack use pnpm@latest-11
 
 This will add a `"packageManager"` field in your local `package.json` which will instruct Corepack to always use a specific version on that project. This can be useful if you want reproducability, as all developers who are using Corepack will use the same version as you. When a new version of pnpm is released, you can re-run the above command.
 
+:::warning
+
+Corepack cannot install pnpm 12 yet. It expects the pnpm package to contain a `bin/pnpm.mjs` file, which the native pnpm 12 package does not have. Use [`pnpm self-update`](#pnpm-12-using-pnpm), [npm](#pnpm-12-using-npm), or the [standalone script](#pnpm-12-using-a-standalone-script) to install the beta.
+
+:::
+
 ## Using other package managers
 
 ### Using npm
 
-We provide two packages of pnpm CLI, `pnpm` and `@pnpm/exe`.
+We provide two packages of pnpm CLI, `pnpm` and `@pnpm/exe`. On pnpm 12 the two are identical, so there is no reason to prefer one over the other; the difference below applies to pnpm 11.
 
 - [`pnpm`](https://www.npmjs.com/package/pnpm) is an ordinary version of pnpm, which needs Node.js to run. Since v11, pnpm is distributed as pure ESM.
 - [`@pnpm/exe`](https://www.npmjs.com/package/@pnpm/exe) is packaged with Node.js into an executable, so it may be used on a system with no Node.js installed. On Linux, glibc and musl builds are both provided and the right one is selected automatically; the glibc build requires glibc 2.27 or newer and `libatomic.so.1` (see [Linux runtime requirements](#on-posix-systems) for details). **Not available for Intel macOS** (`darwin-x64`) — install `pnpm` instead, see [#11423](https://github.com/pnpm/pnpm/issues/11423).
@@ -173,19 +187,75 @@ Do you wanna use pnpm on CI servers? See: [Continuous Integration](./continuous-
 
 :::
 
+## Installing the pnpm 12 beta
+
+:::warning
+
+pnpm 12 is a rewrite of pnpm in Rust and is currently in **beta**. It is not recommended for production use yet. Please [report any issues](https://github.com/pnpm/pnpm/issues) you run into.
+
+:::
+
+pnpm 12 has no intentional breaking changes compared to pnpm 11, so the rest of this documentation applies to both versions. Only installation differs while v12 is in beta: it is published under the `next-12` tag on npm and as a prerelease on GitHub, so Homebrew, winget, Scoop and Chocolatey don't offer it yet.
+
+### Using pnpm {#pnpm-12-using-pnpm}
+
+If you already have pnpm v11.10.0 or newer, this is the easiest way to switch:
+
+```
+pnpm self-update next-12
+```
+
+pnpm links the native binary directly, so nothing else is needed. Note that inside a project that pins pnpm through the `packageManager` field, [`self-update`] only updates that pin instead of installing pnpm globally.
+
+### Using npm {#pnpm-12-using-npm}
+
+If you don't have pnpm installed yet:
+
+```sh
+npm install -g --allow-scripts=pnpm pnpm@next-12
+```
+
+:::info
+
+`--allow-scripts=pnpm` is required. The published package is a small wrapper whose `preinstall` script replaces it with the native binary for your platform, and recent versions of npm block install scripts by default. Without the flag, `pnpm` is left as a placeholder file that fails to run. For the same reason, don't install pnpm 12 with `--ignore-scripts` or `--no-optional`. If you install it with pnpm or Bun, allow the build scripts of the `pnpm` package.
+
+:::
+
+Node.js 18 or newer is needed to run that install script, but not to run pnpm afterwards — pnpm 12 is a native binary.
+
+### Using a standalone script {#pnpm-12-using-a-standalone-script}
+
+Set `PNPM_VERSION` to the exact beta version (the POSIX script does not accept npm dist-tags).
+
+On POSIX systems:
+
+```sh
+curl -fsSL https://get.pnpm.io/install.sh | env PNPM_VERSION=12.0.0-beta.2 sh -
+```
+
+On Windows, using PowerShell:
+
+```powershell
+$env:PNPM_VERSION="12.0.0-beta.2"; Invoke-WebRequest https://get.pnpm.io/install.ps1 -UseBasicParsing | Invoke-Expression
+```
+
+This installs pnpm without requiring Node.js, and unlike pnpm 11 it also works on Intel macOS.
+
 ## Compatibility
 
 Here is a list of past pnpm versions with respective Node.js version support.
 
-| Node.js    | pnpm 8 | pnpm 9 | pnpm 10 | pnpm 11 |
-|------------|--------|--------|---------|---------|
-| Node.js 14 | ❌     | ❌     | ❌      | ❌      |
-| Node.js 16 | ✔️      | ❌     | ❌      | ❌      |
-| Node.js 18 | ✔️      | ✔️      | ✔️       | ❌      |
-| Node.js 20 | ✔️      | ✔️      | ✔️       | ❌      |
-| Node.js 22 | ✔️      | ✔️      | ✔️       | ✔️       |
-| Node.js 24 | ✔️      | ✔️      | ✔️       | ✔️       |
-| Node.js 26 | ✔️      | ✔️      | ✔️       | ✔️       |
+| Node.js    | pnpm 8 | pnpm 9 | pnpm 10 | pnpm 11 | pnpm 12 |
+|------------|--------|--------|---------|---------|---------|
+| Node.js 14 | ❌     | ❌     | ❌      | ❌      | ❌      |
+| Node.js 16 | ✔️      | ❌     | ❌      | ❌      | ❌      |
+| Node.js 18 | ✔️      | ✔️      | ✔️       | ❌      | ✔️       |
+| Node.js 20 | ✔️      | ✔️      | ✔️       | ❌      | ✔️       |
+| Node.js 22 | ✔️      | ✔️      | ✔️       | ✔️       | ✔️       |
+| Node.js 24 | ✔️      | ✔️      | ✔️       | ✔️       | ✔️       |
+| Node.js 26 | ✔️      | ✔️      | ✔️       | ✔️       | ✔️       |
+
+pnpm 12 only needs Node.js when it is installed from npm; the version installed by the standalone script runs without Node.js.
 
 ## Troubleshooting
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -42,7 +42,7 @@ Add-MpPreference -ExclusionPath $(pnpm store path)
 
 ### On POSIX systems
 
-:::warning Not supported on Intel macOS
+:::warning Not supported on Intel macOS in pnpm 11
 
 On pnpm 11, the standalone script does not run on Intel Macs (`darwin-x64`). Use [npm](#using-npm), [Corepack](#using-corepack), or [Homebrew](#using-homebrew) instead. See [#11423](https://github.com/pnpm/pnpm/issues/11423) for context.
 
@@ -217,7 +217,7 @@ npm install -g --allow-scripts=pnpm pnpm@next-12
 
 :::info
 
-`--allow-scripts=pnpm` is required. The published package is a small wrapper whose `preinstall` script replaces it with the native binary for your platform, and recent versions of npm block install scripts by default. Without the flag, `pnpm` is left as a placeholder file that fails to run. For the same reason, don't install pnpm 12 with `--ignore-scripts` or `--no-optional`. If you install it with pnpm or Bun, allow the build scripts of the `pnpm` package.
+`--allow-scripts=pnpm` is required on npm 11.16 and newer, which blocks install scripts by default. The published package is a small wrapper whose `preinstall` script replaces it with the native binary for your platform, so without the flag `pnpm` is left as a placeholder file that fails to run. Older versions of npm run install scripts anyway and ignore the flag, so the command above works on any version. For the same reason, don't install pnpm 12 with `--ignore-scripts` or `--no-optional`. If you install it with pnpm or Bun, allow the build scripts of the `pnpm` package.
 
 :::
 

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -72,6 +72,13 @@ const docusaurusConfig = {
           "sidebarPath": path.join(__dirname, "sidebars.json"),
           includeCurrentVersion: false,
           lastVersion: lastDocsVersion,
+          versions: {
+            // pnpm 12 is a Rust rewrite with no intentional breaking changes,
+            // so these docs describe both majors instead of getting a separate
+            // docs version. Only the displayed label changes; the version is
+            // still named 11.x on disk, in URLs, and in Crowdin.
+            [lastDocsVersion]: { label: '11 & 12' },
+          },
         },
         "gtag": {
           trackingID: "UA-91385296-1",

--- a/vercel.json
+++ b/vercel.json
@@ -27,6 +27,11 @@
       "permanent": false
     },
     {
+      "source": "/12.x/:splat*",
+      "destination": "/:splat*",
+      "permanent": false
+    },
+    {
       "source": "/9.x/:splat*",
       "destination": "/:splat*",
       "permanent": true


### PR DESCRIPTION
pnpm 12 is a Rust rewrite with no intentional breaking changes vs v11, so it doesn't need its own docs version — the 11.x docs already describe it. Two changes follow from that:

1. **Relabel the 11.x docs version to "11 & 12"** so the version dropdown says what the docs actually cover.
2. **Document the beta's installation** in a dedicated section of the existing installation page, rather than a separate `installation-v12` page. v11 stays the default path throughout.

## The relabel

```ts
versions: {
  [lastDocsVersion]: { label: '11 & 12' },
},
```

Only the *displayed* label changes — the version is still named `11.x` on disk, in URLs, in the `versioned_sidebars` filename and in the Crowdin paths. So there's no snapshot to commit, no `.gitignore`/`copy-docs` rename, no second sidebar file, and no translation churn. The dropdown and the "for up-to-date documentation" banner on the 10.x pages both pick it up.

Cutting a real `12.x` version later is still one `git add -f versioned_docs/version-11.x` away if v12 ever diverges.

## Install paths, in order

1. **`pnpm self-update next-12`** — leads the section. Anyone already on pnpm 11.10.0+ needs nothing else, and it's already documented at `docs/cli/self-update.md:42`.
2. **npm**, for people without pnpm.
3. **The standalone script**, for people without Node.js.

## Verified against pnpm 12.0.0-beta.2

Every claim below was checked against the published artifacts, not inferred:

- **`pnpm self-update next-12` works** — ran it against an isolated `PNPM_HOME` from pnpm 11.18.0; it linked the native binary and the result runs.
- **npm needs `--allow-scripts=pnpm`.** The published package is a wrapper whose `preinstall` script swaps in the native binary from `@pnpm/exe.<platform>`. npm 12 blocks install scripts by default, so a plain `npm install -g pnpm@next-12` silently leaves the placeholder and `pnpm` fails with a shell syntax error. The flag is accepted (and harmless) on npm 11 too, so one command covers both.
- **The standalone script needs an exact `PNPM_VERSION`.** `install.sh` interpolates it straight into the GitHub release URL, so a dist-tag like `next-12` would 404. (`install.ps1` does resolve dist-tags, but documenting the exact version keeps both platforms identical.)
- **Corepack cannot install v12.** It looks for `bin/pnpm.mjs`, which the native package doesn't ship — it fails with `MODULE_NOT_FOUND`. Documented as a known limitation.
- **Intel macOS works again on v12** (`pnpm-darwin-x64.tar.gz` is in the release, and get.pnpm.io's abort is already `major_version -eq 11`), so the existing `darwin-x64` warnings are now scoped to v11.
- **`pnpm` and `@pnpm/exe` are identical on v12** — same bins, same optional deps — so the v11-only distinction is labelled as such.

## Also

- Compatibility table gains a `pnpm 12` column (`engines: node >=18`), with a note that Node.js is only needed to *install* from npm, not to run pnpm.
- `/12.x/*` → `/*` redirect for guessed URLs, deliberately non-permanent so it can be dropped if `12.x` ever becomes a real docs version.

`LOCALE_CI=en docusaurus build` passes; the new anchors resolve and `/installation` is absent from the (pre-existing) broken-anchor list.

## Open questions

- **Translated locales may keep showing "11.x"** until Crowdin picks up the new label. Version labels are translatable (`i18n/<locale>/docusaurus-plugin-content-docs/version-11.x.json`), and existing entries hold the old string. I couldn't verify this locally — there's no `i18n/` checkout here — so it's worth a look after the next `crowdin:sync`.
- In my test, `pnpm self-update next-12` installed **12.0.0-beta.0**, not the `next-12` tag's current 12.0.0-beta.2 — the release-age cooldown resolving to the newest eligible version. Expected behavior, and `docs/cli/self-update.md` covers `minimumReleaseAge`, but it may surprise beta testers. Say the word if you want a note about it on the page.
- `12.0.0-beta.2` is hardcoded in the standalone-script commands and will need bumping each beta, as was done for the v11 RCs in 99943f97.
- The **"Linux runtime requirements"** note (glibc 2.27+, `libatomic.so.1`) is left untouched — it was written for the v11 Node SEA build and I couldn't confirm what the Rust binary actually needs. Worth a follow-up if the requirements changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
