### PR TITLE
docs: update install instructions

### DIFF
--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -30,9 +30,13 @@ show it for each one.
 
 :::note
 
-Earlier versions of this page used Corepack. Corepack cannot install pnpm 12: it
-expects the package to contain a `bin/pnpm.mjs`, which the native pnpm 12 package
-does not have.
+Earlier versions of this page used Corepack. Corepack installs a JavaScript shim
+in place of pnpm, so every `pnpm` call starts Node.js to run the shim before pnpm
+itself starts — a cost paid on each invocation, and CI jobs make many of them.
+Installing pnpm itself avoids that entirely.
+
+Corepack also cannot install pnpm 12: it expects the package to contain a
+`bin/pnpm.mjs`, which the native pnpm 12 package does not have.
 
 :::
 

--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -125,10 +125,11 @@ pipelines:
           name: Build and test
           image: debian:stable-slim
           script:
-            - apt-get update && apt-get install -y --no-install-recommends ca-certificates curl
+            - apt-get update && apt-get install -y --no-install-recommends ca-certificates curl libatomic1 libstdc++6
             - export PNPM_HOME="$HOME/.local/share/pnpm"
             - export PATH="$PNPM_HOME/bin:$PATH"
             - curl -fsSL https://get.pnpm.io/install.sh | sh -
+            - pnpm config set store-dir "$BITBUCKET_CLONE_DIR/.pnpm-store"
             - pnpm runtime set node lts -g
             - pnpm install
             - pnpm run build # Replace with your build/test…etc. commands
@@ -137,9 +138,14 @@ pipelines:
 ```
 
 All the lines of a step run in one shell, so `export` carries to the ones that
-follow. This example installs Node.js with pnpm rather than starting from a
-`node` image; keep your existing image and drop the `pnpm runtime set` line if
-you would rather not.
+follow, and `store-dir` is pointed at the directory the cache saves.
+
+This example starts from a plain image and lets pnpm install Node.js. A minimal
+image needs the libraries the pnpm 11 executable links against — `libatomic1`
+and `libstdc++6` — which images like `node:24` already carry; see [Linux runtime
+requirements](./installation.md#on-posix-systems). pnpm 12 is statically linked
+and needs neither. Keep your existing `node` image and drop the `apt-get` and
+`pnpm runtime set` lines if you would rather not change it.
 
 ## CircleCI
 

--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -5,6 +5,37 @@ title: Continuous Integration
 
 pnpm can easily be used in various continuous integration systems.
 
+## Installing pnpm
+
+Outside of GitHub Actions, which has [its own action](#github-actions), install pnpm
+with the standalone script:
+
+```sh
+curl -fsSL https://get.pnpm.io/install.sh | sh -
+```
+
+Two things make this convenient in CI:
+
+- **It needs no Node.js.** pnpm is a self-contained executable, and it can install
+  the runtime for you afterwards with `pnpm runtime set node lts -g`, so a job
+  does not need a Node.js image to begin with.
+- **It picks its own version.** If your `package.json` has a `packageManager` or
+  `devEngines.packageManager` field, pnpm switches to that version on first use,
+  so the pipeline does not pin a version in two places.
+
+The script installs into `PNPM_HOME` and appends to a shell profile, which a CI
+job never reloads. Declare `PNPM_HOME` and put `$PNPM_HOME/bin` on `PATH`
+yourself, using whatever mechanism the platform provides — the examples below
+show it for each one.
+
+:::note
+
+Earlier versions of this page used Corepack. Corepack cannot install pnpm 12: it
+expects the package to contain a `bin/pnpm.mjs`, which the native pnpm 12 package
+does not have.
+
+:::
+
 :::note
 
 In all the provided configuration files the store is cached. However, this is not required, and it is not guaranteed that caching the store will make installation faster. So feel free to not cache the pnpm store in your job.
@@ -29,13 +60,17 @@ On [AppVeyor], you can use pnpm for installing your dependencies by adding this
 to your `appveyor.yml`:
 
 ```yaml title="appveyor.yml"
+environment:
+  PNPM_HOME: C:\pnpm
+
 install:
-  - ps: Install-Product node $env:nodejs_version
-  - npm install --global corepack@latest
-  - corepack enable
-  - corepack prepare pnpm@latest-11 --activate
-  - pnpm install
+  - ps: $env:PATH = "$env:PNPM_HOME;$env:PNPM_HOME\bin;$env:PATH"
+  - ps: Invoke-WebRequest https://get.pnpm.io/install.ps1 -UseBasicParsing | Invoke-Expression
+  - ps: pnpm install
 ```
+
+pnpm brings its own runtime, so `Install-Product node` is no longer needed. Add
+`pnpm runtime set node lts -g` if your build scripts call `node` directly.
 
 [AppVeyor]: https://www.appveyor.com
 
@@ -46,6 +81,7 @@ On Azure Pipelines, you can use pnpm for installing and caching your dependencie
 ```yaml title="azure-pipelines.yml"
 variables:
   pnpm_config_cache: $(Pipeline.Workspace)/.pnpm-store
+  PNPM_HOME: $(Pipeline.Workspace)/.pnpm
 
 steps:
   - task: Cache@2
@@ -55,10 +91,9 @@ steps:
     displayName: Cache pnpm
 
   - script: |
-      npm install --global corepack@latest
-      corepack enable
-      corepack prepare pnpm@latest-11 --activate
-      pnpm config set store-dir $(pnpm_config_cache)
+      curl -fsSL https://get.pnpm.io/install.sh | sh -
+      echo "##vso[task.prependpath]$(PNPM_HOME)/bin"
+      "$(PNPM_HOME)/bin/pnpm" config set store-dir $(pnpm_config_cache)
     displayName: "Setup pnpm"
 
   - script: |
@@ -66,6 +101,9 @@ steps:
       pnpm run build
     displayName: "pnpm install and build"
 ```
+
+`task.prependpath` puts pnpm on `PATH` for the steps that follow; within the step
+that installs it, call it by its full path.
 
 ## Bitbucket Pipelines
 
@@ -81,16 +119,23 @@ pipelines:
     "**":
       - step:
           name: Build and test
-          image: node:24.14.1
+          image: debian:stable-slim
           script:
-            - npm install --global corepack@latest
-            - corepack enable
-            - corepack prepare pnpm@latest-11 --activate
+            - apt-get update && apt-get install -y --no-install-recommends ca-certificates curl
+            - export PNPM_HOME="$HOME/.local/share/pnpm"
+            - export PATH="$PNPM_HOME/bin:$PATH"
+            - curl -fsSL https://get.pnpm.io/install.sh | sh -
+            - pnpm runtime set node lts -g
             - pnpm install
             - pnpm run build # Replace with your build/test…etc. commands
           caches:
             - pnpm
 ```
+
+All the lines of a step run in one shell, so `export` carries to the ones that
+follow. This example installs Node.js with pnpm rather than starting from a
+`node` image; keep your existing image and drop the `pnpm runtime set` line if
+you would rather not.
 
 ## CircleCI
 
@@ -102,9 +147,11 @@ version: 2.1
 jobs:
   build: # this can be any name you choose
     docker:
-      - image: node:18
+      - image: node:24
     resource_class: large
     parallelism: 10
+    environment:
+      PNPM_HOME: /root/.local/share/pnpm
 
     steps:
       - checkout
@@ -115,10 +162,9 @@ jobs:
       - run:
           name: Install pnpm package manager
           command: |
-            npm install --global corepack@latest
-            corepack enable
-            corepack prepare pnpm@latest-11 --activate
-            pnpm config set store-dir .pnpm-store
+            curl -fsSL https://get.pnpm.io/install.sh | sh -
+            echo 'export PATH="$PNPM_HOME/bin:$PATH"' >> "$BASH_ENV"
+            "$PNPM_HOME/bin/pnpm" config set store-dir .pnpm-store
       - run:
           name: Install Dependencies
           command: |
@@ -129,6 +175,9 @@ jobs:
           paths:
             - .pnpm-store
 ```
+
+CircleCI sources `$BASH_ENV` before every step, which is how pnpm reaches the
+steps that follow.
 
 ## GitHub Actions
 
@@ -178,10 +227,11 @@ stages:
 build:
   stage: build
   image: node:24.14.1
+  variables:
+    PNPM_HOME: "$CI_PROJECT_DIR/.pnpm"
   before_script:
-    - npm install --global corepack@latest
-    - corepack enable
-    - corepack prepare pnpm@latest-11 --activate
+    - export PATH="$PNPM_HOME/bin:$PATH"
+    - curl -fsSL https://get.pnpm.io/install.sh | sh -
     - pnpm config set store-dir .pnpm-store
   script:
     - pnpm install # install dependencies
@@ -201,22 +251,27 @@ You can use pnpm for installing and caching your dependencies:
 pipeline {
     agent {
         docker {
-            image 'node:lts-bullseye-slim'
+            image 'node:lts-bookworm-slim'
             args '-p 3000:3000'
         }
+    }
+    environment {
+        PNPM_HOME = "${WORKSPACE}/.pnpm"
+        PATH = "${PNPM_HOME}/bin:${PATH}"
     }
     stages {
         stage('Build') {
             steps {
-                sh 'npm install --global corepack@latest'
-                sh 'corepack enable'
-                sh 'corepack prepare pnpm@latest-11 --activate'
+                sh 'curl -fsSL https://get.pnpm.io/install.sh | sh -'
                 sh 'pnpm install'
             }
         }
     }
 }
 ```
+
+Each `sh` step runs in its own shell, so `PATH` is set in the pipeline's
+`environment` block rather than exported inside a step.
 
 ## Semaphore
 
@@ -233,12 +288,14 @@ agent:
 blocks:
   - name: Install dependencies
     task:
+      env_vars:
+        - name: PNPM_HOME
+          value: /home/semaphore/.local/share/pnpm
       jobs:
         - name: pnpm install
           commands:
-            - npm install --global corepack@latest
-            - corepack enable
-            - corepack prepare pnpm@latest-11 --activate
+            - export PATH="$PNPM_HOME/bin:$PATH"
+            - curl -fsSL https://get.pnpm.io/install.sh | sh -
             - checkout
             - cache restore node-$(checksum pnpm-lock.yaml)
             - pnpm install
@@ -257,10 +314,12 @@ cache:
   npm: false
   directories:
     - "~/.pnpm-store"
+env:
+  global:
+    - PNPM_HOME="$HOME/.local/share/pnpm"
+    - PATH="$PNPM_HOME/bin:$PATH"
 before_install:
-  - npm install --global corepack@latest
-  - corepack enable
-  - corepack prepare pnpm@latest-11 --activate
+  - curl -fsSL https://get.pnpm.io/install.sh | sh -
   - pnpm config set store-dir ~/.pnpm-store
 install:
   - pnpm install

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -9,7 +9,7 @@ If you don't use the standalone script or `@pnpm/exe` to install pnpm, then you 
 
 :::info
 
-Looking for pnpm 12? It is currently in beta and installed differently from pnpm 11. See [Installing the pnpm 12 beta](#installing-the-pnpm-12-beta).
+Looking for pnpm 12? It is currently in beta and installed differently from pnpm 11. See [Installing the pnpm 12 RC](#installing-the-pnpm-12-rc).
 
 :::
 
@@ -94,59 +94,12 @@ Prior to running the install script, you may optionally set an env variable `PNP
 curl -fsSL https://get.pnpm.io/install.sh | env PNPM_VERSION=<version> sh -
 ```
 
-## Using Corepack
-
-Due to an issue with [outdated signatures in Corepack](https://github.com/nodejs/corepack/issues/612), Corepack should be updated to its latest version first:
-
-```
-npm install --global corepack@latest
-```
-
-Since v16.13, Node.js is shipping [Corepack](https://nodejs.org/api/corepack.html) for managing package managers. This is an experimental feature, so you need to enable it by running:
-
-:::info
-
-If you have installed Node.js with `pnpm runtime` Corepack won't be installed on your system, you will need to install it separately. See [#4029](https://github.com/pnpm/pnpm/issues/4029).
-
-:::
-
-```
-corepack enable pnpm
-```
-
-This will automatically install pnpm on your system.
-
-You can pin the version of pnpm used on your project using the following command:
-
-```
-corepack use pnpm@latest-11
-```
-
-This will add a `"packageManager"` field in your local `package.json` which will instruct Corepack to always use a specific version on that project. This can be useful if you want reproducability, as all developers who are using Corepack will use the same version as you. When a new version of pnpm is released, you can re-run the above command.
-
-:::warning
-
-Corepack cannot install pnpm 12 yet. It expects the pnpm package to contain a `bin/pnpm.mjs` file, which the native pnpm 12 package does not have. Use [`pnpm self-update`](#pnpm-12-using-pnpm), [npm](#pnpm-12-using-npm), or the [standalone script](#pnpm-12-using-a-standalone-script) to install the beta.
-
-:::
-
 ## Using other package managers
 
 ### Using npm
 
-We provide two packages of pnpm CLI, `pnpm` and `@pnpm/exe`. On pnpm 12 the two are identical, so there is no reason to prefer one over the other; the difference below applies to pnpm 11.
-
-- [`pnpm`](https://www.npmjs.com/package/pnpm) is an ordinary version of pnpm, which needs Node.js to run. Since v11, pnpm is distributed as pure ESM.
-- [`@pnpm/exe`](https://www.npmjs.com/package/@pnpm/exe) is packaged with Node.js into an executable, so it may be used on a system with no Node.js installed. On Linux, glibc and musl builds are both provided and the right one is selected automatically; the glibc build requires glibc 2.27 or newer and `libatomic.so.1` (see [Linux runtime requirements](#on-posix-systems) for details). **Not available for Intel macOS** (`darwin-x64`) — install `pnpm` instead, see [#11423](https://github.com/pnpm/pnpm/issues/11423).
-
 ```sh
-npx pnpm@latest-11 dlx @pnpm/exe@latest-11 setup
-```
-
-or
-
-```sh
-npm install -g pnpm@latest-11
+npx get-pnpm
 ```
 
 ### Using Homebrew
@@ -187,11 +140,11 @@ Do you wanna use pnpm on CI servers? See: [Continuous Integration](./continuous-
 
 :::
 
-## Installing the pnpm 12 beta
+## Installing the pnpm 12 RC
 
 :::warning
 
-pnpm 12 is a rewrite of pnpm in Rust and is currently in **beta**. It is not recommended for production use yet. Please [report any issues](https://github.com/pnpm/pnpm/issues) you run into.
+pnpm 12 is a rewrite of pnpm in Rust and is currently in **beta**. Please [report any issues](https://github.com/pnpm/pnpm/issues) you run into.
 
 :::
 
@@ -212,16 +165,10 @@ pnpm links the native binary directly, so nothing else is needed. Note that insi
 If you don't have pnpm installed yet:
 
 ```sh
-npm install -g --allow-scripts=pnpm pnpm@next-12
+npx get-pnpm next-12
 ```
 
-:::info
-
-`--allow-scripts=pnpm` is required on npm 11.16 and newer, which blocks install scripts by default. The published package is a small wrapper whose `preinstall` script replaces it with the native binary for your platform, so without the flag `pnpm` is left as a placeholder file that fails to run. Older versions of npm run install scripts anyway and ignore the flag, so the command above works on any version. For the same reason, don't install pnpm 12 with `--ignore-scripts` or `--no-optional`. If you install it with pnpm or Bun, allow the build scripts of the `pnpm` package.
-
-:::
-
-Node.js 18 or newer is needed to run that install script, but not to run pnpm afterwards — pnpm 12 is a native binary.
+Node.js 22.13 or newer is needed to run that install script, but not to run pnpm afterwards — pnpm 12 is a native binary.
 
 ### Using a standalone script {#pnpm-12-using-a-standalone-script}
 
@@ -230,13 +177,13 @@ Set `PNPM_VERSION` to the exact beta version (the POSIX script does not accept n
 On POSIX systems:
 
 ```sh
-curl -fsSL https://get.pnpm.io/install.sh | env PNPM_VERSION=12.0.0-beta.2 sh -
+curl -fsSL https://get.pnpm.io/install.sh | env PNPM_VERSION=12.0.0-rc.3 sh -
 ```
 
 On Windows, using PowerShell:
 
 ```powershell
-$env:PNPM_VERSION="12.0.0-beta.2"; Invoke-WebRequest https://get.pnpm.io/install.ps1 -UseBasicParsing | Invoke-Expression
+$env:PNPM_VERSION="12.0.0-rc.3"; Invoke-WebRequest https://get.pnpm.io/install.ps1 -UseBasicParsing | Invoke-Expression
 ```
 
 This installs pnpm without requiring Node.js, and unlike pnpm 11 it also works on Intel macOS.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -9,7 +9,7 @@ If you don't use the standalone script or `@pnpm/exe` to install pnpm, then you 
 
 :::info
 
-Looking for pnpm 12? It is currently in beta and installed differently from pnpm 11. See [Installing the pnpm 12 RC](#installing-the-pnpm-12-rc).
+Looking for pnpm 12? It is currently a release candidate and installed differently from pnpm 11. See [Installing the pnpm 12 RC](#installing-the-pnpm-12-rc).
 
 :::
 
@@ -23,7 +23,7 @@ You may install pnpm even if you don't have Node.js installed, using the followi
 
 Sometimes, Windows Defender may block our executable if you install pnpm this way.
 
-Due to this issue, we currently recommend installing pnpm using [npm](#using-npm) or [Corepack](#using-corepack) on Windows.
+Due to this issue, we currently recommend installing pnpm using [npm](#using-npm) on Windows.
 
 :::
 
@@ -44,7 +44,7 @@ Add-MpPreference -ExclusionPath $(pnpm store path)
 
 :::warning Not supported on Intel macOS in pnpm 11
 
-On pnpm 11, the standalone script does not run on Intel Macs (`darwin-x64`). Use [npm](#using-npm), [Corepack](#using-corepack), or [Homebrew](#using-homebrew) instead. See [#11423](https://github.com/pnpm/pnpm/issues/11423) for context.
+On pnpm 11, the standalone script does not run on Intel Macs (`darwin-x64`). Use [Homebrew](#using-homebrew), or install pnpm 12, which ships an Intel build. See [#11423](https://github.com/pnpm/pnpm/issues/11423) for context.
 
 pnpm 12 ships an Intel macOS build again, so this limitation doesn't apply to it.
 
@@ -144,11 +144,11 @@ Do you wanna use pnpm on CI servers? See: [Continuous Integration](./continuous-
 
 :::warning
 
-pnpm 12 is a rewrite of pnpm in Rust and is currently in **beta**. Please [report any issues](https://github.com/pnpm/pnpm/issues) you run into.
+pnpm 12 is a rewrite of pnpm in Rust and is currently a **release candidate**. Please [report any issues](https://github.com/pnpm/pnpm/issues) you run into.
 
 :::
 
-pnpm 12 has no intentional breaking changes compared to pnpm 11, so the rest of this documentation applies to both versions. Only installation differs while v12 is in beta: it is published under the `next-12` tag on npm and as a prerelease on GitHub, so Homebrew, winget, Scoop and Chocolatey don't offer it yet.
+pnpm 12 has no intentional breaking changes compared to pnpm 11, so the rest of this documentation applies to both versions. Only installation differs while v12 is a release candidate: it is published under the `next-12` tag on npm and as a prerelease on GitHub, so Homebrew, winget, Scoop and Chocolatey don't offer it yet.
 
 ### Using pnpm {#pnpm-12-using-pnpm}
 
@@ -172,18 +172,18 @@ Node.js 22.13 or newer is needed to run that install script, but not to run pnpm
 
 ### Using a standalone script {#pnpm-12-using-a-standalone-script}
 
-Set `PNPM_VERSION` to the exact beta version (the POSIX script does not accept npm dist-tags).
+Set `PNPM_VERSION` to `next-12`, or to an exact version.
 
 On POSIX systems:
 
 ```sh
-curl -fsSL https://get.pnpm.io/install.sh | env PNPM_VERSION=12.0.0-rc.3 sh -
+curl -fsSL https://get.pnpm.io/install.sh | env PNPM_VERSION=next-12 sh -
 ```
 
 On Windows, using PowerShell:
 
 ```powershell
-$env:PNPM_VERSION="12.0.0-rc.3"; Invoke-WebRequest https://get.pnpm.io/install.ps1 -UseBasicParsing | Invoke-Expression
+$env:PNPM_VERSION="next-12"; Invoke-WebRequest https://get.pnpm.io/install.ps1 -UseBasicParsing | Invoke-Expression
 ```
 
 This installs pnpm without requiring Node.js, and unlike pnpm 11 it also works on Intel macOS.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated pnpm 12 installation guidance to reflect release candidate terminology.
  * Replaced Corepack recommendations with `npx get-pnpm` and standalone installation instructions.
  * Updated Node.js requirements, installation commands, links, and platform-specific guidance.
  * Added standalone pnpm setup instructions for continuous integration environments, including `PNPM_HOME` and `PATH` configuration.
  * Updated CI examples across multiple providers to use standalone installation and document environment persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->