### PR TITLE
fix(docs): fixed docker example 3

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -213,8 +213,8 @@ RUN corepack enable
 
 FROM base AS prod
 
-COPY pnpm-lock.yaml /app
 WORKDIR /app
+COPY pnpm-lock.yaml /app
 RUN pnpm fetch --prod
 
 COPY . /app


### PR DESCRIPTION
In the example 3, `COPY pnpm-lock.yaml /app` was made before the dir `/app` was created by `WORKDIR /app`

This fixes it by having the `WORKDIR /app` before the `COPY`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the CI/CD Dockerfile example to set the working directory before copying the lockfile, with no change to the resulting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->