### PR TITLE
docs: document pnpm 11.20

### DIFF
--- a/blog/releases/11.20.md
+++ b/blog/releases/11.20.md
@@ -13,13 +13,13 @@ pnpm 11.20 fixes a package-substitution risk in projects that install from more 
 
 ### Named registries are recorded in the lockfile
 
-**Security fix.** This affects projects using [`namedRegistries`](/settings/dependency-resolution#namedregistries) on pnpm 11.1.0–11.19.x, and is semi-breaking for them — see "If you use named registries" below.
+**Security fix.** This affects projects that install through a [named registry](/settings/dependency-resolution#namedregistries) alias on pnpm 11.1.0–11.19.x — an alias you configured under `namedRegistries`, or the built-in `gh:`, which needs no configuration. It is semi-breaking for them; see "If you use named registries" below.
 
 The lockfile recorded no marker for which registry a package came from. Packages were keyed by `name@version` alone, so when two registries served the same name and version, both collapsed onto a single `packages:` entry and whichever resolved first decided the tarball that every consumer got. A package you expect from your private registry could be installed from a different registry that publishes the same name and version, with nothing in the lockfile to reveal it.
 
 Packages resolved from a named registry are now recorded under registry-qualified keys — `<name>@<registryName>:<version>`, e.g. `foo@work:1.0.0` — so each registry gets its own entry and the lockfile pins which one a dependency came from.
 
-The lockfile format version is unchanged. Registry-qualified keys appear only for packages resolved from a named registry, so a project that does not use `namedRegistries` sees no difference, and older pnpm versions keep reading the file.
+The lockfile format version is unchanged. Registry-qualified keys appear only for packages resolved from a named registry, so a project that installs nothing through an alias sees no difference, and older pnpm versions keep reading the file.
 
 Two related changes come with it:
 

--- a/blog/releases/11.20.md
+++ b/blog/releases/11.20.md
@@ -1,0 +1,70 @@
+---
+title: pnpm 11.20
+authors: zkochan
+tags: [release]
+date: 2026-08-03
+---
+
+pnpm 11.20 fixes a package-substitution risk in projects that install from more than one registry: packages resolved from a [named registry](/settings/dependency-resolution#namedregistries) are now recorded in the lockfile under registry-qualified keys. It also adds a built-in `npmjs:` alias, stops empty proxy settings from failing installs, hardens `pnpm rebuild` against a malicious lockfile, and speeds up dependency resolution.
+
+<!-- truncate -->
+
+## Minor Changes
+
+### Named registries are recorded in the lockfile
+
+**Security fix.** This affects projects using [`namedRegistries`](/settings/dependency-resolution#namedregistries) on pnpm 11.1.0–11.19.x, and is semi-breaking for them — see "If you use named registries" below.
+
+The lockfile recorded no marker for which registry a package came from. Packages were keyed by `name@version` alone, so when two registries served the same name and version, both collapsed onto a single `packages:` entry and whichever resolved first decided the tarball that every consumer got. A package you expect from your private registry could be installed from a different registry that publishes the same name and version, with nothing in the lockfile to reveal it.
+
+Packages resolved from a named registry are now recorded under registry-qualified keys — `<name>@<registryName>:<version>`, e.g. `foo@work:1.0.0` — so each registry gets its own entry and the lockfile pins which one a dependency came from.
+
+The lockfile format version is unchanged. Registry-qualified keys appear only for packages resolved from a named registry, so a project that does not use `namedRegistries` sees no difference, and older pnpm versions keep reading the file.
+
+Two related changes come with it:
+
+- Every alias the lockfile references must stay in `namedRegistries`. Reading an entry whose alias is gone fails with `ERR_PNPM_MISSING_NAMED_REGISTRY` rather than silently falling back to the default registry, since that would fetch a different package. Renaming an alias re-resolves the packages that used it.
+- An alias that shadows a reserved dependency specifier prefix (`file`, `link`, `workspace`, `runtime`, `npm`, `jsr`, ...) is now rejected with `ERR_PNPM_RESERVED_NAMED_REGISTRY_NAME` instead of being silently shadowed by the corresponding resolver.
+
+Tarball URLs that follow the standard registry layout are no longer written to the lockfile for named-registry packages; they are recomputed from `namedRegistries` on demand.
+
+[`pnpm licenses`](/cli/licenses) and [`pnpm sbom`](/cli/sbom) keep the two artifacts apart as well: license records carry the registry alias, and SBOM components carry the purl `repository_url` qualifier.
+
+#### If you use named registries
+
+Your next non-frozen install re-keys those entries, which shows up as a lockfile diff. Commit it — that diff is the fix being applied. Review it: an entry that moves to a registry you did not expect is worth investigating.
+
+Everyone working on the project should be on this version or newer before you do. An older pnpm reads the re-keyed lockfile fine — frozen installs are unaffected — but it does not produce registry-qualified keys itself, so any install that updates the lockfile writes those entries back to the old shape, and the next install on a current pnpm re-qualifies them. The result is a lockfile that flips back and forth, and while it is in the old shape the project is exposed again. Because the lockfile format version is deliberately unchanged, pnpm cannot detect this and warn you about it.
+
+There is no setting to keep the old behavior: the old shape is the vulnerability.
+
+### The built-in `npmjs:` alias
+
+`npmjs:` now resolves to `https://registry.npmjs.org/` with no configuration, alongside the existing `gh:` alias for GitHub Packages. It pins a dependency to the public registry even when `registry` points elsewhere, such as an internal proxy:
+
+```json title="package.json"
+{
+  "dependencies": {
+    "left-pad": "npmjs:^1.3.0"
+  }
+}
+```
+
+`npm:` cannot do this — it is the alias protocol (`npm:<name>@<range>`) and resolves through whatever `registry` points at.
+
+If you mirror or proxy npmjs, point the alias at your mirror:
+
+```yaml title="pnpm-workspace.yaml"
+namedRegistries:
+  npmjs: https://npm.internal.example.com/
+```
+
+Built-in registry URLs are also the prefixes a lockfile's recorded tarball URL is matched against when pnpm verifies a package. Without the override, an entry whose tarball URL is on `registry.npmjs.org` is verified against the public registry rather than your mirror. This only affects lockfiles that record such URLs — a canonical URL for your configured registry is omitted from the lockfile and unaffected — and only when a tarball-URL, `minimumReleaseAge`, or `trustPolicy` check runs. Overriding the alias is the same escape hatch GHES users already have for `gh`.
+
+## Patch Changes
+
+- An empty [`http-proxy`](/settings/network#httpproxy), [`https-proxy`](/settings/network#httpsproxy), `proxy`, or [`no-proxy`](/settings/network#noproxy) value — from the `.npmrc`, `pnpm-workspace.yaml`, the CLI, or the `HTTP_PROXY` / `HTTPS_PROXY` / `PROXY` / `NO_PROXY` environment variables — no longer fails the install with `ERR_PNPM_INVALID_PROXY`. Empty settings read as unset, so a shell exporting `HTTP_PROXY=` disables the proxy, and an empty `proxy=` in the `.npmrc` no longer suppresses `HTTPS_PROXY` ([#13533](https://github.com/pnpm/pnpm/issues/13533)). `proxy=false` in the `.npmrc` or `proxy: false` in `pnpm-workspace.yaml` now turns proxying off instead of being read as a proxy host named `false`.
+- **Security:** [`pnpm rebuild`](/cli/rebuild) now refuses a lockfile whose `packages` key carries a path traversal in the package name (e.g. `../../../escaped@1.0.0`), instead of running that package's lifecycle scripts and linking its bins in a directory outside the virtual store. Such a name is rejected with `ERR_PNPM_INVALID_DEPENDENCY_NAME`.
+- The env lockfile no longer pins `@pnpm/exe` alongside `pnpm` when the wanted pnpm version is 12 or newer. From v12 the unscoped `pnpm` package is itself the native executable, so `@pnpm/exe` is not published for it and resolving it would fail.
+- Fixed the order in which pnpm matches a lockfile's recorded tarball URL against known registry URLs. Two registry URLs of equal length were previously ordered arbitrarily, so which one a tarball URL matched could differ between runs.
+- Dependency resolution is faster: package metadata is now filtered once per packument instead of once per dependency edge when `minimumReleaseAge` is active, and parsed semver versions and ranges are reused instead of re-parsed on every comparison.

--- a/docs/cli/licenses.md
+++ b/docs/cli/licenses.md
@@ -11,6 +11,8 @@ Aliases: `ls`
 
 List licenses for installed packages.
 
+Since v11.20.0, a package resolved from a [named registry](../settings/dependency-resolution.md#namedregistries) is reported separately from a package of the same name and version that came from another registry. The registry alias is shown next to the package name in the table output and is exposed as the `registryName` field with `--json`.
+
 ## Options
 
 ### --dev, -D

--- a/docs/cli/sbom.md
+++ b/docs/cli/sbom.md
@@ -26,6 +26,8 @@ pnpm sbom --sbom-format cyclonedx --exclude-peers
 
 Inside a workspace, `pnpm sbom` supports filtering. When a single workspace package is selected, the root component in the SBOM uses that package's metadata.
 
+Since v11.20.0, a component resolved from a [named registry](../settings/dependency-resolution.md#namedregistries) carries the purl `repository_url` qualifier (for example `pkg:npm/foo@1.0.0?repository_url=https%3A%2F%2Fnpm.work.example.com%2F`), so the same name and version served by two registries does not collapse onto one component. Credentials that a `namedRegistries` URL may embed — userinfo or a query string — are stripped from the qualifier, while the origin and path are kept, since two registries can differ only by path.
+
 CycloneDX output marks components reachable only through `devDependencies` with `scope: "excluded"` and the `cdx:npm:package:development` property. Runtime components, including installed optional dependencies, use the default required scope.
 
 ## Options

--- a/docs/package-sources.md
+++ b/docs/package-sources.md
@@ -42,6 +42,20 @@ pnpm add jsr:@hono/hono@latest
 
 This works just like installing from npm, but tells pnpm to resolve the package through JSR instead.
 
+### Named registries
+
+Added in: v11.1.0
+
+A [named registry](./settings/dependency-resolution.md#namedregistries) alias resolves a package against a specific registry, regardless of the default one:
+
+```
+pnpm add work:@corp/lib@^2.0.0
+pnpm add gh:@my-org/private-pkg
+pnpm add npmjs:left-pad
+```
+
+`gh:` (GitHub Packages) and, since v11.20.0, `npmjs:` (the public npm registry) work without configuration. Any other alias must be mapped under [`namedRegistries`](./settings/dependency-resolution.md#namedregistries) in `pnpm-workspace.yaml`.
+
 ### Workspace
 
 Note that when adding dependencies and working within a [workspace], packages

--- a/docs/package-sources.md
+++ b/docs/package-sources.md
@@ -48,13 +48,13 @@ Added in: v11.1.0
 
 A [named registry](./settings/dependency-resolution.md#namedregistries) alias resolves a package against a specific registry, regardless of the default one:
 
-```
+```sh
 pnpm add work:@corp/lib@^2.0.0
 pnpm add gh:@my-org/private-pkg
 pnpm add npmjs:left-pad
 ```
 
-`gh:` (GitHub Packages) and, since v11.20.0, `npmjs:` (the public npm registry) work without configuration. Any other alias must be mapped under [`namedRegistries`](./settings/dependency-resolution.md#namedregistries) in `pnpm-workspace.yaml`.
+`gh:` (GitHub Packages) and, since v11.20.0, `npmjs:` (the public npm registry) work without configuration. Any other alias must be mapped under [`namedRegistries`](./settings/dependency-resolution.md#namedregistries) in `pnpm-workspace.yaml` or, since v11.11.0, in the [global configuration file](./cli/config.md) (`config.yaml`).
 
 ### Workspace
 

--- a/docs/settings/dependency-resolution.md
+++ b/docs/settings/dependency-resolution.md
@@ -481,11 +481,11 @@ packages:
 
 Before v11.20.0, packages were keyed by `name@version` alone, so the same name and version served by two registries collapsed onto a single entry and whichever resolved first decided the tarball that every consumer got. That is a package-substitution risk: a package you expect from your private registry could be installed from another registry that publishes the same name and version, with nothing in the lockfile to reveal it. Registry-qualified keys give each registry its own entry and pin which one a dependency came from.
 
-The lockfile format version is unchanged, and qualified keys appear only for packages resolved from a named registry. A project that does not use `namedRegistries` sees no difference, and older pnpm versions keep reading the file.
+The lockfile format version is unchanged, and qualified keys appear only for packages resolved from a named registry — including the built-in `gh:` and `npmjs:` aliases, which need no `namedRegistries` entry. A project that installs nothing through an alias sees no difference, and older pnpm versions keep reading the file.
 
 :::caution
 
-If you use named registries, your first non-frozen install on v11.20.0 or newer re-keys those entries, which shows up as a lockfile diff. Commit it — that diff is the fix being applied. Review it too: an entry that moves to a registry you did not expect is worth investigating.
+If any dependency is installed through an alias, your first non-frozen install on v11.20.0 or newer re-keys those entries, which shows up as a lockfile diff. Commit it — that diff is the fix being applied. Review it too: an entry that moves to a registry you did not expect is worth investigating.
 
 Have everyone working on the project move to v11.20.0 or newer first. An older pnpm reads the re-keyed lockfile fine, and frozen installs are unaffected, but it does not produce registry-qualified keys itself: any install that updates the lockfile writes those entries back to the old shape, and the next install on a current pnpm re-qualifies them. The lockfile then flips back and forth, and while it is in the old shape the project is exposed again. Because the lockfile format version is deliberately unchanged, pnpm cannot detect this and warn you.
 

--- a/docs/settings/dependency-resolution.md
+++ b/docs/settings/dependency-resolution.md
@@ -430,8 +430,69 @@ namedRegistries:
 
 `pnpm add work:@corp/lib@^2.0.0` resolves `@corp/lib@^2.0.0` against `https://npm.work.example.com/`.
 
-The `gh:` alias is built in and points at the [GitHub Packages npm registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-npm-registry) (`https://npm.pkg.github.com/`) by default. Override it under `namedRegistries` for GitHub Enterprise Server.
-
 Authentication is picked up from the existing per-URL `.npmrc` entries (e.g. `//npm.pkg.github.com/:_authToken=...`), so no separate auth mechanism is required.
 
 Since v11.11.0, this setting may also be defined in the [global configuration file](../cli/config.md) (`config.yaml`), so an alias like `work:` can be shared across every project on the machine.
+
+#### Built-in aliases
+
+Two aliases work without any configuration:
+
+| Alias    | Registry                      | Notes                                                                                                                                         |
+|----------|-------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
+| `gh:`    | `https://npm.pkg.github.com/` | The [GitHub Packages npm registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-npm-registry). |
+| `npmjs:` | `https://registry.npmjs.org/` | The public npm registry. Added in v11.20.0.                                                                                                   |
+
+Entries you define under `namedRegistries` are merged on top of these, so either one can be overridden — GitHub Enterprise Server users point `gh` at their own host, and an organization that mirrors or proxies npmjs should point `npmjs` at the mirror:
+
+```yaml title="pnpm-workspace.yaml"
+namedRegistries:
+  gh: https://npm.pkg.github.example.com/
+  npmjs: https://npm.internal.example.com/
+```
+
+`npmjs:` pins a dependency to the public registry even when the default [`registry`](#registries) points somewhere else, such as an internal proxy:
+
+```json title="package.json"
+{
+  "dependencies": {
+    "left-pad": "npmjs:^1.3.0"
+  }
+}
+```
+
+The `npm:` prefix cannot do this — it is the [alias protocol](../aliases.md) (`npm:<name>@<range>`) and resolves through whatever `registry` points at.
+
+The built-in URLs are also the prefixes that a tarball URL recorded in the lockfile is matched against when pnpm verifies a package. If you proxy npmjs and do not override the alias, an entry whose tarball URL is on `registry.npmjs.org` is verified against the public registry rather than against your mirror. This only affects lockfiles that record such a URL — a canonical URL for your configured registry is omitted from the lockfile — and only when a tarball-URL, [`minimumReleaseAge`](#minimumreleaseage), or [`trustPolicy`](#trustpolicy) check runs.
+
+#### Reserved alias names
+
+Since v11.20.0, an alias that shadows a reserved dependency specifier prefix (`file`, `link`, `workspace`, `runtime`, `npm`, `jsr`, `git`, `github`, `gitlab`, `bitbucket`, `catalog`, `custom`, `http`, `https`, `ssh`) is rejected with `ERR_PNPM_RESERVED_NAMED_REGISTRY_NAME`. Previously such an alias was silently shadowed by the corresponding resolver. An alias must also start with a letter and contain only letters, digits, `.`, `_`, and `-`.
+
+#### Named registries in the lockfile
+
+Since v11.20.0, a package resolved from a named registry is recorded in `pnpm-lock.yaml` under a registry-qualified key, `<name>@<registryName>:<version>`:
+
+```yaml title="pnpm-lock.yaml"
+packages:
+  foo@work:1.0.0:
+    resolution: {integrity: sha512-...}
+```
+
+Before v11.20.0, packages were keyed by `name@version` alone, so the same name and version served by two registries collapsed onto a single entry and whichever resolved first decided the tarball that every consumer got. That is a package-substitution risk: a package you expect from your private registry could be installed from another registry that publishes the same name and version, with nothing in the lockfile to reveal it. Registry-qualified keys give each registry its own entry and pin which one a dependency came from.
+
+The lockfile format version is unchanged, and qualified keys appear only for packages resolved from a named registry. A project that does not use `namedRegistries` sees no difference, and older pnpm versions keep reading the file.
+
+:::caution
+
+If you use named registries, your first non-frozen install on v11.20.0 or newer re-keys those entries, which shows up as a lockfile diff. Commit it — that diff is the fix being applied. Review it too: an entry that moves to a registry you did not expect is worth investigating.
+
+Have everyone working on the project move to v11.20.0 or newer first. An older pnpm reads the re-keyed lockfile fine, and frozen installs are unaffected, but it does not produce registry-qualified keys itself: any install that updates the lockfile writes those entries back to the old shape, and the next install on a current pnpm re-qualifies them. The lockfile then flips back and forth, and while it is in the old shape the project is exposed again. Because the lockfile format version is deliberately unchanged, pnpm cannot detect this and warn you.
+
+There is no setting to keep the old behavior — the old shape is the vulnerability.
+
+:::
+
+Every alias that the lockfile references must stay in `namedRegistries`. Reading an entry whose alias is gone fails with `ERR_PNPM_MISSING_NAMED_REGISTRY` rather than falling back to the default registry, since that would fetch a different package. Renaming an alias re-resolves the packages that used it.
+
+Tarball URLs that follow the standard registry layout are no longer written to the lockfile for named-registry packages; they are recomputed from `namedRegistries` on demand.

--- a/docs/settings/network.md
+++ b/docs/settings/network.md
@@ -24,6 +24,8 @@ httpsProxy: "https://use%21r:pas%2As@my.proxy:1234/foo"
 
 Do not encode the colon (`:`) between the username and password.
 
+Since v11.20.0, an empty value reads as unset instead of failing the install with `ERR_PNPM_INVALID_PROXY`, so a shell that exports `HTTPS_PROXY=` simply disables the proxy. Setting the value to `false` or `null` in `pnpm-workspace.yaml` or the `.npmrc` also turns proxying off. On the command line, `false` and `null` are ordinary host names, since a flag carries its value verbatim.
+
 ### httpProxy
 
 * Default: **null**
@@ -33,12 +35,18 @@ A proxy to use for outgoing HTTP requests. If the `HTTP_PROXY` or `http_proxy`
 environment variables are set, proxy settings will be honored by the underlying
 request library.
 
+Empty, `false`, and `null` values behave as described for [`httpsProxy`](#httpsproxy).
+
+The `.npmrc` also supports npm's legacy `proxy` setting, which is used as the fallback for both `https-proxy` and `http-proxy`. Since v11.20.0, an empty `proxy=` reads as unset and therefore no longer suppresses the `HTTPS_PROXY` environment variable, and `proxy=false` (or `proxy: false` in `pnpm-workspace.yaml`) turns proxying off instead of being read as a proxy host named `false` ([#13533](https://github.com/pnpm/pnpm/issues/13533)).
+
 ### noProxy
 
 * Default: **null**
 * Type: **String**
 
 A comma-separated string of domain extensions that a proxy should not be used for.
+
+Empty, `false`, and `null` values behave as described for [`httpsProxy`](#httpsproxy).
 
 ### localAddress
 

--- a/docs/supply-chain-security.md
+++ b/docs/supply-chain-security.md
@@ -29,6 +29,10 @@ Additionally, the [trustPolicyIgnoreAfter] setting allows you to ignore trust ch
 
 It goes without saying that you should always lock your dependencies with a lockfile. Commit your lockfile to your repository to avoid unexpected updates.
 
+### Pin dependencies to the registry they come from
+
+If you install from more than one registry, use [namedRegistries] aliases for the packages that must come from a specific one. Since v11.20.0, pnpm records those packages in the lockfile under registry-qualified keys (`<name>@<registryName>:<version>`), so a package cannot be quietly substituted by another registry that publishes the same name and version. See [Named registries in the lockfile]. Packages installed without an alias are resolved through the default [registries] configuration as before.
+
 [Socket]: https://socket.dev/
 [Snyk]: https://snyk.io
 [Xygeni]: https://xygeni.io/
@@ -41,3 +45,6 @@ It goes without saying that you should always lock your dependencies with a lock
 [allowBuilds]: settings/build.md#allowbuilds
 [blockExoticSubdeps]: settings/dependency-resolution.md#blockexoticsubdeps
 [trustPolicyIgnoreAfter]: settings/dependency-resolution.md#trustpolicyignoreafter
+[namedRegistries]: settings/dependency-resolution.md#namedregistries
+[registries]: settings/dependency-resolution.md#registries
+[Named registries in the lockfile]: settings/dependency-resolution.md#named-registries-in-the-lockfile


### PR DESCRIPTION
Documents the changes released in pnpm v11.20.0.

## Docs

- **`namedRegistries`** ([settings/dependency-resolution](https://pnpm.io/settings/dependency-resolution#namedregistries)) gains three subsections:
  - *Built-in aliases* — `gh:` plus the new `npmjs:`, how user entries override them, why `npm:` cannot pin to the public registry, and the tarball-URL-prefix consequence for orgs that mirror npmjs.
  - *Reserved alias names* — `ERR_PNPM_RESERVED_NAMED_REGISTRY_NAME` and the reserved prefix list.
  - *Named registries in the lockfile* — registry-qualified keys (`foo@work:1.0.0`), the package-substitution risk they fix, the unchanged lockfile format version, a caution covering the migration (commit the diff, get everyone onto v11.20+ first, no opt-out), and `ERR_PNPM_MISSING_NAMED_REGISTRY`.
- **Network settings** — empty / `false` / `null` proxy values now read as unset instead of failing with `ERR_PNPM_INVALID_PROXY`; CLI values stay verbatim; the legacy `.npmrc` `proxy` fallback (#13533).
- **`pnpm licenses`** — packages are reported per registry; alias shown in the table and as `registryName` with `--json`.
- **`pnpm sbom`** — purl `repository_url` qualifier, including what is stripped from the URL.
- **Supported package sources** — new "Named registries" trusted-source section.
- **Mitigating supply chain attacks** — new section on pinning dependencies to the registry they come from.

## Blog

Adds `blog/releases/11.20.md`, covering the named-registry security fix, the `npmjs:` alias, and the patch changes (proxy handling, `pnpm rebuild` path-traversal rejection, the `@pnpm/exe` env-lockfile fix, tarball-URL match ordering, and the resolution speedups).

Verified against the v11.20.0 release commit and the pnpm source. `pnpm build` passes; the only broken link it reports is the pre-existing `/cli/pn` in the 11.0 release post.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added registry-qualified lockfile entries, built-in `gh:` and `npmjs:` aliases, and improved deterministic tarball matching.
  * Improved license and SBOM reporting for packages from named registries.
  * Enhanced proxy handling, dependency-resolution performance, and environment lockfile support for pnpm 12+.
  * Added clearer validation for missing or reserved registry aliases.

* **Security**
  * Strengthened `pnpm rebuild` protections and guidance for pinning dependencies to their source registry.

* **Documentation**
  * Expanded guidance for named registries, lockfile migrations, package sources, proxy settings, licenses, and SBOM output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->