### PR TITLE
docs: document globalShims and project-aware global bins

### DIFF
--- a/docs/global-packages.md
+++ b/docs/global-packages.md
@@ -172,6 +172,8 @@ If the project provides nothing, or the lookup is declined, the globally install
 
 A project you `cd` into is not automatically allowed to run its own binaries in place of your global ones.
 
+This section describes the default `auto` policy. Under `auto`:
+
 * A **stable Node.js release** is verified against the Node.js release team's signatures before it runs, so it switches without asking. (On musl-based systems the matching builds are unsigned, so they fall under the prompt instead.)
 * **Everything else** — Deno, Bun, Node.js prereleases, and any ordinary package you enable — asks once, per project and per candidate:
 
@@ -185,7 +187,9 @@ Answers are remembered in a machine-local registry, keyed to the project directo
 
 In CI and any non-interactive session, the question cannot be asked, so the global version runs and nothing is recorded.
 
-There is one more guard that applies regardless of trust: the project's command must come from the **same package** as the global one. A project that ships a lookalike `tsc` from some other package does not match, and your global `tsc` runs.
+The other two [policies](./settings/other.md#globalshims) change which candidates reach that question. `prompt` sends every candidate through it, including a signature-verified stable Node.js release; answers are still remembered, so it asks once per project and candidate rather than on every run. `always` skips the question entirely and switches straight away — which is also what makes it usable in CI, where a prompt would otherwise fall back to the global version.
+
+There is one more guard that applies regardless of policy: the project's command must come from the **same package** as the global one. A project that ships a lookalike `tsc` from some other package does not match, and your global `tsc` runs.
 
 ### Which packages participate
 

--- a/docs/global-packages.md
+++ b/docs/global-packages.md
@@ -126,6 +126,94 @@ You can check the current global bin directory with:
 pnpm bin -g
 ```
 
+## Project-aware global bins
+
+Added in: v12.0.0-rc.2 (pnpm v12 only)
+
+Global commands can follow the project you are standing in. When you run a global command from inside a project that asks for a different version of the same tool, pnpm runs the version the project asks for.
+
+The most useful case is Node.js itself. Given a project that pins its runtime:
+
+```json title="package.json"
+{
+  "devEngines": {
+    "runtime": {
+      "name": "node",
+      "version": "^22.0.0",
+      "onFail": "download"
+    }
+  }
+}
+```
+
+a bare `node` inside that directory runs Node.js 22, even if your global Node.js is a different major:
+
+```sh
+cd ~/projects/legacy-app
+node --version   # v22.x.x — the version the project pins
+cd ~
+node --version   # your globally installed version
+```
+
+No shell hooks, `.bashrc` edits, or `use`-style commands are involved — the shims pnpm writes into the global bin directory do the dispatch themselves.
+
+### How a version is chosen
+
+pnpm walks up from the current working directory to the nearest project that provides the command, then:
+
+* For the **runtimes** (`node`, `deno`, `bun`), only the manifest pin counts — [`devEngines.runtime`](./package_json.md#devenginesruntime), then `engines.runtime`. The pinned version is downloaded into the [global virtual store](./global-virtual-store.md) on demand and executed directly. The project's `node_modules/.bin` is never consulted for a runtime, so a dependency cannot supply the `node` you run.
+* For **any other package**, the project's `node_modules/.bin/<name>` is used.
+
+Directories inside the pnpm home are skipped, since global installs are not projects.
+
+If the project provides nothing, or the lookup is declined, the globally installed version runs — commands never fail merely because dispatch did not apply.
+
+### Trust
+
+A project you `cd` into is not automatically allowed to run its own binaries in place of your global ones.
+
+* A **stable Node.js release** is verified against the Node.js release team's signatures before it runs, so it switches without asking. (On musl-based systems the matching builds are unsigned, so they fall under the prompt instead.)
+* **Everything else** — Deno, Bun, Node.js prereleases, and any ordinary package you enable — asks once, per project and per candidate:
+
+  ```text
+  The project at "/home/user/projects/app" provides its own "tsc", which will be used
+  instead of the globally installed one.
+  Do you trust this project? [y/N]
+  ```
+
+Answers are remembered in a machine-local registry, keyed to the project directory *and* to a fingerprint of the exact binary. If the binary or the providing package changes, pnpm asks again rather than reusing the old approval.
+
+In CI and any non-interactive session, the question cannot be asked, so the global version runs and nothing is recorded.
+
+There is one more guard that applies regardless of trust: the project's command must come from the **same package** as the global one. A project that ships a lookalike `tsc` from some other package does not match, and your global `tsc` runs.
+
+### Which packages participate
+
+Only the runtimes participate by default. Enable others with [`globalShims`](./settings/other.md#globalshims), keyed by the providing package's name:
+
+```yaml title="~/.config/pnpm/config.yaml"
+globalShims:
+  typescript: true
+```
+
+Because pnpm decides at install time which bins to give dispatching shims, a package that is already installed globally needs to be reinstalled after you enable it:
+
+```sh
+pnpm add -g typescript
+```
+
+Turning a package *off* needs no reinstall — the setting is re-read on every dispatch. The same setting disables dispatch per package, or entirely with `globalShims: false`. For a single command, set `PNPM_SHIM_BYPASS=1`:
+
+```sh
+PNPM_SHIM_BYPASS=1 node --version
+```
+
+:::note
+
+`globalShims` is deliberately not read from a project's `pnpm-workspace.yaml` — only from the global configuration file, the pnpm home directory's own `pnpm-workspace.yaml`, and the environment. See the [setting's documentation](./settings/other.md#globalshims) for details.
+
+:::
+
 ## Global virtual store
 
 Global installs use the [global virtual store](./global-virtual-store.md). Packages are stored at `{storeDir}/links` and shared across global installations. This avoids redundant fetches when multiple global packages depend on the same libraries.

--- a/docs/package_json.md
+++ b/docs/package_json.md
@@ -114,7 +114,7 @@ How it works:
 
 To override the declared `onFail` behavior without editing the manifest, use the [`runtimeOnFail`](./settings/cli.md#runtimeonfail) setting.
 
-Since v12.0.0-rc.2, a bare `node` (or `deno`/`bun`) run from inside the project also follows this pin, not just scripts. See [project-aware global bins](./global-packages.md#project-aware-global-bins).
+Since v12.0.0-rc.2, a bare `node` (or `deno`/`bun`) run from inside the project also follows this pin, not just scripts. This can be turned off with the [`globalShims`](./settings/other.md#globalshims) setting, or skipped for a single command with `PNPM_SHIM_BYPASS=1`. See [project-aware global bins](./global-packages.md#project-aware-global-bins).
 
 ## devEngines.packageManager
 

--- a/docs/package_json.md
+++ b/docs/package_json.md
@@ -114,6 +114,8 @@ How it works:
 
 To override the declared `onFail` behavior without editing the manifest, use the [`runtimeOnFail`](./settings/cli.md#runtimeonfail) setting.
 
+Since v12.0.0-rc.2, a bare `node` (or `deno`/`bun`) run from inside the project also follows this pin, not just scripts. See [project-aware global bins](./global-packages.md#project-aware-global-bins).
+
 ## devEngines.packageManager
 
 Added in: v11.0.0

--- a/docs/settings/other.md
+++ b/docs/settings/other.md
@@ -65,6 +65,63 @@ In pnpm v11, globally installed binaries are stored in a `bin` subdirectory of `
 
 :::
 
+### globalShims
+
+Added in: v12.0.0-rc.2
+
+* Default: **\{ node: auto, deno: auto, bun: auto \}**
+* Type: **Boolean**, **Object**
+
+Controls which globally installed packages get [project-aware shims](../global-packages.md#project-aware-global-bins) — global commands that run the version the current project asks for instead of the globally installed one.
+
+The setting is a map from **package name** to policy. The key is the name of the package that *provides* the command, not the command itself, so an entry for `typescript` covers its `tsc` bin.
+
+```yaml
+globalShims:
+  node: auto
+  deno: false
+  typescript: prompt
+```
+
+The supported policies are:
+
+| Value | Behavior |
+|---|---|
+| `auto` (or `true`) | Switch automatically when the candidate is authenticated by a publisher signature; otherwise ask for confirmation once. |
+| `prompt` | Always ask for confirmation, even for signature-verified candidates. |
+| `always` | Always switch, never ask. |
+| `false` | Disable the project-aware shim for this package. |
+
+Layers merge key by key over the built-in defaults, so a single entry can change one package without restating the rest — `globalShims: { bun: false }` leaves `node` and `deno` at `auto`.
+
+The scalar shorthands replace the whole map instead of merging: `globalShims: false` disables every project-aware shim, and `globalShims: true` resets to the defaults.
+
+:::warning
+
+This setting is only read from locations a project cannot write to: the [global configuration file](../cli/config.md), a `pnpm-workspace.yaml` in the pnpm home directory itself, and the `PNPM_CONFIG_GLOBAL_SHIMS` environment variable (a JSON value), applied in that order. A project's own `pnpm-workspace.yaml` is ignored — otherwise a repository could grant itself the right to run its own binaries in place of your global ones.
+
+:::
+
+Disabling a package, or changing its policy, takes effect on the very next command — the setting is re-read on each dispatch, so no reinstall is needed.
+
+Newly *enabling* a package is the exception. pnpm decides at install time which bins to write dispatching shims for, so a package that was already installed globally while it was disabled needs to be reinstalled to pick up the change:
+
+```sh
+pnpm add -g typescript
+```
+
+To bypass dispatch for a single invocation, set `PNPM_SHIM_BYPASS=1`:
+
+```sh
+PNPM_SHIM_BYPASS=1 node --version
+```
+
+:::note
+
+Project-aware shims are a pnpm v12 feature and are not available in v11.
+
+:::
+
 ### npmrcAuthFile
 
 Added in: v11.0.0

--- a/docs/settings/other.md
+++ b/docs/settings/other.md
@@ -88,8 +88,8 @@ The supported policies are:
 | Value | Behavior |
 |---|---|
 | `auto` (or `true`) | Switch automatically when the candidate is authenticated by a publisher signature; otherwise ask for confirmation once. |
-| `prompt` | Always ask for confirmation, even for signature-verified candidates. |
-| `always` | Always switch, never ask. |
+| `prompt` | Put every candidate through the confirmation gate, including signature-verified ones. Answers are still remembered, so this asks once per project and candidate, not on every run. |
+| `always` | Always switch, never ask. Usable in CI, where a prompt would fall back to the global version. |
 | `false` | Disable the project-aware shim for this package. |
 
 Layers merge key by key over the built-in defaults, so a single entry can change one package without restating the rest — `globalShims: { bun: false }` leaves `node` and `deno` at `auto`.


### PR DESCRIPTION
Documents the `globalShims` behaviour released in pnpm **v12.0.0-rc.2** (pnpm/pnpm#13731).

## Changes

**`docs/settings/other.md`** — new `globalShims` reference entry after `globalBinDir`:

- Default `{ node: auto, deno: auto, bun: auto }`; type Boolean or Object
- Keyed by the *providing package* name, so an entry for `typescript` covers its `tsc` bin
- Policy table: `auto` (or `true`), `prompt`, `always`, `false`
- Key-wise merging across layers vs. the scalar shorthands that replace the whole map
- A warning that the dispatcher reads this **only** from locations a project cannot write to — the global config file, the pnpm home's own `pnpm-workspace.yaml`, and `PNPM_CONFIG_GLOBAL_SHIMS` — never a project's `pnpm-workspace.yaml`
- `PNPM_SHIM_BYPASS=1` for a one-off bypass

**`docs/global-packages.md`** — new "Project-aware global bins" section covering the user-facing behaviour: the `cd` into a pinned project → `node --version` example, how a version is chosen (runtimes resolve from `devEngines.runtime` / `engines.runtime` only and never from `node_modules/.bin`; other packages resolve from `node_modules/.bin`), and the trust model — signature-verified stable Node runs promptless, everything else prompts once per project *and* binary fingerprint, non-interactive/CI falls back to the global version, and same-package validation defeats lookalikes.

**`docs/package_json.md`** — one line under `devEngines.runtime` noting that a bare `node` now follows the pin, not just scripts.

## Notes

- **One detail differs from the feature commit message.** It says the mode "takes effect without relinking", which is only half true: the dispatcher re-reads the setting on every dispatch, so *disabling* or changing a policy is immediate, but `global.rs` partitions bins into direct vs. context-aware shims at **install** time, so newly *enabling* a package needs `pnpm add -g <pkg>` to rewrite its shim. Both halves are documented.
- **Version labelling.** `docs/` serves the version labelled "11 & 12", so the feature is marked `Added in: v12.0.0-rc.2` with an explicit "not available in v11" note, following the existing `Added in:` convention.

## Verification

`pnpm build` passes. The new anchors and all three cross-links resolve in the built HTML. The only broken links reported are the pre-existing `/cli/pn` reference in the 11.0 blog post across locales, untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Documented project-aware global shims for Node.js, Deno, and Bun commands.
  * Added guidance for runtime version resolution, trust prompts, package policies, CI behavior, and bypass options.
  * Documented the `globalShims` setting, including configuration formats, defaults, trusted sources, and reinstall requirements.
  * Clarified that bare runtime commands use versions pinned through `devEngines.runtime`.
  * Added guidance for disabling or bypassing shims and noted v11 incompatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->