### PR TITLE
docs: read the pnpm version from package.json in the CI examples

### DIFF
--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -151,7 +151,6 @@ jobs:
       - name: Install pnpm and Node.js
         uses: pnpm/setup@c9883cc79df532ad1a7b81bf9ab944ceb090d65c # v2.0.0
         with:
-          version: 11
           runtime: node@${{ matrix.node-version }}
           cache: true
 ```
@@ -160,6 +159,10 @@ jobs:
 runtime, so no separate `actions/setup-node` step is needed. It also runs `pnpm
 install` for you, and `cache: true` caches the pnpm store between runs. Set
 `install: false` if you would rather run the install yourself.
+
+The pnpm version comes from the `packageManager` or `devEngines.packageManager`
+field of your `package.json`, so the workflow never needs updating when you
+change it. Add a `version` input if your `package.json` declares neither.
 
 [pnpm-setup]: https://github.com/pnpm/setup
 

--- a/docs/using-changesets.md
+++ b/docs/using-changesets.md
@@ -94,7 +94,6 @@ jobs:
       - name: Setup pnpm and Node.js
         uses: pnpm/setup@v2
         with:
-          version: 11
           runtime: node@20
           cache: true
       


### PR DESCRIPTION
Follow-up to #854. Drops the `version: 11` input from both `pnpm/setup` examples.

`pnpm/setup` resolves the version from `packageManager` or `devEngines.packageManager` when `version` is omitted, so the workflow no longer states a pnpm version that has to be kept in sync with the project's own — one fewer place to bump, and no way for the two to disagree.

`continuous-integration.md` gains a sentence saying where the version comes from, and noting that a `version` input is still needed if `package.json` declares neither field — otherwise the action fails with "No pnpm version is specified".

Note this makes the example differ from the corepack snippets elsewhere on the page, which do pin (`corepack prepare pnpm@latest-11`). That is inherent to the mechanism: corepack is told a version, `pnpm/setup` reads the one the project already declares.

🤖 Generated with [Claude Code](https://claude.com/claude-code)