### PR TITLE
docs: document pnpm v12.0.0-rc.5

### DIFF
--- a/blog/2026-08-10-whats-different-in-pnpm-12.md
+++ b/blog/2026-08-10-whats-different-in-pnpm-12.md
@@ -8,7 +8,7 @@ tags: [release]
 
 pnpm 12 is a rewrite of pnpm in Rust, and it is currently a **release candidate**. Upgrading is not meant to be a migration: apart from the differences below, it keeps the commands, flags, settings, and lockfile format of pnpm 11, and the [documentation](/motivation) applies to both versions.
 
-Three things differ, and one of them — a removed flag — fails outright rather than behaving differently. This post collects them in one place.
+Four things differ, and one of them — a removed flag — fails outright rather than behaving differently. This post collects them in one place.
 
 <!--truncate-->
 
@@ -42,6 +42,14 @@ git config --global url."git@github.com:".insteadOf https://github.com/
 ```
 
 pnpm shells out to `git`, so the rewrite applies to all of its Git operations automatically. Details, including how unknown hosts and credentialed URLs are handled, are in [How Git dependencies are resolved](/package-sources#how-git-dependencies-are-resolved).
+
+## Lockfiles of cyclic dependency graphs
+
+Since v12.0.0-rc.5, pnpm breaks dependency cycles at a fixed place instead of wherever the installation happens to walk into them: the packages in a cycle are ordered by package ID, and the edges that close the cycle are always cut at the same point.
+
+The effect is that the lockfile is a function of the dependency graph alone. Reordering the `packages` globs in `pnpm-workspace.yaml`, reordering entries in `package.json`, or simply installing twice all produce a byte-identical lockfile — in pnpm 11 they could produce different ones for a project with cyclic dependencies. Cycle-heavy workspaces also resolve peers 2–3× faster, use about 25% less memory, and get a substantially smaller lockfile, because a package inside a cycle no longer gets a separate peer variant per path that reaches it.
+
+Existing lockfiles keep working: `--frozen-lockfile` installs consume them unchanged, and an install that doesn't re-resolve leaves them untouched. The first install that does re-resolve re-keys the peer variants of cyclic packages once, so expect a one-time lockfile diff on such projects. The details are in [How peers are resolved](/how-peers-are-resolved#cyclic-dependencies).
 
 ## `pnpm install --resolution-only` is gone
 

--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -19,6 +19,16 @@ When used without arguments, updates all dependencies.
 |`pnpm up foo@2`       | Updates `foo` to the latest version on v2                                |
 |`pnpm up "@babel/*"` | Updates all dependencies under the `@babel` scope                        |
 
+## What an update writes
+
+Besides moving `pnpm-lock.yaml` to the newly resolved versions, `pnpm update` writes the new range back to the place the dependency is declared:
+
+* In `package.json`, the range is moved onto the resolved version while the operator the dependency already declared is kept, so `^1.1.0` stays a caret range.
+* A dependency declared through the [`catalog:` protocol](../catalogs.md) is not rewritten in `package.json`. The catalog entry it points at is updated instead, in `pnpm-workspace.yaml`.
+* A dependency declared through a dist-tag, such as `"foo": "latest"`, keeps tracking the tag. The tag stays in `package.json` and only the lockfile moves to the version behind it — with `--latest` as well.
+
+Pass [`--no-save`](#--no-save) to update the lockfile only and leave the declared ranges alone.
+
 ## Selecting dependencies with patterns
 
 You can use patterns to update specific dependencies.

--- a/docs/how-peers-are-resolved.md
+++ b/docs/how-peers-are-resolved.md
@@ -113,3 +113,17 @@ node_modules
     ├── c@1.0.0
     ├── c@1.1.0
 ```
+
+## Cyclic dependencies
+
+Added in: v12.0.0-rc.5 (pnpm v12 only)
+
+Packages may depend on each other in a cycle: `a` depends on `b`, and `b` — directly, or through further packages — depends back on `a`. When a package inside such a cycle has peer dependencies, there is no single point "higher in the graph" to resolve them from, because entering the cycle at `a` and entering it at `b` lead to different parents.
+
+pnpm cuts every cycle at a fixed place. The packages that form a cycle are ordered by their package IDs, and the edges that close it are cut at the same point no matter where the installation walks into it. The cut edge is still a real dependency — it is resolved against an occurrence of its target taken at the project level — but the walk never travels around the cycle, so a package inside a cycle is no longer resolved once per path that reaches it. Peer dependencies of packages inside a cycle still resolve to the nearest match along that order.
+
+Because the cut no longer depends on the path the installation takes, the lockfile is a function of the dependency graph alone. Repeated installs, reordered `packages` globs in `pnpm-workspace.yaml`, and reordered entries in `package.json` all produce a byte-identical lockfile. Projects with cycle-heavy dependency graphs also end up with a smaller lockfile, since packages inside a cycle no longer get a separate peer variant per path that reaches them.
+
+Existing lockfiles keep working: [`--frozen-lockfile`](./cli/install.md#--frozen-lockfile) installs consume them unchanged, and installs that skip resolution leave them untouched. The first install that re-resolves — after a dependency change, for instance — re-keys the peer variants of cyclic packages once, which shows up as a one-time lockfile diff.
+
+In pnpm v11, where the cut depends on the order the graph is walked, the same dependencies can produce different lockfiles depending on the order projects and dependencies are listed in.

--- a/docs/settings/other.md
+++ b/docs/settings/other.md
@@ -203,6 +203,14 @@ This resolution mode works only with npm's [full metadata]. So it is slower in s
 
 When `resolutionMode` is set to `lowest-direct`, direct dependencies will be resolved to their lowest versions.
 
+Only the dependencies declared in `package.json` count as direct here. A peer dependency that [`autoInstallPeers`](./peer-dependencies.md#autoinstallpeers) adds is not something the project declared, so it is resolved like a subdependency: to the highest version satisfying the peer range, or under `time-based`, to the highest version within the publish-date cutoff.
+
+:::note
+
+pnpm v12 resolved automatically installed peers to their lowest satisfying version until v12.0.0-rc.5. If you are on an earlier v12 release candidate, an install with this setting may pull in old peer versions along with the dependencies those old versions carried.
+
+:::
+
 ### registrySupportsTimeField
 
 * Default: **false**

--- a/docs/settings/other.md
+++ b/docs/settings/other.md
@@ -205,12 +205,6 @@ When `resolutionMode` is set to `lowest-direct`, direct dependencies will be res
 
 Only the dependencies declared in `package.json` count as direct here. A peer dependency that [`autoInstallPeers`](./peer-dependencies.md#autoinstallpeers) adds is not something the project declared, so it is resolved like a subdependency: to the highest version satisfying the peer range, or under `time-based`, to the highest version within the publish-date cutoff.
 
-:::note
-
-pnpm v12 resolved automatically installed peers to their lowest satisfying version until v12.0.0-rc.5. If you are on an earlier v12 release candidate, an install with this setting may pull in old peer versions along with the dependencies those old versions carried.
-
-:::
-
 ### registrySupportsTimeField
 
 * Default: **false**

--- a/docs/settings/peer-dependencies.md
+++ b/docs/settings/peer-dependencies.md
@@ -11,6 +11,8 @@ sidebar_label: "Peer dependencies"
 
 When `true`, any missing non-optional peer dependencies are automatically installed.
 
+The version picked is the highest one satisfying the peer range. Since an automatically installed peer is not a dependency the project declares, [`resolutionMode`](./other.md#resolutionmode) treats it as a subdependency rather than a direct one, so `lowest-direct` does not lower it.
+
 #### Version Conflicts
 
 If there are conflicting version requirements for a peer dependency from different packages, pnpm will not install any version of the conflicting peer dependency automatically. Instead, a warning is printed. For example, if one dependency requires `react@^16.0.0` and another requires `react@^17.0.0`, these requirements conflict, and no automatic installation will occur.


### PR DESCRIPTION
Documents the user-visible changes from [pnpm v12.0.0-rc.5](https://github.com/pnpm/pnpm/releases).

- **`docs/how-peers-are-resolved.md`** — new "Cyclic dependencies" section (`Added in: v12.0.0-rc.5 (pnpm v12 only)`): cycle members are ordered by package ID and the closing edge is cut at the same point regardless of the walk path, peers inside a cycle keep nearest-wins along that order, the lockfile becomes a function of the dependency graph alone, cycle-heavy projects get a smaller one, and the first install that re-resolves re-keys their peer variants once.
- **`blog/2026-08-10-whats-different-in-pnpm-12.md`** — same change as the fourth v12-vs-v11 difference (intro count bumped), with the 2–3× peer resolution speedup and ~25% memory figures, and a link to the docs section.
- **`docs/settings/other.md` (`resolutionMode`) and `docs/settings/peer-dependencies.md` (`autoInstallPeers`)** — an auto-installed peer is not a declared direct dependency, so it resolves like a subdependency (highest satisfying, or highest within the publish-date cutoff under `time-based`); `lowest-direct` does not lower it.
- **`docs/cli/update.md`** — new "What an update writes" section: the range is written back to `package.json` with the declared operator preserved, a `catalog:` dependency updates the catalog entry instead, and a dist-tag dependency keeps tracking the tag (including under `--latest`).

Not documented on purpose: the retained `deprecated` marker and the workspace importer-order fix are internal correctness fixes (the visible half of the latter — reordering `packages` globs yields an identical lockfile — is covered in the cycles section), and the `pnpm config delete` ENOENT fix was v11-only.

`pnpm build` passes; the only broken link reported (`/cli/pn` in the 11.0 release post) is pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Documented deterministic lockfile generation for cyclic dependencies, including migration behavior and reduced lockfile variations.
  - Clarified what `pnpm update` records, including lockfile, version ranges, catalog entries, and unchanged dist-tags.
  - Explained how `--no-save` prevents version range updates.
  - Documented cyclic peer resolution and differences from pnpm 11.
  - Clarified that automatically installed peer dependencies use the highest satisfying version and are unaffected by `lowest-direct`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
