### PR TITLE
feat: benchmark Bun, and Yarn 6 instead of Yarn 4

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -25,9 +25,6 @@ jobs:
           npm install --global corepack
           corepack enable
           corepack prepare pnpm@next-10 --activate
-          corepack prepare yarn@stable --activate
-      - run: curl https://bun.sh/install | bash
-      - run: /home/runner/.bun/bin/bun -v
       # fnm is compared against pnpm in the Node.js version management section.
       - name: Install fnm
         run: |

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -5,6 +5,8 @@ pnpm install
 pnpm run benchmark
 ```
 
+npm, pnpm, and Bun are installed from the registry by the benchmark itself. Yarn is not on the registry anymore — Yarn 6 ships as a platform binary — so it is downloaded from its release channel instead, which needs `unzip` on `PATH`.
+
 The Node.js version management section compares pnpm with fnm and nvm. nvm is cloned by the benchmark itself, but `fnm` has to be on `PATH`:
 
 ```

--- a/benchmarks/benchmarkFixture.js
+++ b/benchmarks/benchmarkFixture.js
@@ -16,7 +16,8 @@ const TMP = tempy.directory()
 const lockfileNameByPM = {
   npm: 'package-lock.json',
   pnpm: 'pnpm-lock.yaml',
-  yarn: 'yarn.lock'
+  yarn: 'yarn.lock',
+  bun: 'bun.lock'
 }
 
 export function createEnv (managersDir) {
@@ -113,11 +114,17 @@ export default async function benchmark (pm, fixture, opts) {
   cleanLockfile(pm, cwd, env)
 
   if (pm.name === 'yarn') {
-    // Disable global mirror that speeds up yarn berry install
+    // Every store Yarn keeps has to sit under `cache/`, the directory the
+    // scenarios below delete to go back to a cold cache. `enableMirror` alone
+    // stopped being enough once Yarn started caching globally by default:
+    // without `enableGlobalCache`, packages land in `globalFolder` instead and
+    // survive every scenario, so no run ever measures a cold cache.
     let yarnRc =
       'enableImmutableInstalls: false\n'
+    + 'enableGlobalCache: false\n'
     + 'enableMirror: false\n'
     + `cacheFolder: ${path.join(cwd, 'cache')}\n`
+    + `globalFolder: ${path.join(cwd, 'cache', 'global')}\n`
     + 'enableScripts: false\n'
     /**
      * @see https://yarnpkg.com/configuration/yarnrc#nodeLinker

--- a/benchmarks/commandsMap.js
+++ b/benchmarks/commandsMap.js
@@ -49,6 +49,7 @@ export default {
     scenario: 'yarn',
     legend: 'Yarn',
     color: '#248ebd',
+    displayVersion: '6',
     name: 'yarn',
     args: [
       'install'
@@ -58,9 +59,26 @@ export default {
     scenario: 'yarn_pnp',
     legend: 'Yarn PnP',
     color: '#40a9ff',
+    displayVersion: '6',
     name: 'yarn',
     args: [
       'install'
+    ]
+  },
+  bun: {
+    scenario: 'bun',
+    legend: 'Bun',
+    color: '#e0709a',
+    name: 'bun',
+    args: [
+      'install',
+      '--ignore-scripts',
+      '--cache-dir=cache',
+      '--registry=https://registry.npmjs.org/',
+      // Bun turns on --frozen-lockfile whenever CI is set, which breaks every
+      // scenario that starts without a lockfile. Yarn is opted out of the same
+      // behaviour through `enableImmutableInstalls: false`.
+      '--no-frozen-lockfile',
     ]
   }
 }

--- a/benchmarks/commandsMap.js
+++ b/benchmarks/commandsMap.js
@@ -49,7 +49,6 @@ export default {
     scenario: 'yarn',
     legend: 'Yarn',
     color: '#248ebd',
-    displayVersion: '6',
     name: 'yarn',
     args: [
       'install'
@@ -59,7 +58,6 @@ export default {
     scenario: 'yarn_pnp',
     legend: 'Yarn PnP',
     color: '#40a9ff',
-    displayVersion: '6',
     name: 'yarn',
     args: [
       'install'

--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -9,6 +9,7 @@ import cmdsMap from './commandsMap.js'
 import benchmark from './recordBenchmark.js'
 import nodeVersionsSection from './nodeVersionsSection.js'
 import { cloneNvm } from './benchmarkNodeVersions.js'
+import { installYarn } from './installYarn.js'
 import generateSvg from './generateSvg.js'
 import generateStackedSvg from './generateStackedSvg.js'
 import spawn from "cross-spawn"
@@ -106,7 +107,7 @@ run()
 async function run () {
   const tmpDir = tempy.directory()
   const managersDirs = {}
-  for (const pm of ['npm', 'pnpm11', 'pnpm12', 'yarn', 'fnm', 'nvm']) {
+  for (const pm of ['npm', 'pnpm11', 'pnpm12', 'yarn', 'bun', 'fnm', 'nvm']) {
     managersDirs[pm] = path.join(tmpDir, pm)
   }
   await Promise.allSettled([
@@ -122,7 +123,9 @@ async function run () {
   // pnpm 12 ships its Rust binary via an install script, so the build must be
   // allowed; otherwise the `pnpm` bin is left as a placeholder that errors out.
   spawn.sync('pnpm', ['add', 'pnpm@next-12', '--allow-build=pnpm'], { cwd: managersDirs.pnpm12, stdio: 'inherit' })
-  spawn.sync('yarn', ['set', 'version', 'stable'], { cwd: managersDirs.yarn, stdio: 'inherit' })
+  await installYarn(managersDirs.yarn)
+  // Like pnpm 12, the bun package downloads its binary from a postinstall script.
+  spawn.sync('pnpm', ['add', 'bun@latest', '--allow-build=bun'], { cwd: managersDirs.bun, stdio: 'inherit' })
   cloneNvm(managersDirs.nvm)
   const formattedNow = new Intl.DateTimeFormat('en-US', { dateStyle: 'medium', timeStyle: 'short' }).format(new Date())
   const pmConfigs = [
@@ -131,6 +134,7 @@ async function run () {
     { key: 'pnpm12', managersDir: managersDirs.pnpm12 },
     { key: 'yarn', managersDir: managersDirs.yarn },
     { key: 'yarn_pnp', managersDir: managersDirs.yarn, hasNodeModules: false },
+    { key: 'bun', managersDir: managersDirs.bun },
   ]
   const pms = pmConfigs.map(({ key }) => key)
   const tableRows = [
@@ -186,6 +190,7 @@ async function run () {
       },
       { ...cmdsMap.yarn, key: 'yarn' },
       { ...cmdsMap.yarn_pnp, key: 'yarn_pnp' },
+      { ...cmdsMap.bun, key: 'bun' },
     ]
     const resArray = sortedTests.map(test => mainBars.map(bar => bar.stacked
       ? {
@@ -273,7 +278,7 @@ async function run () {
 
   **Last benchmarked at**: _${formattedNow}_ (_daily_ updated).
 
-  This benchmark compares the performance of npm, pnpm, Yarn Classic, and Yarn PnP (check [Yarn's benchmarks](https://yarnpkg.com/benchmarks) for any other Yarn modes that are not included here). It also compares how fast pnpm, fnm, and nvm install and switch Node.js versions.
+  This benchmark compares the performance of npm, pnpm, Yarn, Yarn PnP, and Bun (check [Yarn's benchmarks](https://yarnpkg.com/benchmarks) for any other Yarn modes that are not included here). It also compares how fast pnpm, fnm, and nvm install and switch Node.js versions.
   `
 
   const explanationItems = sortedTests.map(t => `- ${explanationByTest[t]}`).join('\n  ')

--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -102,7 +102,24 @@ const toArray = (testList, pms, resultsObj) => testList
 
 run()
   .then(() => console.log('done'))
-  .catch(err => console.error(err))
+  .catch(err => {
+    console.error(err)
+    // Without this the benchmark reports success to CI no matter what failed.
+    process.exitCode = 1
+  })
+
+/**
+ * A package manager that fails to install is worse than a failed benchmark: the
+ * scenarios still find the machine's own `npm`/`pnpm`/`bun` further down PATH
+ * and quietly measure that version instead of the one being benchmarked.
+ */
+function addPackageManager (args, cwd) {
+  const result = spawn.sync('pnpm', ['add', ...args], { cwd, stdio: 'inherit' })
+  if (result.error) throw result.error
+  if (result.status !== 0) {
+    throw new Error(`\`pnpm add ${args.join(' ')}\` failed with status code ${result.status}`)
+  }
+}
 
 async function run () {
   const tmpDir = tempy.directory()
@@ -118,14 +135,14 @@ async function run () {
   for (const dir of Object.values(managersDirs)) {
     fs.writeFileSync(path.join(dir, 'package.json'), '{}', 'utf8')
   }
-  spawn.sync('pnpm', ['add', 'npm@latest'], { cwd: managersDirs.npm, stdio: 'inherit' })
-  spawn.sync('pnpm', ['add', 'pnpm@latest'], { cwd: managersDirs.pnpm11, stdio: 'inherit' })
+  addPackageManager(['npm@latest'], managersDirs.npm)
+  addPackageManager(['pnpm@latest'], managersDirs.pnpm11)
   // pnpm 12 ships its Rust binary via an install script, so the build must be
   // allowed; otherwise the `pnpm` bin is left as a placeholder that errors out.
-  spawn.sync('pnpm', ['add', 'pnpm@next-12', '--allow-build=pnpm'], { cwd: managersDirs.pnpm12, stdio: 'inherit' })
+  addPackageManager(['pnpm@next-12', '--allow-build=pnpm'], managersDirs.pnpm12)
   await installYarn(managersDirs.yarn)
   // Like pnpm 12, the bun package downloads its binary from a postinstall script.
-  spawn.sync('pnpm', ['add', 'bun@latest', '--allow-build=bun'], { cwd: managersDirs.bun, stdio: 'inherit' })
+  addPackageManager(['bun@latest', '--allow-build=bun'], managersDirs.bun)
   cloneNvm(managersDirs.nvm)
   const formattedNow = new Intl.DateTimeFormat('en-US', { dateStyle: 'medium', timeStyle: 'short' }).format(new Date())
   const pmConfigs = [

--- a/benchmarks/installYarn.js
+++ b/benchmarks/installYarn.js
@@ -6,9 +6,12 @@ import spawn from 'cross-spawn'
 
 const YARN_REPOSITORY = 'https://repo.yarnpkg.com'
 
+// Every target Yarn publishes. Notably there is no x86_64-apple-darwin build,
+// so the benchmark cannot run on an Intel Mac.
 const TARGETS = {
   'darwin arm64': 'aarch64-apple-darwin',
   'linux arm64': 'aarch64-unknown-linux-musl',
+  'linux ia32': 'i686-unknown-linux-musl',
   'linux x64': 'x86_64-unknown-linux-musl',
 }
 
@@ -19,7 +22,7 @@ const TARGETS = {
 export async function installYarn (managersDir) {
   const target = TARGETS[`${process.platform} ${process.arch}`]
   if (!target) {
-    throw new Error(`Yarn publishes no release for ${process.platform} ${process.arch}`)
+    throw new Error(`Yarn publishes no ${process.platform} ${process.arch} release, so it cannot be benchmarked on this machine`)
   }
   const version = await latestYarnVersion()
   const downloadDir = path.join(managersDir, '.download')

--- a/benchmarks/installYarn.js
+++ b/benchmarks/installYarn.js
@@ -1,0 +1,67 @@
+'use strict'
+import fs from 'fs'
+import path from 'path'
+import rimraf from 'rimraf'
+import spawn from 'cross-spawn'
+
+const YARN_REPOSITORY = 'https://repo.yarnpkg.com'
+
+const TARGETS = {
+  'darwin arm64': 'aarch64-apple-darwin',
+  'linux arm64': 'aarch64-unknown-linux-musl',
+  'linux x64': 'x86_64-unknown-linux-musl',
+}
+
+/**
+ * Yarn 6 is a Rust rewrite distributed as a platform binary instead of an npm
+ * package, so it can't be installed the way the other package managers are.
+ */
+export async function installYarn (managersDir) {
+  const target = TARGETS[`${process.platform} ${process.arch}`]
+  if (!target) {
+    throw new Error(`Yarn publishes no release for ${process.platform} ${process.arch}`)
+  }
+  const version = await latestYarnVersion()
+  const downloadDir = path.join(managersDir, '.download')
+  const binDir = path.join(managersDir, 'node_modules/.bin')
+  rimraf.sync(downloadDir)
+  fs.mkdirSync(downloadDir, { recursive: true })
+  fs.mkdirSync(binDir, { recursive: true })
+
+  const archive = path.join(downloadDir, 'yarn.zip')
+  await download(`${YARN_REPOSITORY}/releases/${version}/${target}`, archive)
+  const result = spawn.sync('unzip', ['-q', '-o', archive, '-d', downloadDir], { stdio: 'inherit' })
+  if (result.status !== 0) {
+    throw new Error(`Failed to extract Yarn ${version}`)
+  }
+
+  // The archive ships two binaries: `yarn` is Yarn Switch, a shim that resolves
+  // and downloads the version a project pins, and `yarn-bin` is the package
+  // manager itself. The benchmark installs one known version, so it runs
+  // `yarn-bin` and never lets the shim fetch anything mid-measurement.
+  const yarnBin = path.join(binDir, 'yarn')
+  fs.copyFileSync(path.join(downloadDir, 'yarn-bin'), yarnBin)
+  fs.chmodSync(yarnBin, 0o755)
+  rimraf.sync(downloadDir)
+}
+
+/**
+ * Every Yarn 6 release so far is a prerelease, which GitHub's "latest release"
+ * endpoint hides, so the version comes from the release channel that Yarn
+ * Switch itself reads.
+ */
+async function latestYarnVersion () {
+  const res = await fetch(`${YARN_REPOSITORY}/channels/default/stable`)
+  if (!res.ok) {
+    throw new Error(`Couldn't detect the latest release of Yarn. ${res.status} ${res.statusText}`)
+  }
+  return (await res.text()).trim()
+}
+
+async function download (url, dest) {
+  const res = await fetch(url)
+  if (!res.ok) {
+    throw new Error(`Failed to download Yarn from ${url}. ${res.status} ${res.statusText}`)
+  }
+  await fs.promises.writeFile(dest, Buffer.from(await res.arrayBuffer()))
+}

--- a/benchmarks/regenerate-svgs.mjs
+++ b/benchmarks/regenerate-svgs.mjs
@@ -63,11 +63,18 @@ const pmConfigs = [
   { key: 'pnpm12' },
   { key: 'yarn' },
   { key: 'yarn_pnp', hasNodeModules: false },
+  { key: 'bun' },
 ]
 
 function latestVersionEntry (key) {
   const dir = path.join(RESULTS, key)
-  return fs.readdirSync(dir)
+  let versions
+  try {
+    versions = fs.readdirSync(dir)
+  } catch {
+    return null
+  }
+  return versions
     .map(v => {
       const file = path.join(dir, v, 'alotta-files.yaml')
       try {
@@ -77,7 +84,7 @@ function latestVersionEntry (key) {
       }
     })
     .filter(Boolean)
-    .sort((a, b) => b.mtime - a.mtime)[0]
+    .sort((a, b) => b.mtime - a.mtime)[0] ?? null
 }
 
 function minPerTest (entries) {
@@ -93,21 +100,29 @@ function toResArray (testList, keys, data) {
 const data = {}
 let latestYamlMtime = 0
 for (const { key } of pmConfigs) {
-  const { v, file, mtime } = latestVersionEntry(key)
-  const entries = await loadYamlFile(file)
-  data[key] = { version: v, results: minPerTest(entries) }
-  if (mtime > latestYamlMtime) latestYamlMtime = mtime
+  // A package manager that was added to the benchmark but hasn't been run by CI
+  // yet has no results to draw, so it is left out of the chart until it does.
+  const entry = latestVersionEntry(key)
+  if (!entry) continue
+  const entries = await loadYamlFile(entry.file)
+  data[key] = { version: entry.v, results: minPerTest(entries) }
+  if (entry.mtime > latestYamlMtime) latestYamlMtime = entry.mtime
+}
+
+if (!data.npm) {
+  console.warn('[regenerate-svgs] no benchmark results recorded yet; skipping')
+  process.exit(0)
 }
 
 const formattedNow = new Intl.DateTimeFormat('en-US', { dateStyle: 'medium', timeStyle: 'short' }).format(new Date(latestYamlMtime))
 
-const allKeys = pmConfigs.map(c => c.key)
+const allKeys = pmConfigs.map(c => c.key).filter(key => data[key])
 const sortedTests = sortTestsBySlowest(tests, data, allKeys)
 const sortedDescriptions = sortedTests.map(t => testDescriptions[t])
 
 // Main chart: pnpm 11 and pnpm 12 are merged into a single stacked bar.
 const mainBars = [
-  { ...cmdsMap.npm, key: 'npm', version: data.npm.version },
+  { ...cmdsMap.npm, key: 'npm' },
   {
     stacked: true,
     color: cmdsMap.pnpm12.color,
@@ -118,9 +133,14 @@ const mainBars = [
     primaryKey: 'pnpm12',
     secondaryKey: 'pnpm11',
   },
-  { ...cmdsMap.yarn, key: 'yarn', version: data.yarn.version },
-  { ...cmdsMap.yarn_pnp, key: 'yarn_pnp', version: data.yarn_pnp.version },
+  { ...cmdsMap.yarn, key: 'yarn' },
+  { ...cmdsMap.yarn_pnp, key: 'yarn_pnp' },
+  { ...cmdsMap.bun, key: 'bun' },
 ]
+  .filter(bar => bar.stacked
+    ? data[bar.primaryKey] && data[bar.secondaryKey]
+    : data[bar.key])
+  .map(bar => bar.stacked ? bar : { ...bar, version: data[bar.key].version })
 const mainResArray = sortedTests.map(test => mainBars.map(bar => bar.stacked
   ? {
       primary: Math.round(data[bar.primaryKey].results[test] / 100) / 10,


### PR DESCRIPTION
## Bun

Added as a sixth column and bar. It is installed from the registry like npm and pnpm are, with flags matching the others (`--ignore-scripts`, `--cache-dir=cache`, `--registry=...`).

Two wrinkles worth noting:
- Bun's binary is downloaded by a postinstall script, so the build has to be allowed, the same way pnpm 12's is.
- Bun turns on `--frozen-lockfile` whenever `CI` is set, which fails every scenario that starts without a lockfile. It is turned back off explicitly, the same way Yarn's `enableImmutableInstalls` already is.

All nine scenarios were run against the `alotta-files` fixture with `CI=true` and pass.

## Yarn 6

Yarn 6 is the Rust rewrite in [yarnpkg/zpm](https://github.com/yarnpkg/zpm). It is not published to npm, so `yarn set version stable` cannot reach it — it ships as a platform binary instead. The new `benchmarks/installYarn.js` resolves the version from `repo.yarnpkg.com/channels/default/stable` and downloads the release archive, which are the same endpoints Yarn Switch itself uses. This needs `unzip` on `PATH`; CI already has it for the fnm step.

The archive contains two binaries: `yarn` (Yarn Switch) and `yarn-bin` (the package manager). The benchmark runs `yarn-bin`. Switch reads `packageManager` to resolve a version and downloads it on demand, so putting it in the measured path would add resolution overhead to every timing and risk timing a download as part of an install — Yarn PnP's warm-cache case is only ~83ms. This mirrors running `pnpm` from `node_modules/.bin` rather than through Corepack.

Currently resolves to **6.0.0-rc.19**; every 6.x release is still a prerelease. Both `nodeLinker: pnpm` and `nodeLinker: pnp` work and the lockfile is still `yarn.lock`, so no scenario needed changing. The chart legend shows `v6` via `displayVersion`, matching how pnpm 12 displays while on an RC.

## Yarn was never measuring a cold cache

Worth reviewing on its own. The `.yarnrc.yml` set `cacheFolder` and `enableMirror: false`, but Yarn now caches globally by default, so packages landed in `globalFolder` (under `~/.yarn`) rather than the `cache/` directory the harness deletes between scenarios.

Confirmed against **both** Yarn 6 and the currently published Yarn 4.18.0: in both, the project `cache/` came out completely empty after an install. Every "cold cache" Yarn number on the live page was in fact measured against a warm global cache.

`enableGlobalCache: false` plus a `globalFolder` inside `cache/` fixes it. Afterwards the cache populates correctly and cold and warm separate cleanly — for PnP, 1269ms cold vs 83ms warm.

**Expect Yarn's cold-cache numbers to get noticeably slower once this lands.** That is the fix working.

## Results are not included

`results/` accumulates runs per version and takes the `min` across them, so mixing timings from a local machine into a dataset built by CI would permanently skew those minima and make the cross-manager comparison meaningless. Each manager was validated through the real harness instead, and `results/` and `src/pages/benchmarks.md` are untouched. The workflow should generate the real numbers.

The workflow also drops the now-redundant `corepack prepare yarn@stable` and the leftover `curl bun.sh/install` steps, since both managers are now installed by the benchmark itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Bun to benchmark coverage, including installation, caching, configuration, and reporting.
  * Added support for Yarn 6 across supported platforms.
  * Improved benchmark isolation by storing package-manager caches within each scenario.

* **Bug Fixes**
  * Improved reporting when benchmark results are incomplete or unavailable.
  * Benchmark failures now correctly produce a nonzero CI status.

* **Documentation**
  * Updated benchmark setup guidance and documented the `unzip` requirement.

* **Chores**
  * Simplified benchmark workflow setup by removing unnecessary Yarn and Bun checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->