### PR TITLE
docs: fix typos found by cspell

### DIFF
--- a/docs/finders.md
+++ b/docs/finders.md
@@ -85,7 +85,7 @@ Output:
     license: MIT
 ```
 
-Othere example use cases:
+Other example use cases:
 * Find all packages with a specific license.
 * Detect packages requiring a minimum Node.js version.
 * List all dependencies that expose binaries.

--- a/versioned_docs/version-10.x/finders.md
+++ b/versioned_docs/version-10.x/finders.md
@@ -89,7 +89,7 @@ Output:
     license: MIT
 ```
 
-Othere example use cases:
+Other example use cases:
 * Find all packages with a specific license.
 * Detect packages requiring a minimum Node.js version.
 * List all dependencies that expose binaries.

--- a/versioned_docs/version-10.x/installation.md
+++ b/versioned_docs/version-10.x/installation.md
@@ -99,7 +99,7 @@ You can pin the version of pnpm used on your project using the following command
 corepack use pnpm@latest-10
 ```
 
-This will add a `"packageManager"` field in your local `package.json` which will instruct Corepack to always use a specific version on that project. This can be useful if you want reproducability, as all developers who are using Corepack will use the same version as you. When a new version of pnpm is released, you can re-run the above command.
+This will add a `"packageManager"` field in your local `package.json` which will instruct Corepack to always use a specific version on that project. This can be useful if you want reproducibility, as all developers who are using Corepack will use the same version as you. When a new version of pnpm is released, you can re-run the above command.
 
 ## Using other package managers
 


### PR DESCRIPTION
## Summary
- Ran cspell over docs/*.md and versioned_docs/*.md, fixed 3 confirmed typos (rest were technical terms/names, no false positive noise).

## Test plan
- N/A, doc-only text fixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a heading typo in the finders documentation.
  * Fixed the spelling of “reproducibility” in the Corepack installation documentation.
  * Applied corrections to both current and versioned documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->