### PR TITLE
docs: document v12 git dependency resolution

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -148,7 +148,12 @@ pnpm 12 is a rewrite of pnpm in Rust and is currently a **release candidate**. P
 
 :::
 
-pnpm 12 has no intentional breaking changes compared to pnpm 11, so the rest of this documentation applies to both versions. Only installation differs while v12 is a release candidate: it is published under the `next-12` tag on npm and as a prerelease on GitHub, so Homebrew, winget, Scoop and Chocolatey don't offer it yet.
+pnpm 12 does not break the way you use pnpm 11, so the rest of this documentation applies to both versions. Only installation differs while v12 is a release candidate: it is published under the `next-12` tag on npm and as a prerelease on GitHub, so Homebrew, winget, Scoop and Chocolatey don't offer it yet.
+
+A few behaviors are new in or specific to v12:
+
+* [Project-aware global bins](./global-packages.md#project-aware-global-bins) — a global `node`, `deno`, or `bun` follows the version the current project pins. Configurable via [`globalShims`](./settings/other.md#globalshims).
+* [Git dependency resolution](./package-sources.md#how-git-dependencies-are-resolved) — specifiers for repositories on GitHub, GitLab, and Bitbucket resolve through the host's canonical HTTPS URL, and the lockfile no longer records an SSH URL for them.
 
 ### Using pnpm {#pnpm-12-using-pnpm}
 

--- a/docs/package-sources.md
+++ b/docs/package-sources.md
@@ -104,7 +104,7 @@ pnpm add https://github.com/indexzero/forever/tarball/v0.5.6
 pnpm add <git remote url>
 ```
 
-Installs the package from the hosted Git provider, cloning it with Git.
+Installs the package from the Git repository at the given URL. Depending on the repository, pnpm either downloads a source archive from the Git host or clones the repository with Git — see [how Git dependencies are resolved](#how-git-dependencies-are-resolved).
 
 You may install packages from Git by:
 
@@ -195,3 +195,43 @@ pnpm add RexSkz/test-git-subdir-fetch.git#beta\&path:/packages/simple-react-app
 ```
 
 Installs from the `beta` branch and only the subdirectory at `/packages/simple-react-app`.
+
+#### How Git dependencies are resolved
+
+Added in: v12.0.0 (pnpm v12 only)
+
+For repositories on GitHub, GitLab, and Bitbucket, the specifier is an **identity**, not a choice of transport. All of the following name the same dependency and resolve identically:
+
+```
+kevva/is-positive
+github:kevva/is-positive
+git+https://github.com/kevva/is-positive.git
+git+ssh://git@github.com/kevva/is-positive.git
+```
+
+Each resolves through the host's canonical HTTPS URL, and the lockfile records one of two shapes:
+
+* the **host's source archive**, a plain tarball download. This is recorded only when an anonymous request for that exact archive URL succeeds, so a recorded archive URL is fetchable by construction.
+* otherwise a **`git` resolution over the canonical HTTPS URL**, which every machine that has access to the repository can fetch.
+
+pnpm never records an SSH URL for these hosts. Which transport a given machine uses to reach the host is that machine's Git configuration, not a property of the project.
+
+##### Using SSH for private repositories
+
+Configure the rewrite in Git itself, on the machine:
+
+```sh
+git config --global url."git@github.com:".insteadOf https://github.com/
+```
+
+pnpm shells out to `git`, so the rewrite applies to all of pnpm's Git operations automatically. The same holds on CI: give the runner an SSH key and this rewrite, or an HTTPS credential helper — the lockfile is identical either way.
+
+##### Repositories on other hosts
+
+A URL that does not point at a known host (a self-hosted GitLab, Gitea, or any internal Git server) is kept exactly as written, transport included — for those, the URL *is* the identity. URLs with credentials embedded in them are also kept verbatim, and never resolve to a host archive.
+
+:::info
+
+In pnpm v11 and earlier, resolution probed the network to decide between HTTPS and SSH. That could record whichever transport happened to work on the machine that ran the install — most often an `ssh://` URL that then failed on CI runners without SSH keys. pnpm v12 removes the probing. Existing lockfile entries are left untouched; the rules above apply when an entry is added or re-resolved.
+
+:::


### PR DESCRIPTION
pnpm v12 changed how git-hosted dependencies are resolved ([pnpm/pnpm#13684](https://github.com/pnpm/pnpm/pull/13684)), and the change is user-visible: it decides what lands in `pnpm-lock.yaml`.

A specifier for a repository on GitHub, GitLab, or Bitbucket is now an **identity**, not a choice of transport. `owner/repo`, `github:owner/repo`, `git+https://github.com/…`, and `git+ssh://git@github.com/…` all resolve through the host's canonical HTTPS URL, and the lockfile records either the host's source archive (only when an anonymous request for that exact archive URL succeeds, so a recorded archive URL is fetchable by construction) or a `git` resolution over the canonical HTTPS URL. An SSH URL is never recorded for those hosts — reaching them over SSH is per-machine git configuration (`url.insteadOf`), which pnpm honors because it shells out to `git`. This removes v11's resolve-time transport probing, which could freeze one machine's working transport into the lockfile and break CI runners configured differently.

## Changes

- **`docs/package-sources.md`** — new "How Git dependencies are resolved" section under *Git repository*: the identity rule, the two lockfile shapes, the `insteadOf` recipe for private repositories, the verbatim handling of unknown hosts and credentialed URLs, and an info box on what changed from v11. Also rewords the section intro, which claimed git dependencies are always cloned with Git — public hosted repos resolve to a host archive.
- **`docs/installation.md`** — the "pnpm 12 has no intentional breaking changes" line was no longer quite true. It now says v12 doesn't break the way you use v11, and links the behaviors that are new in or specific to v12: project-aware global bins and git dependency resolution.

Marked `Added in: v12.0.0 (pnpm v12 only)`, matching the `globalShims` convention — v11 keeps the probing behavior.

## Testing

`pnpm build` passes. The only broken links reported are pre-existing (`/cli/pn` in the translated 11.0 release posts); no broken anchors from the new cross-references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)