### PR TITLE
docs: document `frozenLockfile` setting

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -184,6 +184,7 @@ Every setting is listed below, grouped by topic. Follow a setting to read its do
 [Full reference →](./settings/store.md#lockfile-settings)
 
 * [lockfile](./settings/store.md#lockfile)
+* [frozenLockfile](./settings/store.md#frozenlockfile)
 * [preferFrozenLockfile](./settings/store.md#preferfrozenlockfile)
 * [lockfileIncludeTarballUrl](./settings/store.md#lockfileincludetarballurl)
 * [gitBranchLockfile](./settings/store.md#gitbranchlockfile)

--- a/docs/settings/store.md
+++ b/docs/settings/store.md
@@ -100,6 +100,19 @@ The read-only store open requires Node.js >=22.15.0, >=23.11.0, or >=24.0.0. On 
 
 When set to `false`, pnpm won't read or generate a `pnpm-lock.yaml` file.
 
+### frozenLockfile
+
+* Default:
+  * For non-CI: **false**
+  * For CI: **true**, if a lockfile is present
+* Type: **Boolean**
+
+When set to `true` and the available `pnpm-lock.yaml` does not satisfy the
+`package.json` dependencies directive, or no lockfile is present, the
+installation will fail.
+
+This setting is `true` by default in [CI environments](../cli/install.md#--frozen-lockfile).
+
 ### preferFrozenLockfile
 
 * Default: **true**


### PR DESCRIPTION
Closes https://github.com/pnpm/pnpm/issues/13643

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added `frozenLockfile` to the lockfile settings overview.
  * Documented default behavior across CI and non-CI environments.
  * Clarified when installation fails due to a missing or out-of-date lockfile.
  * Explained how the setting relates to CI behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->