### PR TITLE
docs: use pnpm/setup in the GitHub Actions examples

### DIFF
--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -148,18 +148,20 @@ jobs:
         node-version: [24]
     steps:
       - uses: actions/checkout@v6
-      - name: Install pnpm
-        uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
+      - name: Install pnpm and Node.js
+        uses: pnpm/setup@c9883cc79df532ad1a7b81bf9ab944ceb090d65c # v2.0.0
         with:
           version: 11
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v6
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: "pnpm"
-      - name: Install dependencies
-        run: pnpm install
+          runtime: node@${{ matrix.node-version }}
+          cache: true
 ```
+
+[`pnpm/setup`][pnpm-setup] installs pnpm, then uses it to install the requested
+runtime, so no separate `actions/setup-node` step is needed. It also runs `pnpm
+install` for you, and `cache: true` caches the pnpm store between runs. Set
+`install: false` if you would rather run the install yourself.
+
+[pnpm-setup]: https://github.com/pnpm/setup
 
 ## GitLab CI
 

--- a/docs/using-changesets.md
+++ b/docs/using-changesets.md
@@ -91,17 +91,12 @@ jobs:
       - name: Checkout code repository
         uses: actions/checkout@v4
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Setup node.js
-        uses: actions/setup-node@v4
+      - name: Setup pnpm and node.js
+        uses: pnpm/setup@v2
         with:
-          node-version: 20
-          cache: 'pnpm'
-      
-      - name: Install dependencies
-        run: pnpm install
+          version: 11
+          runtime: node@20
+          cache: true
       
       - name: Create and publish versions
         uses: changesets/action@v1

--- a/docs/using-changesets.md
+++ b/docs/using-changesets.md
@@ -91,7 +91,7 @@ jobs:
       - name: Checkout code repository
         uses: actions/checkout@v4
 
-      - name: Setup pnpm and node.js
+      - name: Setup pnpm and Node.js
         uses: pnpm/setup@v2
         with:
           version: 11


### PR DESCRIPTION
Switches the GitHub Actions examples from `pnpm/action-setup` to [`pnpm/setup`](https://github.com/pnpm/setup), released as v2.0.0.

`pnpm/setup` installs pnpm *and* a JavaScript runtime in a single step, so each example collapses:

- `actions/setup-node` is no longer needed — `runtime: node@<version>` covers it.
- `cache: true` replaces setup-node's `cache: "pnpm"`.
- The explicit `pnpm install` step goes away; the action runs it when a `package.json` is present. `install: false` opts out, which the surrounding prose in `continuous-integration.md` now mentions.

The `continuous-integration.md` example keeps the commit-SHA pin it already used, now `c9883cc79df532ad1a7b81bf9ab944ceb090d65c # v2.0.0`. `using-changesets.md` keeps its floating tag (`@v2`), matching the `@v4` it used before.

Both files are edited only in `docs/`, which `pnpm copy-docs` copies to `versioned_docs/version-11.x`, so this covers the v11 and v12 docs in one change.

`versioned_docs/version-10.x` deliberately keeps `pnpm/action-setup`: `pnpm/setup` installs pnpm 11 or newer only, since it relies on pnpm's self-contained release binaries and the `pnpm runtime` command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated GitHub Actions examples to use a combined pnpm setup step.
  - Added automatic Node.js provisioning, dependency installation, and pnpm store caching.
  - Documented how to disable automatic dependency installation.
  - Simplified setup guidance for Changesets workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->