### PR TITLE
feat: benchmark pnpm vs fnm on Node.js version management

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -28,6 +28,15 @@ jobs:
           corepack prepare yarn@stable --activate
       - run: curl https://bun.sh/install | bash
       - run: /home/runner/.bun/bin/bun -v
+      # fnm is compared against pnpm in the Node.js version management section.
+      - name: Install fnm
+        run: |
+          curl -fsSL https://github.com/Schniz/fnm/releases/latest/download/fnm-linux.zip -o /tmp/fnm.zip
+          unzip -o /tmp/fnm.zip -d /tmp/fnm
+          mkdir -p "$HOME/.local/bin"
+          install -m 755 /tmp/fnm/fnm "$HOME/.local/bin/fnm"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/fnm" --version
       - run: pnpm --dir=benchmarks install
       - run: pnpm --dir=benchmarks run benchmark
       - run: pnpm --dir=benchmarks run benchmark

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -4,3 +4,9 @@
 pnpm install
 pnpm run benchmark
 ```
+
+The Node.js version management section compares pnpm with [fnm](https://github.com/Schniz/fnm), so `fnm` has to be on `PATH`:
+
+```
+curl -fsSL https://fnm.vercel.app/install | bash
+```

--- a/benchmarks/benchmarkNodeVersions.js
+++ b/benchmarks/benchmarkNodeVersions.js
@@ -1,0 +1,127 @@
+'use strict'
+import fs from 'fs'
+import path from 'path'
+import rimraf from 'rimraf'
+import pathKey from 'path-key'
+import spawn from 'cross-spawn'
+import tempy from 'tempy'
+import { createEnv } from './benchmarkFixture.js'
+
+const TMP = tempy.directory()
+
+// Every scenario measures the primary version. The secondary one is only
+// installed (unmeasured) so that the switch scenario has another version to
+// switch away from.
+export const PRIMARY_NODE_VERSION = '24'
+const SECONDARY_NODE_VERSION = '22'
+
+// Each runner isolates its tool in `dir` so that scenarios never see the
+// machine's real Node.js installations:
+//   env()             environment that points the tool at `dir`
+//   prepare()         create whatever the tool expects to exist upfront
+//   install(version)  install a Node.js version and make it the active one
+//   activate(version) make an already installed version the active one
+//   dropInstalled()   remove the installed runtimes, keeping the tool's cache
+const runners = {
+  pnpm12: (dir) => {
+    // pnpm keeps the linked runtime under PNPM_HOME and the fetched files in
+    // its content-addressable store, which lives outside of PNPM_HOME here so
+    // that dropping the installed runtime leaves the store warm.
+    const home = path.join(dir, 'home')
+    const store = path.join(dir, 'store')
+    const install = (version) => ({
+      name: 'pnpm',
+      args: ['runtime', 'set', 'node', version, '--global', `--store-dir=${store}`],
+    })
+    // pnpm refuses to install a global runtime when its global bin directory
+    // is not in PATH, so the directory is created and exported upfront.
+    const prepare = () => fs.mkdirSync(path.join(home, 'bin'), { recursive: true })
+    return {
+      env: (baseEnv) => {
+        const pathEnv = pathKey()
+        const env = Object.create(baseEnv)
+        env.PNPM_HOME = home
+        env[pathEnv] = [path.join(home, 'bin'), baseEnv[pathEnv]].join(path.delimiter)
+        return env
+      },
+      prepare,
+      install,
+      // pnpm has no dedicated command for switching: setting an already
+      // installed version links it into the global bin directory.
+      activate: install,
+      dropInstalled: () => {
+        rimraf.sync(home)
+        prepare()
+      },
+    }
+  },
+  fnm: (dir) => {
+    const fnmDir = path.join(dir, 'fnm')
+    return {
+      env: (baseEnv) => {
+        const env = Object.create(baseEnv)
+        env.FNM_DIR = fnmDir
+        return env
+      },
+      prepare: () => {},
+      install: (version) => ({ name: 'fnm', args: ['install', version] }),
+      activate: (version) => ({ name: 'fnm', args: ['default', version] }),
+      // fnm stores nothing besides the unpacked versions, so this leaves it
+      // with a cold cache. That is the point of the scenario: fnm has to
+      // download Node.js again, pnpm can link it from its store.
+      dropInstalled: () => {
+        rimraf.sync(path.join(fnmDir, 'node-versions'))
+        rimraf.sync(path.join(fnmDir, 'aliases'))
+      },
+    }
+  },
+}
+
+export default async function benchmarkNodeVersions (pm, opts) {
+  const dir = path.join(TMP, pm.scenario)
+  rimraf.sync(dir)
+  fs.mkdirSync(dir, { recursive: true })
+
+  const runner = runners[pm.scenario](dir)
+  const env = runner.env(createEnv(opts.managersDir))
+  runner.prepare()
+
+  console.log('# clean install of Node.js')
+
+  const cleanInstall = measure(runner.install(PRIMARY_NODE_VERSION), dir, env)
+
+  runner.dropInstalled()
+
+  console.log('# install of Node.js with a warm store')
+
+  const warmStoreInstall = measure(runner.install(PRIMARY_NODE_VERSION), dir, env)
+
+  console.log(`# installing Node.js ${SECONDARY_NODE_VERSION} to switch away from`)
+
+  run(runner.install(SECONDARY_NODE_VERSION), dir, env)
+
+  console.log('# switching to an already installed version')
+
+  const switchVersion = measure(runner.activate(PRIMARY_NODE_VERSION), dir, env)
+
+  rimraf.sync(dir)
+  return {
+    cleanInstall,
+    warmStoreInstall,
+    switchVersion,
+  }
+}
+
+function measure (cmd, cwd, env) {
+  const startTime = Date.now()
+  run(cmd, cwd, env)
+  return Date.now() - startTime
+}
+
+function run (cmd, cwd, env) {
+  console.log(`> ${cmd.name} ${cmd.args.join(' ')}`)
+  const result = spawn.sync(cmd.name, cmd.args, { env, cwd, stdio: 'inherit' })
+  if (result.status !== 0) {
+    throw new Error(`${cmd.name} failed with status code ${result.status}`)
+  }
+}

--- a/benchmarks/benchmarkNodeVersions.js
+++ b/benchmarks/benchmarkNodeVersions.js
@@ -26,7 +26,7 @@ const RUNS_PER_MEASUREMENT = 10
 //   install(version)          install a version and make it the global default
 //   setDefault(version)       make an installed version the global default
 //   dropInstalled()           remove installed runtimes, keeping the tool's cache
-//   resolveVersion(version)   the exact version an installed version spec is
+//   defaultVersion()          run Node.js with whatever the global default is
 //   pinProject(dir, version)  pin a project directory to a version
 //   runInProject()            run Node.js in a pinned project directory
 const runners = {
@@ -63,7 +63,8 @@ const runners = {
         rimraf.sync(home)
         prepare()
       },
-      resolveVersion: runInProject,
+      // Outside of a pinned project the shim runs the global default.
+      defaultVersion: runInProject,
       pinProject: (projectDir, version) => {
         fs.writeFileSync(path.join(projectDir, 'package.json'), JSON.stringify({
           name: 'pinned-project',
@@ -94,7 +95,7 @@ const runners = {
         rimraf.sync(path.join(fnmDir, 'node-versions'))
         rimraf.sync(path.join(fnmDir, 'aliases'))
       },
-      resolveVersion: (version) => ({ name: 'fnm', args: ['exec', `--using=${version}`, '--', 'node', '--version'] }),
+      defaultVersion: () => ({ name: 'fnm', args: ['exec', '--using=default', '--', 'node', '--version'] }),
       pinProject: (projectDir, version) => {
         fs.writeFileSync(path.join(projectDir, '.node-version'), `${version}\n`)
       },
@@ -125,12 +126,17 @@ export default async function benchmarkNodeVersions (pm, opts) {
   console.log(`# installing Node.js ${SECONDARY_NODE_VERSION} to switch away from`)
 
   run(runner.install(SECONDARY_NODE_VERSION), dir, env)
-  const pinnedVersion = capture(runner.resolveVersion(SECONDARY_NODE_VERSION), dir, env).trim().replace(/^v/, '')
+  // fnm keeps the version it installed first as the default, so the version to
+  // switch away from is selected explicitly. Both tools are then in the same
+  // state, which is what makes the timing below a switch and not a no-op.
+  run(runner.setDefault(SECONDARY_NODE_VERSION), dir, env)
+  const pinnedVersion = readDefaultVersion(runner, dir, env)
   assertVersion(pinnedVersion, SECONDARY_NODE_VERSION)
 
   console.log('# making an installed version the global default')
 
   const setDefault = measure(runner.setDefault(PRIMARY_NODE_VERSION), dir, env)
+  assertVersion(readDefaultVersion(runner, dir, env), PRIMARY_NODE_VERSION)
 
   console.log(`# running Node.js in a project pinned to ${pinnedVersion}`)
 
@@ -152,7 +158,12 @@ export default async function benchmarkNodeVersions (pm, opts) {
   }
 }
 
-// Guards against measuring some other Node.js that happens to be on PATH.
+function readDefaultVersion (runner, cwd, env) {
+  return capture(runner.defaultVersion(), cwd, env).trim().replace(/^v/, '')
+}
+
+// Guards against measuring some other Node.js that happens to be on PATH, and
+// against a scenario silently degrading into a no-op.
 function assertVersion (actual, expectedMajor) {
   if (!/^v?\d+\./.test(actual) || actual.replace(/^v/, '').split('.')[0] !== expectedMajor) {
     throw new Error(`Expected Node.js ${expectedMajor} to be used, got "${actual}"`)
@@ -162,11 +173,13 @@ function assertVersion (actual, expectedMajor) {
 function measure (cmd, cwd, env, runs = 1) {
   let best = Infinity
   for (let i = 0; i < runs; i++) {
-    const startTime = Date.now()
+    // Some of these scenarios take single digit milliseconds, which the
+    // resolution of Date.now() would round beyond recognition.
+    const startTime = process.hrtime.bigint()
     run(cmd, cwd, env)
-    best = Math.min(best, Date.now() - startTime)
+    best = Math.min(best, Number(process.hrtime.bigint() - startTime) / 1e6)
   }
-  return best
+  return Math.round(best * 100) / 100
 }
 
 function run (cmd, cwd, env) {

--- a/benchmarks/benchmarkNodeVersions.js
+++ b/benchmarks/benchmarkNodeVersions.js
@@ -9,19 +9,26 @@ import { createEnv } from './benchmarkFixture.js'
 
 const TMP = tempy.directory()
 
-// Every scenario measures the primary version. The secondary one is only
-// installed (unmeasured) so that the switch scenario has another version to
-// switch away from.
+// The install scenarios measure the primary version. The secondary one is what
+// the global default is switched away from and what the project is pinned to.
 export const PRIMARY_NODE_VERSION = '24'
-const SECONDARY_NODE_VERSION = '22'
+export const SECONDARY_NODE_VERSION = '22'
+
+// Running Node.js takes single digit milliseconds, which is the same order of
+// magnitude as the noise of spawning a process, so that scenario is measured
+// repeatedly and the fastest run is kept.
+const RUNS_PER_MEASUREMENT = 10
 
 // Each runner isolates its tool in `dir` so that scenarios never see the
 // machine's real Node.js installations:
-//   env()             environment that points the tool at `dir`
-//   prepare()         create whatever the tool expects to exist upfront
-//   install(version)  install a Node.js version and make it the active one
-//   activate(version) make an already installed version the active one
-//   dropInstalled()   remove the installed runtimes, keeping the tool's cache
+//   env()                     environment that points the tool at `dir`
+//   prepare()                 create whatever the tool expects to exist upfront
+//   install(version)          install a version and make it the global default
+//   setDefault(version)       make an installed version the global default
+//   dropInstalled()           remove installed runtimes, keeping the tool's cache
+//   resolveVersion(version)   the exact version an installed version spec is
+//   pinProject(dir, version)  pin a project directory to a version
+//   runInProject()            run Node.js in a pinned project directory
 const runners = {
   pnpm12: (dir) => {
     // pnpm keeps the linked runtime under PNPM_HOME and the fetched files in
@@ -36,6 +43,9 @@ const runners = {
     // pnpm refuses to install a global runtime when its global bin directory
     // is not in PATH, so the directory is created and exported upfront.
     const prepare = () => fs.mkdirSync(path.join(home, 'bin'), { recursive: true })
+    // The `node` on PATH is a shim that picks the runtime of the current
+    // project, so running Node.js needs no extra command.
+    const runInProject = () => ({ name: 'node', args: ['--version'] })
     return {
       env: (baseEnv) => {
         const pathEnv = pathKey()
@@ -46,17 +56,28 @@ const runners = {
       },
       prepare,
       install,
-      // pnpm has no dedicated command for switching: setting an already
-      // installed version links it into the global bin directory.
-      activate: install,
+      // pnpm has no dedicated command for this: setting an already installed
+      // version links it into the global bin directory.
+      setDefault: install,
       dropInstalled: () => {
         rimraf.sync(home)
         prepare()
       },
+      resolveVersion: runInProject,
+      pinProject: (projectDir, version) => {
+        fs.writeFileSync(path.join(projectDir, 'package.json'), JSON.stringify({
+          name: 'pinned-project',
+          devEngines: { runtime: { name: 'node', version, onFail: 'download' } },
+        }))
+      },
+      runInProject,
     }
   },
   fnm: (dir) => {
     const fnmDir = path.join(dir, 'fnm')
+    // `fnm exec` resolves the version of the current project and runs the
+    // command with it, which is what the `--use-on-cd` shell hook does on `cd`.
+    const runInProject = () => ({ name: 'fnm', args: ['exec', '--', 'node', '--version'] })
     return {
       env: (baseEnv) => {
         const env = Object.create(baseEnv)
@@ -65,7 +86,7 @@ const runners = {
       },
       prepare: () => {},
       install: (version) => ({ name: 'fnm', args: ['install', version] }),
-      activate: (version) => ({ name: 'fnm', args: ['default', version] }),
+      setDefault: (version) => ({ name: 'fnm', args: ['default', version] }),
       // fnm stores nothing besides the unpacked versions, so this leaves it
       // with a cold cache. That is the point of the scenario: fnm has to
       // download Node.js again, pnpm can link it from its store.
@@ -73,6 +94,11 @@ const runners = {
         rimraf.sync(path.join(fnmDir, 'node-versions'))
         rimraf.sync(path.join(fnmDir, 'aliases'))
       },
+      resolveVersion: (version) => ({ name: 'fnm', args: ['exec', `--using=${version}`, '--', 'node', '--version'] }),
+      pinProject: (projectDir, version) => {
+        fs.writeFileSync(path.join(projectDir, '.node-version'), `${version}\n`)
+      },
+      runInProject,
     }
   },
 }
@@ -99,23 +125,48 @@ export default async function benchmarkNodeVersions (pm, opts) {
   console.log(`# installing Node.js ${SECONDARY_NODE_VERSION} to switch away from`)
 
   run(runner.install(SECONDARY_NODE_VERSION), dir, env)
+  const pinnedVersion = capture(runner.resolveVersion(SECONDARY_NODE_VERSION), dir, env).trim().replace(/^v/, '')
+  assertVersion(pinnedVersion, SECONDARY_NODE_VERSION)
 
-  console.log('# switching to an already installed version')
+  console.log('# making an installed version the global default')
 
-  const switchVersion = measure(runner.activate(PRIMARY_NODE_VERSION), dir, env)
+  const setDefault = measure(runner.setDefault(PRIMARY_NODE_VERSION), dir, env)
+
+  console.log(`# running Node.js in a project pinned to ${pinnedVersion}`)
+
+  const projectDir = path.join(dir, 'project')
+  fs.mkdirSync(projectDir, { recursive: true })
+  runner.pinProject(projectDir, pinnedVersion)
+  // The first run materializes the pinned runtime, the benchmark measures the
+  // repeated runs that a project does afterwards.
+  const runsPinnedVersion = capture(runner.runInProject(), projectDir, env).trim()
+  assertVersion(runsPinnedVersion, SECONDARY_NODE_VERSION)
+  const runInProject = measure(runner.runInProject(), projectDir, env, RUNS_PER_MEASUREMENT)
 
   rimraf.sync(dir)
   return {
     cleanInstall,
     warmStoreInstall,
-    switchVersion,
+    setDefault,
+    runInProject,
   }
 }
 
-function measure (cmd, cwd, env) {
-  const startTime = Date.now()
-  run(cmd, cwd, env)
-  return Date.now() - startTime
+// Guards against measuring some other Node.js that happens to be on PATH.
+function assertVersion (actual, expectedMajor) {
+  if (!/^v?\d+\./.test(actual) || actual.replace(/^v/, '').split('.')[0] !== expectedMajor) {
+    throw new Error(`Expected Node.js ${expectedMajor} to be used, got "${actual}"`)
+  }
+}
+
+function measure (cmd, cwd, env, runs = 1) {
+  let best = Infinity
+  for (let i = 0; i < runs; i++) {
+    const startTime = Date.now()
+    run(cmd, cwd, env)
+    best = Math.min(best, Date.now() - startTime)
+  }
+  return best
 }
 
 function run (cmd, cwd, env) {
@@ -124,4 +175,12 @@ function run (cmd, cwd, env) {
   if (result.status !== 0) {
     throw new Error(`${cmd.name} failed with status code ${result.status}`)
   }
+}
+
+function capture (cmd, cwd, env) {
+  const result = spawn.sync(cmd.name, cmd.args, { env, cwd })
+  if (result.status !== 0) {
+    throw new Error(`${cmd.name} failed with status code ${result.status}. ${result.stderr?.toString()}`)
+  }
+  return result.stdout.toString()
 }

--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -7,6 +7,7 @@ import prettyMs from 'pretty-ms'
 import tempy from 'tempy'
 import cmdsMap from './commandsMap.js'
 import benchmark from './recordBenchmark.js'
+import nodeVersionsSection from './nodeVersionsSection.js'
 import generateSvg from './generateSvg.js'
 import generateStackedSvg from './generateStackedSvg.js'
 import spawn from "cross-spawn"
@@ -19,6 +20,7 @@ const BENCH_IMGS = path.join(DIRNAME, '../static/img/benchmarks')
 
 const { stripIndents } = commonTags
 const LIMIT_RUNS = 30
+const NODE_VERSIONS_SVG = 'node-versions'
 
 const fixtures = [
   /*{
@@ -103,7 +105,7 @@ run()
 async function run () {
   const tmpDir = tempy.directory()
   const managersDirs = {}
-  for (const pm of ['npm', 'pnpm11', 'pnpm12', 'yarn']) {
+  for (const pm of ['npm', 'pnpm11', 'pnpm12', 'yarn', 'fnm']) {
     managersDirs[pm] = path.join(tmpDir, pm)
   }
   await Promise.allSettled([
@@ -252,12 +254,24 @@ async function run () {
     })
   }
 
+  const nodeVersions = await nodeVersionsSection({
+    managersDirs: { pnpm12: managersDirs.pnpm12, fnm: managersDirs.fnm },
+    formattedNow,
+    limitRuns: LIMIT_RUNS,
+    svgName: NODE_VERSIONS_SVG,
+  })
+  sections.push(nodeVersions.section)
+  svgs.push({
+    path: path.join(BENCH_IMGS, `${NODE_VERSIONS_SVG}.svg`),
+    file: nodeVersions.svg
+  })
+
   const introduction = stripIndents`
   # Benchmarks of JavaScript Package Managers
 
   **Last benchmarked at**: _${formattedNow}_ (_daily_ updated).
 
-  This benchmark compares the performance of npm, pnpm, Yarn Classic, and Yarn PnP (check [Yarn's benchmarks](https://yarnpkg.com/benchmarks) for any other Yarn modes that are not included here).
+  This benchmark compares the performance of npm, pnpm, Yarn Classic, and Yarn PnP (check [Yarn's benchmarks](https://yarnpkg.com/benchmarks) for any other Yarn modes that are not included here). It also compares how fast pnpm and [fnm](https://github.com/Schniz/fnm) install and switch Node.js versions.
   `
 
   const explanationItems = sortedTests.map(t => `- ${explanationByTest[t]}`).join('\n  ')

--- a/benchmarks/nodeManagersMap.js
+++ b/benchmarks/nodeManagersMap.js
@@ -1,0 +1,20 @@
+// Tools compared in the "Node.js Version Management" section.
+// The scenarios themselves live in `benchmarkNodeVersions.js`.
+export default {
+  pnpm12: {
+    scenario: 'pnpm12',
+    legend: 'pnpm',
+    mdLegend: 'pnpm 12 🦀',
+    color: '#fbae00',
+    displayVersion: '12',
+    mascot: '🦀',
+    name: 'pnpm',
+  },
+  fnm: {
+    scenario: 'fnm',
+    legend: 'fnm',
+    mdLegend: '[fnm](https://github.com/Schniz/fnm)',
+    color: '#6f42c1',
+    name: 'fnm',
+  },
+}

--- a/benchmarks/nodeVersionsSection.js
+++ b/benchmarks/nodeVersionsSection.js
@@ -1,0 +1,92 @@
+'use strict'
+import crypto from 'crypto'
+import commonTags from 'common-tags'
+import prettyMs from 'pretty-ms'
+import nodeManagersMap from './nodeManagersMap.js'
+import recordBenchmark from './recordBenchmark.js'
+import benchmarkNodeVersions, { PRIMARY_NODE_VERSION } from './benchmarkNodeVersions.js'
+import generateSvg from './generateSvg.js'
+
+const { stripIndents } = commonTags
+
+const managers = ['pnpm12', 'fnm']
+
+const tests = [
+  'cleanInstall',
+  'warmStoreInstall',
+  'switchVersion',
+]
+
+// Switching is orders of magnitude faster than an install, so it would render
+// as an invisible bar. The table below the chart still reports it.
+const chartTests = ['cleanInstall', 'warmStoreInstall']
+
+const testDescriptions = {
+  cleanInstall:     `install Node.js ${PRIMARY_NODE_VERSION} with nothing cached`,
+  warmStoreInstall: `install Node.js ${PRIMARY_NODE_VERSION} that was installed before`,
+  switchVersion:    'switch to an already installed Node.js version',
+}
+
+const chartLabels = {
+  cleanInstall:     ['install', 'clean'],
+  warmStoreInstall: ['install', 'warm store'],
+}
+
+/**
+ * Benchmarks pnpm against fnm on installing and switching Node.js versions and
+ * returns the markdown section and the chart to write next to it.
+ */
+export default async function nodeVersionsSection ({ managersDirs, formattedNow, limitRuns, svgName }) {
+  const results = {}
+  for (const key of managers) {
+    results[key] = min(await recordBenchmark(nodeManagersMap[key], 'node-versions', {
+      limitRuns,
+      managersDir: managersDirs[key],
+      benchmarkFn: (pm, _fixture, opts) => benchmarkNodeVersions(pm, opts),
+    }))
+  }
+
+  const headerLegends = managers.map((key) => nodeManagersMap[key].mdLegend ?? nodeManagersMap[key].legend).join(' | ')
+  const headerSep = managers.map(() => '---').join(' | ')
+  const rows = tests.map((test) => {
+    const values = managers.map((key) => prettyMs(results[key][test])).join(' | ')
+    return `| ${testDescriptions[test]} | ${values} |`
+  }).join('\n')
+
+  const bars = managers.map((key) => ({ ...nodeManagersMap[key], key }))
+  const resArray = chartTests.map((test) => bars.map((bar) => Math.round(results[bar.key][test] / 100) / 10))
+  const svg = generateSvg(resArray, bars, chartTests.map((test) => chartLabels[test]), formattedNow)
+  const svgHash = hashContent(svg)
+
+  const section = stripIndents`
+    ## Node.js Version Management
+
+    pnpm installs and switches Node.js versions itself, so a separate version manager is not needed. This section compares [\`pnpm runtime set node\`](/cli/runtime) with [fnm](https://github.com/Schniz/fnm).
+
+    | scenario | ${headerLegends} |
+    | ---      | ${headerSep} |
+    ${rows}
+
+    <img alt="Graph comparing pnpm and fnm on installing Node.js" src="/img/benchmarks/${svgName}.svg?v=${svgHash}" />
+
+    A few things to keep in mind when reading these numbers:
+
+    - pnpm keeps Node.js in its content-addressable store, so installing a version that was installed before is a relink with no download. fnm has no download cache, so it fetches Node.js again.
+    - pnpm doesn't extract the \`npm\`, \`npx\`, and \`corepack\` binaries bundled with Node.js, so on a clean install it downloads and writes fewer files than fnm.
+    - Switching is not the same operation in both tools. pnpm links the runtime into its global bin directory, which works in any shell without setup. fnm flips a symlink, which is close to instant but only takes effect in shells that evaluate \`fnm env\`.
+  `
+
+  return { section, svg }
+}
+
+function min (benchmarkResults) {
+  const results = {}
+  for (const test of tests) {
+    results[test] = Math.min(...benchmarkResults.map((res) => res[test]))
+  }
+  return results
+}
+
+function hashContent (content) {
+  return crypto.createHash('sha256').update(content).digest('hex').slice(0, 8)
+}

--- a/benchmarks/nodeVersionsSection.js
+++ b/benchmarks/nodeVersionsSection.js
@@ -4,7 +4,7 @@ import commonTags from 'common-tags'
 import prettyMs from 'pretty-ms'
 import nodeManagersMap from './nodeManagersMap.js'
 import recordBenchmark from './recordBenchmark.js'
-import benchmarkNodeVersions, { PRIMARY_NODE_VERSION } from './benchmarkNodeVersions.js'
+import benchmarkNodeVersions, { PRIMARY_NODE_VERSION, SECONDARY_NODE_VERSION } from './benchmarkNodeVersions.js'
 import generateSvg from './generateSvg.js'
 
 const { stripIndents } = commonTags
@@ -14,17 +14,19 @@ const managers = ['pnpm12', 'fnm']
 const tests = [
   'cleanInstall',
   'warmStoreInstall',
-  'switchVersion',
+  'setDefault',
+  'runInProject',
 ]
 
-// Switching is orders of magnitude faster than an install, so it would render
-// as an invisible bar. The table below the chart still reports it.
+// Only the installs are charted. The other scenarios are milliseconds, so they
+// would render as invisible bars. The table below the chart reports them all.
 const chartTests = ['cleanInstall', 'warmStoreInstall']
 
 const testDescriptions = {
   cleanInstall:     `install Node.js ${PRIMARY_NODE_VERSION} with nothing cached`,
   warmStoreInstall: `install Node.js ${PRIMARY_NODE_VERSION} that was installed before`,
-  switchVersion:    'switch to an already installed Node.js version',
+  setDefault:       'make an installed version the global default',
+  runInProject:     `run \`node\` in a project pinned to Node.js ${SECONDARY_NODE_VERSION}`,
 }
 
 const chartLabels = {
@@ -73,7 +75,9 @@ export default async function nodeVersionsSection ({ managersDirs, formattedNow,
 
     - pnpm keeps Node.js in its content-addressable store, so installing a version that was installed before is a relink with no download. fnm has no download cache, so it fetches Node.js again.
     - pnpm doesn't extract the \`npm\`, \`npx\`, and \`corepack\` binaries bundled with Node.js, so on a clean install it downloads and writes fewer files than fnm.
-    - Switching is not the same operation in both tools. pnpm links the runtime into its global bin directory, which works in any shell without setup. fnm flips a symlink, which is close to instant but only takes effect in shells that evaluate \`fnm env\`.
+    - Changing the global default is not the same operation in both tools. pnpm links the runtime into its global bin directory, fnm flips a symlink that only takes effect in shells evaluating \`fnm env\`.
+    - Per-project switching costs no command at all in pnpm: the \`node\` on your PATH is a shim that reads the [\`devEngines.runtime\`](/package_json#devenginesruntime) of the project and runs the matching version. With fnm, a \`.node-version\` file is picked up by its \`--use-on-cd\` shell hook, which is what the \`fnm exec\` in this row measures.
+    - Both tools have to materialize the pinned version the first time a project asks for it: pnpm links it from its store, fnm downloads it. The row above measures the repeated runs after that.
   `
 
   return { section, svg }

--- a/benchmarks/recordBenchmark.js
+++ b/benchmarks/recordBenchmark.js
@@ -12,6 +12,9 @@ const RESULTS = path.join(DIRNAME, 'results')
 export default async function (pm, fixture, opts) {
   opts = opts || {}
   const limitRuns = opts.limitRuns || Infinity
+  // Sections that don't install a fixture (the Node.js version managers, for
+  // instance) pass their own benchmark function but record results the same way.
+  const runBenchmark = opts.benchmarkFn ?? benchmark
 
   pm.version = getPMVersion(pm.name, opts)
   const resultsFile = path.join(RESULTS, pm.scenario, pm.version, `${fixture}.yaml`)
@@ -19,7 +22,7 @@ export default async function (pm, fixture, opts) {
 
   if (prevResults.length >= limitRuns) return prevResults
 
-  const newResults = await benchmark(pm, fixture, {
+  const newResults = await runBenchmark(pm, fixture, {
     hasNodeModules: opts.hasNodeModules,
     managersDir: opts.managersDir,
   })


### PR DESCRIPTION
Adds a **Node.js Version Management** section to the benchmarks page, comparing [`pnpm runtime set node`](https://pnpm.io/cli/runtime) and pnpm's runtime shim with [fnm](https://github.com/Schniz/fnm).

## Scenarios

Each tool runs in a fully isolated directory (`PNPM_HOME` plus a separate `--store-dir` for pnpm, `FNM_DIR` for fnm), so the machine's real Node.js installations are never touched:

1. install Node.js 24 with nothing cached
2. install Node.js 24 that was installed before — the runtime is dropped, the tool's store is left as it is
3. make an installed version the global default — `pnpm runtime set node 24 -g` vs `fnm default 24`
4. run `node` in a project pinned to Node.js 22 — pnpm's shim resolving `devEngines.runtime` vs `fnm exec` reading `.node-version`, which is what fnm's `--use-on-cd` hook does

Scenario 4 is the one that matters day to day, and it is checked to actually run the pinned version so that a stray Node.js on `PATH` cannot be measured by accident. Since it takes single digit milliseconds, it is run 10 times and the fastest run is kept.

The chart covers only the two install scenarios; the millisecond-scale rows would render as invisible bars. All four are in the table.

Sample numbers from a local run (the published ones will come from the benchmark runner):

| scenario | pnpm 12 🦀 | fnm |
| --- | --- | --- |
| install Node.js 24 with nothing cached | 1.6s | 1.7s |
| install Node.js 24 that was installed before | 590ms | 1.7s |
| make an installed version the global default | 687ms | 2ms |
| run `node` in a project pinned to Node.js 22 | 6ms | 2ms |

Notes below the table explain the differences the numbers don't show: pnpm relinks from its content-addressable store while fnm has no download cache, pnpm doesn't extract the bundled `npm`/`npx`/`corepack`, changing the global default is a relink in pnpm but a symlink flip in fnm that only applies to shells evaluating `fnm env`, per-project switching needs no command and no shell hook in pnpm, and both tools have to materialize a pinned version the first time a project asks for it.

## Changes

- `benchmarks/benchmarkNodeVersions.js` — the scenarios, one runner per tool
- `benchmarks/nodeManagersMap.js` — tool configs, same shape as `commandsMap.js`
- `benchmarks/nodeVersionsSection.js` — records results and builds the table and chart
- `benchmarks/recordBenchmark.js` — optional `benchmarkFn` so non-fixture benchmarks record results the same way, under `results/<tool>/<version>/node-versions.yaml`
- `benchmarks/index.js` — renders the section and `static/img/benchmarks/node-versions.svg`
- `.github/workflows/benchmark.yml` — installs the latest fnm release binary so the numbers refresh with the weekly run

`src/pages/benchmarks.md` is generated, so the section shows up on the site after the next benchmark run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added benchmark coverage for Node.js version installation, switching, and project execution using pnpm and fnm.
  - Benchmark results now include comparisons, timing tables, and visual charts for Node.js version management scenarios.
  - Added support for custom benchmark implementations while preserving existing benchmark behavior.

- **Documentation**
  - Updated benchmark setup instructions with fnm installation requirements.
  - Expanded benchmark descriptions to explain Node.js version installation and switching measurements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->