### PR TITLE
docs: drop Corepack from the Docker page

### DIFF
--- a/docs/cli/env.md
+++ b/docs/cli/env.md
@@ -11,12 +11,6 @@ title: "pnpm env <cmd>"
 
 Manages the Node.js environment.
 
-:::danger
-
-`pnpm env` does not include the binaries for Corepack. If you want to use Corepack to install other package managers, you need to install it separately (e.g. `pnpm add -g corepack`).
-
-:::
-
 <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/84-MzN_0Cng" title="The pnpm patch command demo" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; fullscreen"></iframe>
 
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -72,13 +72,15 @@ CMD ["pnpm", "start"]
 - You want to upgrade pnpm and Node.js independently.
 - You prefer a minimal Debian base without the Node.js build toolchain.
 
-If you already have a preferred Node.js base image (e.g. `node:XX-slim`), the recipes further down this page remain a fine choice.
+The recipes further down this page start from this image and let pnpm install Node.js. If you prefer your own Node.js base image, keep the rest of each recipe and [install pnpm](./installation.md) into that image instead.
 
 ## Minimizing Docker image size and build time
 
-* Use a small image, e.g. `node:XX-slim`.
+* Use a small image, e.g. `ghcr.io/pnpm/pnpm` or `node:XX-slim`.
 * Leverage multi-stage if possible and makes sense.
 * Leverage BuildKit cache mounts.
+
+The recipes below use the official pnpm image, which already sets `PNPM_HOME=/pnpm` and puts `/pnpm/bin` on `PATH`, so the store the cache mounts target is at `/pnpm/store`.
 
 ### Example 1: Build a bundle in a Docker container
 
@@ -95,10 +97,8 @@ dist
 ```
 
 ```dockerfile title="Dockerfile"
-FROM node:24-slim AS base
-ENV PNPM_HOME="/pnpm"
-ENV PATH="$PNPM_HOME/bin:$PATH"
-RUN corepack enable
+FROM ghcr.io/pnpm/pnpm:11 AS base
+RUN pnpm runtime set node 24 -g
 COPY . /app
 WORKDIR /app
 
@@ -165,10 +165,8 @@ dist
 ```
 
 ```dockerfile title="Dockerfile"
-FROM node:24-slim AS base
-ENV PNPM_HOME="/pnpm"
-ENV PATH="$PNPM_HOME/bin:$PATH"
-RUN corepack enable
+FROM ghcr.io/pnpm/pnpm:11 AS base
+RUN pnpm runtime set node 24 -g
 
 FROM base AS build
 COPY . /usr/src/app
@@ -205,11 +203,9 @@ On CI or CD environments, the BuildKit cache mounts might not be available, beca
 So an alternative is to use a typical Dockerfile with layers that are built incrementally, for this scenario, `pnpm fetch` is the best option, as it only needs the `pnpm-lock.yaml` file and the layer cache will only be lost when you change the dependencies.
 
 ```dockerfile title="Dockerfile"
-FROM node:24-slim AS base
+FROM ghcr.io/pnpm/pnpm:11 AS base
 
-ENV PNPM_HOME="/pnpm"
-ENV PATH="$PNPM_HOME/bin:$PATH"
-RUN corepack enable
+RUN pnpm runtime set node 24 -g
 
 FROM base AS prod
 


### PR DESCRIPTION
Closes the docs half of pnpm/pnpm#13884, requested in https://github.com/pnpm/pnpm/issues/11732#issuecomment-5271149215.

## What changed

The three Docker recipes were the last place the docs told people to run `corepack enable`. They now start from the official `ghcr.io/pnpm/pnpm` image that the top of this page already documents, and let pnpm install Node.js:

```diff
-FROM node:24-slim AS base
-ENV PNPM_HOME="/pnpm"
-ENV PATH="$PNPM_HOME/bin:$PATH"
-RUN corepack enable
+FROM ghcr.io/pnpm/pnpm:11 AS base
+RUN pnpm runtime set node 24 -g
```

The image already sets `PNPM_HOME=/pnpm` and puts `/pnpm/bin` on `PATH`, so the two `ENV` lines are redundant and the BuildKit cache mounts still target `/pnpm/store`.

Installing pnpm into `node:XX-slim` is still supported, but it is no longer a one-liner — the standalone script needs `ca-certificates`, `curl` and `libatomic1` added to that image, plus a `SHELL` that `pnpm setup` recognizes — so the prose points at the installation page for that path instead of spelling it out in every recipe.

Also removes the `pnpm env` danger note about Corepack binaries, the second docs todo in pnpm/pnpm#13884.

Both files under `docs/` cover v11 and v12: `versioned_docs/version-11.x` is generated from `docs/` by `pnpm copy-docs`, so no separate versioned edit is needed.

## Verification

Every recipe was extracted verbatim from the rendered page and built with Podman:

- Example 1 builds and the final image's `pnpm start` runs the bundle.
- Example 3 (`pnpm fetch`) builds.
- Example 2 builds `--target app1`, deploying app1 and app2. Its runtime behavior is unchanged from the current docs — the pre-existing `node:24-slim` + Corepack version of the same Dockerfile fails identically at `pnpm start` on the deploy fixture used for testing.

## Not included

`corepack enable` still appears in the Docker examples on [podman](https://pnpm.io/podman) and [`pnpm fetch`](https://pnpm.io/cli/fetch) (the latter also pins `pnpm@latest-11`). Those are outside the todos listed in pnpm/pnpm#13884; happy to fold them in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)