### PR TITLE
docs: note that --resolution-only is gone in v12, and move v12 differences to a blog post

### DIFF
--- a/blog/2026-08-10-whats-different-in-pnpm-12.md
+++ b/blog/2026-08-10-whats-different-in-pnpm-12.md
@@ -16,7 +16,7 @@ Three things differ, and one of them — a removed flag — fails outright rathe
 
 A globally installed `node`, `deno`, or `bun` now follows the version the current project pins, instead of always running the globally installed one.
 
-If a project pins a runtime — through [`devEngines`](/settings/other#devengines), or by installing a runtime as a dependency — then running `node` inside that project uses the pinned version, while running it outside any project uses the global one. You no longer need a separate version manager to get that behavior.
+If a project pins a runtime — through [`devEngines.runtime`](/package_json#devenginesruntime), or by installing a runtime as a dependency — then running `node` inside that project uses the pinned version, while running it outside any project uses the global one. You no longer need a separate version manager to get that behavior.
 
 The setting that controls this is [`globalShims`](/settings/other#globalshims), and the full description is in [Project-aware global bins](/global-packages#project-aware-global-bins).
 

--- a/blog/2026-08-10-whats-different-in-pnpm-12.md
+++ b/blog/2026-08-10-whats-different-in-pnpm-12.md
@@ -6,7 +6,7 @@ authors: zkochan
 tags: [release]
 ---
 
-pnpm 12 is a rewrite of pnpm in Rust, and it is currently a **release candidate**. Upgrading is not meant to be a migration: apart from the differences below, it keeps the commands, flags, settings, and lockfile format of pnpm 11, and the [documentation](/installation) applies to both versions.
+pnpm 12 is a rewrite of pnpm in Rust, and it is currently a **release candidate**. Upgrading is not meant to be a migration: apart from the differences below, it keeps the commands, flags, settings, and lockfile format of pnpm 11, and the [documentation](/motivation) applies to both versions.
 
 Three things differ, and one of them — a removed flag — fails outright rather than behaving differently. This post collects them in one place.
 

--- a/blog/2026-08-10-whats-different-in-pnpm-12.md
+++ b/blog/2026-08-10-whats-different-in-pnpm-12.md
@@ -6,9 +6,9 @@ authors: zkochan
 tags: [release]
 ---
 
-pnpm 12 is a rewrite of pnpm in Rust, and it is currently a **release candidate**. It keeps the commands, flags, settings, and lockfile format of pnpm 11, so upgrading is not meant to be a migration — the [documentation](/installation) applies to both versions.
+pnpm 12 is a rewrite of pnpm in Rust, and it is currently a **release candidate**. Upgrading is not meant to be a migration: apart from the differences below, it keeps the commands, flags, settings, and lockfile format of pnpm 11, and the [documentation](/installation) applies to both versions.
 
-A short list of behaviors does differ. This post collects them in one place.
+Three things differ, and one of them — a removed flag — fails outright rather than behaving differently. This post collects them in one place.
 
 <!--truncate-->
 

--- a/blog/2026-08-10-whats-different-in-pnpm-12.md
+++ b/blog/2026-08-10-whats-different-in-pnpm-12.md
@@ -1,0 +1,66 @@
+---
+title: "What's different in pnpm 12"
+date: 2026-08-10
+slug: whats-different-in-pnpm-12
+authors: zkochan
+tags: [release]
+---
+
+pnpm 12 is a rewrite of pnpm in Rust, and it is currently a **release candidate**. It keeps the commands, flags, settings, and lockfile format of pnpm 11, so upgrading is not meant to be a migration — the [documentation](/installation) applies to both versions.
+
+A short list of behaviors does differ. This post collects them in one place.
+
+<!--truncate-->
+
+## Project-aware global bins
+
+A globally installed `node`, `deno`, or `bun` now follows the version the current project pins, instead of always running the globally installed one.
+
+If a project pins a runtime — through [`devEngines`](/settings/other#devengines), or by installing a runtime as a dependency — then running `node` inside that project uses the pinned version, while running it outside any project uses the global one. You no longer need a separate version manager to get that behavior.
+
+The setting that controls this is [`globalShims`](/settings/other#globalshims), and the full description is in [Project-aware global bins](/global-packages#project-aware-global-bins).
+
+## Git dependency resolution
+
+For repositories on GitHub, GitLab, and Bitbucket, a specifier is now an **identity**, not a choice of transport. All of these name the same dependency and resolve identically:
+
+```
+kevva/is-positive
+github:kevva/is-positive
+git+https://github.com/kevva/is-positive.git
+git+ssh://git@github.com/kevva/is-positive.git
+```
+
+Each resolves through the host's canonical HTTPS URL, and pnpm never records an SSH URL for those hosts. Which transport a given machine uses to reach the host is that machine's Git configuration, not a property of the project — so a lockfile written on a laptop with SSH keys still installs on a CI runner without them.
+
+In pnpm 11 the resolver probed transports and could record `git@github.com:owner/repo.git`, which then failed for everyone whose machine had no key for that host. If you have such an entry in a lockfile written by an older pnpm, re-resolve those dependencies once with `pnpm update <package>` — pnpm will not rewrite the entry on its own, because the lockfile is the record of what to install.
+
+To reach private repositories over SSH, configure the rewrite in Git rather than in the specifier:
+
+```sh
+git config --global url."git@github.com:".insteadOf https://github.com/
+```
+
+pnpm shells out to `git`, so the rewrite applies to all of its Git operations automatically. Details, including how unknown hosts and credentialed URLs are handled, are in [How Git dependencies are resolved](/package-sources#how-git-dependencies-are-resolved).
+
+## `pnpm install --resolution-only` is gone
+
+pnpm 12 does not implement this flag and rejects it:
+
+```
+error: unexpected argument '--resolution-only' found
+```
+
+The flag existed to print out peer dependency issues. [`pnpm peers check`](/cli/peers#check) does that directly — it reads the issues from the lockfile, so it needs neither a re-resolution nor an install:
+
+```sh
+pnpm peers check
+```
+
+If you call `--resolution-only` from a CI script, this is the one change here that will stop a build rather than change a result, so it is worth grepping for before you switch.
+
+## Trying it
+
+pnpm 12 is published under the `next-12` tag on npm and as a prerelease on GitHub. Homebrew, winget, Scoop, and Chocolatey don't offer it yet. See [Installing the pnpm 12 RC](/installation#installing-the-pnpm-12-rc) for the ways to install it.
+
+Please [report any issues](https://github.com/pnpm/pnpm/issues) you run into.

--- a/docs/cli/install.md
+++ b/docs/cli/install.md
@@ -200,6 +200,14 @@ dependencies.
 
 Re-runs resolution: useful for printing out peer dependency issues.
 
+:::info
+
+This flag exists in pnpm 11 only. pnpm 12 does not implement it and rejects it with `error: unexpected argument '--resolution-only' found`.
+
+To list peer dependency issues on either version, run [`pnpm peers check`](./peers.md#check) instead. It reads them from the lockfile, so it needs neither a re-resolution nor an install.
+
+:::
+
 import CpuFlag from '../settings/_cpuFlag.mdx'
 
 <CpuFlag />

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -148,12 +148,7 @@ pnpm 12 is a rewrite of pnpm in Rust and is currently a **release candidate**. P
 
 :::
 
-pnpm 12 does not break the way you use pnpm 11, so the rest of this documentation applies to both versions. Only installation differs while v12 is a release candidate: it is published under the `next-12` tag on npm and as a prerelease on GitHub, so Homebrew, winget, Scoop and Chocolatey don't offer it yet.
-
-A few behaviors are new in or specific to v12:
-
-* [Project-aware global bins](./global-packages.md#project-aware-global-bins) — a global `node`, `deno`, or `bun` follows the version the current project pins. Configurable via [`globalShims`](./settings/other.md#globalshims).
-* [Git dependency resolution](./package-sources.md#how-git-dependencies-are-resolved) — specifiers for repositories on GitHub, GitLab, and Bitbucket resolve through the host's canonical HTTPS URL, and the lockfile no longer records an SSH URL for them.
+Apart from a short list of differences, pnpm 12 does not change the way you use pnpm 11, so the rest of this documentation applies to both versions — see [What's different in pnpm 12](/blog/whats-different-in-pnpm-12). Only installation differs while v12 is a release candidate: it is published under the `next-12` tag on npm and as a prerelease on GitHub, so Homebrew, winget, Scoop and Chocolatey don't offer it yet.
 
 ### Using pnpm {#pnpm-12-using-pnpm}
 


### PR DESCRIPTION
## Summary

Two things, both prompted by [pnpm/pnpm#13743](https://github.com/pnpm/pnpm/issues/13743).

**`--resolution-only` in v12.** pnpm 12 does not implement the flag and rejects it outright:

```
$ pnpm install --resolution-only
error: unexpected argument '--resolution-only' found
```

That's a hard failure, not a changed result, so anyone calling it from CI needs to know before switching. The CLI reference now says so at the flag itself, and points at [`pnpm peers check`](https://pnpm.io/cli/peers#check) — which reads peer dependency issues straight from the lockfile, needing neither a re-resolution nor an install. That is the use case the flag's own help text names ("useful for printing out peer dependency issues"), and `peers check` exists in both v11 and v12.

**Moved the v12 differences off the install page.** The "A few behaviors are new in or specific to v12" list had grown to three entries, which is release-note material sitting in the middle of installation instructions. It's now a blog post, [What's different in pnpm 12](https://pnpm.io/blog/whats-different-in-pnpm-12), covering project-aware global bins, Git dependency resolution, and the removed flag. The install page keeps one sentence and a link.

While rewording that sentence I softened "pnpm 12 does not break the way you use pnpm 11" to "Apart from a short list of differences, pnpm 12 does not change the way you use pnpm 11" — with a flag that hard-errors, the stronger claim isn't quite right. Easy to revert if you prefer the original wording.

## Checks

`pnpm build` passes. The only broken links it reports are pre-existing: `/cli/pn` from the translated `blog/releases/11.0` pages, untouched here.

---
Written by an agent (Claude Code, claude-opus-5[1m]).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added release information for pnpm 12, including compatibility details, project-aware runtime behavior, canonical Git dependency resolution, and installation guidance.
* **Documentation**
  * Documented that `--resolution-only` is unavailable in pnpm 12 and recommended `pnpm peers check` for reviewing peer dependency issues.
  * Updated installation guidance to clarify pnpm 12’s release-candidate status, availability limitations, and documented differences from pnpm 11.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->