### PR TITLE
feat: benchmark installs through a pnpr registry over an emulated network

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -7,6 +7,18 @@ pnpm run benchmark
 
 npm, pnpm, and Bun are installed from the registry by the benchmark itself. Yarn is not on the registry anymore — Yarn 6 ships as a platform binary — so it is downloaded from its release channel instead, which needs `unzip` on `PATH`.
 
+## Installing through a registry server
+
+One section installs every package manager through a [pnpr](https://pnpm.io/pnpr) registry instead of npmjs, and measures pnpm a second time with dependency resolution offloaded to that server. pnpr is installed from the registry by the benchmark, like the package managers are, and needs no setup.
+
+Two things about that section are worth knowing before changing it.
+
+Its numbers are recorded under their own fixture name (`alotta-files-pnpr`). They are measured against a different registry across an emulated network, so pooling them with the main section's runs of the same fixture would average two unrelated things together.
+
+The network is emulated by `latencyProxy.js`, which every client's traffic passes through — including pnpm's resolution requests, at the same round trip, so no client gets a cheaper link than another. It runs as a process of its own because installs are measured with a synchronous spawn: a proxy inside the benchmark process would accept no connection until the install it is serving had already finished. The same reasoning applies to output — pnpr and the proxy write to files rather than pipes, because nothing drains a pipe while a measured install holds the event loop, and a full pipe buffer would stop the server answering mid-scenario.
+
+## Node.js version management
+
 The Node.js version management section compares pnpm with fnm and nvm. nvm is cloned by the benchmark itself, but `fnm` has to be on `PATH`:
 
 ```

--- a/benchmarks/benchmarkFixture.js
+++ b/benchmarks/benchmarkFixture.js
@@ -133,6 +133,20 @@ async function writeRegistryConfig (cwd, opts) {
   }
 }
 
+/**
+ * Undoes an install. Yarn PnP writes no `node_modules` at all, so removing only
+ * that would leave its whole installation in place and hand the scenario that
+ * follows a project that is already installed.
+ */
+function removeInstallOutput (cwd, modules) {
+  if (modules) {
+    rimraf.sync(modules)
+  }
+  for (const name of ['.pnp.cjs', '.pnp.loader.mjs', '.yarn']) {
+    rimraf.sync(path.join(cwd, name))
+  }
+}
+
 export default async function benchmark (pm, fixture, opts) {
   const cwd = path.join(TMP, pm.scenario, fixture)
   const env = createEnv(opts.managersDir)
@@ -195,13 +209,9 @@ export default async function benchmark (pm, fixture, opts) {
   // stays cold until a scenario that is being measured asks it.
   console.log('# warm-up (not measured)')
   measureInstall(pm, cwd, env)
-  if (modules) {
-    rimraf.sync(modules)
-  }
+  removeInstallOutput(cwd, modules)
   measureInstall(pm, cwd, env)
-  if (modules) {
-    rimraf.sync(modules)
-  }
+  removeInstallOutput(cwd, modules)
   rimraf.sync(path.join(cwd, 'cache'))
   cleanLockfile(pm, cwd, env)
 

--- a/benchmarks/benchmarkFixture.js
+++ b/benchmarks/benchmarkFixture.js
@@ -100,6 +100,39 @@ async function updateDependenciesInPackageJson (cwd) {
   return originalAsString
 }
 
+/**
+ * Points a package manager at a registry other than the public one. Only the
+ * pnpr section uses this; the main benchmark installs straight from npmjs.
+ *
+ * Reads are anonymous, so no token is needed to fetch packages. The token is
+ * only for pnpr's resolver, which does require authentication, and it is
+ * written as `_authToken` rather than `_auth` because Basic credentials would
+ * cost a password hash on every request inside the measured loop.
+ */
+async function writeRegistryConfig (cwd, opts) {
+  let npmrc = `registry=${opts.registry}\n`
+  if (opts.authToken) {
+    // The resolver is reached on a link of its own, so it is a different host
+    // and port than the registry. pnpm sends whichever credential is
+    // configured for the URL it is talking to, and the resolver is the one
+    // that demands one, so both are declared.
+    const hosts = new Set([opts.registry, opts.pnprServer].filter(Boolean).map((url) => new URL(url).host))
+    for (const host of hosts) {
+      npmrc += `//${host}/:_authToken=${opts.authToken}\n`
+    }
+  }
+  await fs.writeFile(path.join(cwd, '.npmrc'), npmrc)
+
+  if (opts.pnprServer) {
+    // pnpm resolves the dependency graph on the server named here instead of
+    // walking it over the network itself.
+    await fs.writeFile(
+      path.join(cwd, 'pnpm-workspace.yaml'),
+      `packages:\n  - '.'\npnprServer: ${opts.pnprServer}\n`
+    )
+  }
+}
+
 export default async function benchmark (pm, fixture, opts) {
   const cwd = path.join(TMP, pm.scenario, fixture)
   const env = createEnv(opts.managersDir)
@@ -112,6 +145,10 @@ export default async function benchmark (pm, fixture, opts) {
   const modules = opts.hasNodeModules ? path.join(cwd, 'node_modules') : null
 
   cleanLockfile(pm, cwd, env)
+
+  if (opts.registry) {
+    await writeRegistryConfig(cwd, opts)
+  }
 
   if (pm.name === 'yarn') {
     // Every store Yarn keeps has to sit under `cache/`, the directory the
@@ -126,6 +163,8 @@ export default async function benchmark (pm, fixture, opts) {
     + `cacheFolder: ${path.join(cwd, 'cache')}\n`
     + `globalFolder: ${path.join(cwd, 'cache', 'global')}\n`
     + 'enableScripts: false\n'
+    // Yarn reads none of `.npmrc`, so its registry has to be set here.
+    + (opts.registry ? `npmRegistryServer: ${opts.registry}\nunsafeHttpWhitelist:\n  - 127.0.0.1\n` : '')
     /**
      * @see https://yarnpkg.com/configuration/yarnrc#nodeLinker
      */
@@ -141,6 +180,25 @@ export default async function benchmark (pm, fixture, opts) {
     }
     await fs.writeFile(path.join(cwd, '.yarnrc.yml'), yarnRc)
   }
+
+  // Installs that nothing is measured from, to keep whatever only the very
+  // first install of a run pays for out of the numbers: a registry answering a
+  // question it has never been asked, a package manager's own start-up, a
+  // filesystem that has not seen these paths yet.
+  //
+  // It runs twice because an install without a lockfile and an install with one
+  // are different questions, and a server that caches answers has to have been
+  // asked both. The first warm-up produces the lockfile the second one sends.
+  // Everything they leave behind is then removed, so the scenarios below still
+  // begin from the state each of them says it does.
+  console.log('# warm-up (not measured)')
+  measureInstall(pm, cwd, env)
+  measureInstall(pm, cwd, env)
+  if (modules) {
+    rimraf.sync(modules)
+  }
+  rimraf.sync(path.join(cwd, 'cache'))
+  cleanLockfile(pm, cwd, env)
 
   console.log(`# first install`)
 

--- a/benchmarks/benchmarkFixture.js
+++ b/benchmarks/benchmarkFixture.js
@@ -188,11 +188,16 @@ export default async function benchmark (pm, fixture, opts) {
   //
   // It runs twice because an install without a lockfile and an install with one
   // are different questions, and a server that caches answers has to have been
-  // asked both. The first warm-up produces the lockfile the second one sends.
-  // Everything they leave behind is then removed, so the scenarios below still
-  // begin from the state each of them says it does.
+  // asked both. The first warm-up produces the lockfile the second one sends,
+  // and `node_modules` goes away in between: a package manager that already has
+  // the right tree installed skips resolving altogether, so leaving it in place
+  // means the second warm-up asks nothing and the question it exists to ask
+  // stays cold until a scenario that is being measured asks it.
   console.log('# warm-up (not measured)')
   measureInstall(pm, cwd, env)
+  if (modules) {
+    rimraf.sync(modules)
+  }
   measureInstall(pm, cwd, env)
   if (modules) {
     rimraf.sync(modules)

--- a/benchmarks/commandsMap.js
+++ b/benchmarks/commandsMap.js
@@ -45,6 +45,26 @@ export default {
       '--ignore-scripts',
     ]
   },
+  // Only used by the pnpr section. The command is pnpm's, unchanged: what makes
+  // it different is the `pnprServer` the fixture is configured with, which moves
+  // dependency resolution onto the server.
+  pnpm_pnpr: {
+    scenario: 'pnpm_pnpr',
+    legend: 'pnpm + pnpr',
+    mdLegend: '[pnpm + pnpr](/pnpr/install-acceleration)',
+    color: '#2fa84f',
+    name: 'pnpm',
+    args: [
+      'install',
+      '--ignore-scripts',
+      '--store-dir=cache/store',
+      '--cache-dir=cache/cache',
+      '--registry=https://registry.npmjs.org/',
+      '--no-strict-peer-dependencies',
+      '--config.auto-install-peers=false',
+      '--config.resolution-mode=highest',
+    ]
+  },
   yarn: {
     scenario: 'yarn',
     legend: 'Yarn',

--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -8,6 +8,7 @@ import tempy from 'tempy'
 import cmdsMap from './commandsMap.js'
 import benchmark from './recordBenchmark.js'
 import nodeVersionsSection from './nodeVersionsSection.js'
+import pnprSection from './pnprSection.js'
 import { cloneNvm } from './benchmarkNodeVersions.js'
 import { installYarn } from './installYarn.js'
 import generateSvg from './generateSvg.js'
@@ -23,6 +24,7 @@ const BENCH_IMGS = path.join(DIRNAME, '../static/img/benchmarks')
 const { stripIndents } = commonTags
 const LIMIT_RUNS = 30
 const NODE_VERSIONS_SVG = 'node-versions'
+const PNPR_SVG = 'pnpr-registry'
 
 const fixtures = [
   /*{
@@ -124,7 +126,7 @@ function addPackageManager (args, cwd) {
 async function run () {
   const tmpDir = tempy.directory()
   const managersDirs = {}
-  for (const pm of ['npm', 'pnpm11', 'pnpm12', 'yarn', 'bun', 'fnm', 'nvm']) {
+  for (const pm of ['npm', 'pnpm11', 'pnpm12', 'yarn', 'bun', 'fnm', 'nvm', 'pnpr']) {
     managersDirs[pm] = path.join(tmpDir, pm)
   }
   await Promise.allSettled([
@@ -278,6 +280,18 @@ async function run () {
     })
   }
 
+  const pnpr = await pnprSection({
+    managersDirs,
+    formattedNow,
+    limitRuns: LIMIT_RUNS,
+    svgName: PNPR_SVG,
+  })
+  sections.push(pnpr.section)
+  svgs.push({
+    path: path.join(BENCH_IMGS, `${PNPR_SVG}.svg`),
+    file: pnpr.svg
+  })
+
   const nodeVersions = await nodeVersionsSection({
     managersDirs: { pnpm12: managersDirs.pnpm12, fnm: managersDirs.fnm, nvm: managersDirs.nvm },
     formattedNow,
@@ -295,7 +309,7 @@ async function run () {
 
   **Last benchmarked at**: _${formattedNow}_ (_daily_ updated).
 
-  This benchmark compares the performance of npm, pnpm, Yarn, Yarn PnP, and Bun (check [Yarn's benchmarks](https://yarnpkg.com/benchmarks) for any other Yarn modes that are not included here). It also compares how fast pnpm, fnm, and nvm install and switch Node.js versions.
+  This benchmark compares the performance of npm, pnpm, Yarn, Yarn PnP, and Bun (check [Yarn's benchmarks](https://yarnpkg.com/benchmarks) for any other Yarn modes that are not included here). It then runs the same comparison again with every package manager installing through a pnpr registry over an emulated network, where pnpm can offload dependency resolution to the server. It also compares how fast pnpm, fnm, and nvm install and switch Node.js versions.
   `
 
   const explanationItems = sortedTests.map(t => `- ${explanationByTest[t]}`).join('\n  ')

--- a/benchmarks/latencyProxy.js
+++ b/benchmarks/latencyProxy.js
@@ -1,0 +1,181 @@
+'use strict'
+import fs from 'fs'
+import net from 'net'
+import path from 'path'
+import spawn from 'cross-spawn'
+import { fileURLToPath } from 'url'
+
+const DIRNAME = path.dirname(fileURLToPath(import.meta.url))
+
+// A TCP proxy that puts an emulated network link in front of a local server.
+//
+// Every package manager in this section talks to a registry running on the same
+// machine, where a round trip is effectively free. That hides the cost the
+// benchmark is trying to show: resolving a dependency graph means walking it
+// level by level, and each level costs one round trip, so on a real network the
+// install time is dominated by graph depth times latency rather than by how
+// fast the registry answers.
+//
+// Ported from the `integrated-benchmark` task in the pnpm monorepo, which
+// emulates the same link for the same reason.
+
+const INITIAL_CWND_BYTES = 14_600
+
+/** Megabits per second to bytes per second, or null for an uncapped link. */
+export function mbpsToBytesPerSec (mbps) {
+  if (!Number.isFinite(mbps) || mbps <= 0) return null
+  return Math.max(1, Math.round(mbps * 125_000))
+}
+
+/**
+ * Models TCP slow start: a connection begins at an initial congestion window
+ * and its effective rate (window / RTT) doubles per delivered window until it
+ * reaches the cap. Without this a transfer runs at the full cap from its first
+ * byte, which overstates throughput for the many small tarballs an install
+ * fetches.
+ */
+function createSlowStart (profile) {
+  const rttSecs = (profile.oneWayMs * 2) / 1000
+  if (!profile.slowStart || rttSecs <= 0 || profile.rateLimit == null) return null
+  return { cwnd: INITIAL_CWND_BYTES, rttSecs, bytesInRound: 0 }
+}
+
+function effectiveRate (ramp, cap, length) {
+  const rate = Math.min(ramp.cwnd / ramp.rttSecs, cap)
+  ramp.bytesInRound += length
+  if (ramp.bytesInRound >= ramp.cwnd) {
+    ramp.bytesInRound = 0
+    ramp.cwnd = Math.min(ramp.cwnd * 2, Math.max(cap * ramp.rttSecs, INITIAL_CWND_BYTES))
+  }
+  return rate
+}
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+/**
+ * Forwards one direction of a connection, holding every chunk for the link's
+ * one-way delay and, when the link is capped, for as long as it takes to put
+ * the chunk on the wire.
+ */
+function pump (src, dst, profile) {
+  const ramp = createSlowStart(profile)
+  // The earliest moment the link is free to start the next chunk. It advances
+  // by each chunk's serialization time so the cap is a sustained throughput
+  // limit rather than a per-chunk one.
+  let linkFreeAt = 0
+  let queue = Promise.resolve()
+
+  src.on('data', (chunk) => {
+    const releaseAt = Date.now() + profile.oneWayMs
+    queue = queue.then(async () => {
+      if (dst.destroyed) return
+      const sendAt = Math.max(releaseAt, linkFreeAt)
+      const wait = sendAt - Date.now()
+      if (wait > 0) await sleep(wait)
+      if (profile.rateLimit != null) {
+        const rate = ramp
+          ? effectiveRate(ramp, profile.rateLimit, chunk.length)
+          : profile.rateLimit
+        linkFreeAt = Math.max(sendAt, Date.now()) + (chunk.length / rate) * 1000
+      }
+      if (dst.destroyed) return
+      // Respect backpressure, otherwise a capped link would buffer whole
+      // tarballs in memory instead of pacing them. The wait has to end if the
+      // socket dies first, or this direction would stall for good and hold the
+      // connection open behind it.
+      if (!dst.write(chunk)) {
+        await new Promise((resolve) => {
+          const done = () => {
+            dst.off('drain', done)
+            dst.off('close', done)
+            dst.off('error', done)
+            resolve()
+          }
+          dst.once('drain', done)
+          dst.once('close', done)
+          dst.once('error', done)
+        })
+      }
+    }).catch(() => {})
+  })
+
+  src.on('end', () => { queue = queue.then(() => { if (!dst.destroyed) dst.end() }).catch(() => {}) })
+  src.on('error', () => dst.destroy())
+}
+
+function listen ({ upstreamPort, roundTripMs, rateLimit, slowStart }) {
+  // The profile is one-way; a round trip pays it twice.
+  const profile = { oneWayMs: roundTripMs / 2, rateLimit, slowStart }
+  // Both sockets have to stay half-open. Delaying a chunk means one direction
+  // is always behind the other, and with Node's default the first side to
+  // finish would close its peer's write side before the chunks still waiting on
+  // the link had been handed over.
+  const server = net.createServer({ allowHalfOpen: true }, (client) => {
+    const upstream = net.connect({ host: '127.0.0.1', port: upstreamPort, allowHalfOpen: true })
+    upstream.on('error', () => client.destroy())
+    client.on('error', () => upstream.destroy())
+    // A peer that vanishes without a clean shutdown would otherwise leave its
+    // other half open forever. An install opens a lot of connections, and
+    // leaking one descriptor per abandoned connection eventually stops the
+    // proxy accepting new ones.
+    upstream.on('close', () => client.destroy())
+    client.on('close', () => upstream.destroy())
+    pump(client, upstream, profile)
+    pump(upstream, client, profile)
+  })
+  server.on('error', (err) => { throw err })
+  return server
+}
+
+/**
+ * Starts the proxy as a process of its own and resolves with the port to point
+ * clients at.
+ *
+ * It has to be a separate process. Installs are measured with a synchronous
+ * spawn, which blocks this process's event loop for as long as the package
+ * manager runs — a proxy living here would accept no connection until the very
+ * install it is supposed to be serving had already finished.
+ */
+export async function startLatencyProxy ({ upstreamPort, roundTripMs, rateLimit = null, slowStart = false, logPath }) {
+  // Like pnpr, the proxy writes to a file instead of a pipe: nothing here
+  // drains a pipe while a measured install holds the event loop, so a full
+  // buffer would block the very process the traffic flows through.
+  const logFd = fs.openSync(logPath, 'a')
+  const proc = spawn(process.execPath, [
+    path.join(DIRNAME, 'latencyProxy.js'),
+    `--upstream-port=${upstreamPort}`,
+    `--round-trip-ms=${roundTripMs}`,
+    `--rate-limit=${rateLimit ?? 0}`,
+    `--slow-start=${slowStart ? 1 : 0}`,
+  ], { stdio: ['ignore', logFd, logFd] })
+  fs.closeSync(logFd)
+
+  const deadline = Date.now() + 15_000
+  while (Date.now() < deadline) {
+    const log = fs.readFileSync(logPath, 'utf8')
+    const port = log.match(/^port=(\d+)$/m)?.[1]
+    if (port) {
+      return { port: Number(port), close: () => { proc.kill() } }
+    }
+    if (proc.exitCode !== null) {
+      throw new Error(`The latency proxy exited with code ${proc.exitCode}. ${log}`)
+    }
+    await sleep(100)
+  }
+  throw new Error(`The latency proxy did not start. ${fs.readFileSync(logPath, 'utf8')}`)
+}
+
+// Running this file directly is what `startLatencyProxy` spawns.
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const arg = (name) => Number(process.argv.find((a) => a.startsWith(`--${name}=`))?.split('=')[1] ?? 0)
+  const rateLimit = arg('rate-limit')
+  const server = listen({
+    upstreamPort: arg('upstream-port'),
+    roundTripMs: arg('round-trip-ms'),
+    rateLimit: rateLimit > 0 ? rateLimit : null,
+    slowStart: arg('slow-start') === 1,
+  })
+  server.listen(0, '127.0.0.1', () => {
+    console.log(`port=${server.address().port}`)
+  })
+}

--- a/benchmarks/latencyProxy.js
+++ b/benchmarks/latencyProxy.js
@@ -59,6 +59,17 @@ const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
  */
 function pump (src, dst, profile) {
   const ramp = createSlowStart(profile)
+  // How many bytes may be on the link at once before the sender is made to
+  // wait. A real link carries a whole round trip's worth of data in flight, so
+  // the bound has to be at least that or the emulation collapses into
+  // stop-and-wait: one chunk crossing at a time, each paying the delay in turn,
+  // which caps throughput at a chunk per delay however fast the link is
+  // configured to be. Above that it only serves to bound memory.
+  const inFlightLimit = Math.max(
+    1024 * 1024,
+    (profile.rateLimit ?? 12_500_000) * (profile.oneWayMs * 2 / 1000) * 2
+  )
+  let queuedBytes = 0
   // The earliest moment the link is free to start the next chunk. It advances
   // by each chunk's serialization time so the cap is a sustained throughput
   // limit rather than a per-chunk one.
@@ -66,6 +77,13 @@ function pump (src, dst, profile) {
   let queue = Promise.resolve()
 
   src.on('data', (chunk) => {
+    // Make the sender wait once the link is carrying as much as it can hold.
+    // Without any bound the whole response is read straight into the queue, and
+    // the proxy ends up holding entire tarballs in memory.
+    queuedBytes += chunk.length
+    if (queuedBytes >= inFlightLimit) {
+      src.pause()
+    }
     const releaseAt = Date.now() + profile.oneWayMs
     queue = queue.then(async () => {
       if (dst.destroyed) return
@@ -96,11 +114,18 @@ function pump (src, dst, profile) {
           dst.once('error', done)
         })
       }
-    }).catch(() => {})
+    }).catch(() => {}).finally(() => {
+      queuedBytes -= chunk.length
+      if (queuedBytes < inFlightLimit && !src.destroyed) {
+        src.resume()
+      }
+    })
   })
 
   src.on('end', () => { queue = queue.then(() => { if (!dst.destroyed) dst.end() }).catch(() => {}) })
   src.on('error', () => dst.destroy())
+
+  return { flushed: () => queue }
 }
 
 function listen ({ upstreamPort, roundTripMs, rateLimit, slowStart }) {
@@ -114,14 +139,18 @@ function listen ({ upstreamPort, roundTripMs, rateLimit, slowStart }) {
     const upstream = net.connect({ host: '127.0.0.1', port: upstreamPort, allowHalfOpen: true })
     upstream.on('error', () => client.destroy())
     client.on('error', () => upstream.destroy())
-    // A peer that vanishes without a clean shutdown would otherwise leave its
-    // other half open forever. An install opens a lot of connections, and
-    // leaking one descriptor per abandoned connection eventually stops the
-    // proxy accepting new ones.
-    upstream.on('close', () => client.destroy())
-    client.on('close', () => upstream.destroy())
-    pump(client, upstream, profile)
-    pump(upstream, client, profile)
+    const toUpstream = pump(client, upstream, profile)
+    const toClient = pump(upstream, client, profile)
+    // A peer that goes away must not take its other half with it while chunks
+    // are still on the link. Ending a response is the ordinary case: the source
+    // socket closes as soon as it has handed over its last bytes, but those
+    // bytes are still waiting out their delay here, and destroying the
+    // destination now would truncate every response by whatever the link still
+    // held. Waiting for the direction to drain first keeps the destroy doing
+    // what it is for — releasing a connection nobody will finish — which
+    // matters because an install opens a great many of them.
+    upstream.on('close', () => { toClient.flushed().finally(() => client.destroy()) })
+    client.on('close', () => { toUpstream.flushed().finally(() => upstream.destroy()) })
   })
   server.on('error', (err) => { throw err })
   return server
@@ -162,6 +191,9 @@ export async function startLatencyProxy ({ upstreamPort, roundTripMs, rateLimit 
     }
     await sleep(100)
   }
+  // A proxy that is alive but never reported a port would otherwise outlive the
+  // run that gave up on it, and keep the benchmark from exiting.
+  proc.kill()
   throw new Error(`The latency proxy did not start. ${fs.readFileSync(logPath, 'utf8')}`)
 }
 

--- a/benchmarks/latencyProxy.test.mjs
+++ b/benchmarks/latencyProxy.test.mjs
@@ -1,0 +1,117 @@
+// Checks that the emulated link behaves like a link.
+//
+// What this proxy gets wrong is not visible in the benchmark's output: a
+// mistake here does not fail a run, it quietly changes every number the pnpr
+// section reports. Both faults these tests cover were live at some point —
+// a link that carried one chunk at a time turned a 380ms transfer into 1.8s,
+// and destroying a socket as soon as its peer closed truncated responses whose
+// last bytes were still crossing the link.
+//
+// Run with: node --test benchmarks/latencyProxy.test.mjs
+
+import assert from 'node:assert/strict'
+import crypto from 'node:crypto'
+import http from 'node:http'
+import path from 'node:path'
+import test from 'node:test'
+import tempy from 'tempy'
+import { startLatencyProxy, mbpsToBytesPerSec } from './latencyProxy.js'
+
+const BODY = crypto.randomBytes(4 * 1024 * 1024)
+const DIGEST = crypto.createHash('sha256').update(BODY).digest('hex')
+const LOGS = tempy.directory()
+
+function startOrigin () {
+  const server = http.createServer((req, res) => {
+    if (req.url === '/big') {
+      res.writeHead(200, { 'content-length': BODY.length })
+      res.end(BODY)
+    } else {
+      res.writeHead(200)
+      res.end('ok')
+    }
+  })
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => resolve({ port: server.address().port, close: () => server.close() }))
+  })
+}
+
+function fetchThrough (port, urlPath, agent) {
+  return new Promise((resolve, reject) => {
+    const startedAt = Date.now()
+    const chunks = []
+    http.get({ host: '127.0.0.1', port, path: urlPath, agent: agent ?? false }, (res) => {
+      res.on('data', (chunk) => chunks.push(chunk))
+      res.on('end', () => {
+        const body = Buffer.concat(chunks)
+        resolve({
+          ms: Date.now() - startedAt,
+          digest: crypto.createHash('sha256').update(body).digest('hex'),
+          bytes: body.length,
+        })
+      })
+    }).on('error', reject)
+  })
+}
+
+const proxyFor = (upstreamPort, options) => startLatencyProxy({
+  upstreamPort,
+  logPath: path.join(LOGS, `${Math.random().toString(36).slice(2)}.log`),
+  ...options,
+})
+
+test('a round trip costs what it is configured to cost', async () => {
+  const origin = await startOrigin()
+  const fast = await proxyFor(origin.port, { roundTripMs: 20 })
+  const slow = await proxyFor(origin.port, { roundTripMs: 120 })
+  try {
+    const quick = await fetchThrough(fast.port, '/small')
+    const sluggish = await fetchThrough(slow.port, '/small')
+    // A request pays the round trip on the connection and again on the exchange.
+    assert.ok(quick.ms >= 20, `expected at least 20ms, got ${quick.ms}ms`)
+    assert.ok(sluggish.ms >= 120, `expected at least 120ms, got ${sluggish.ms}ms`)
+    assert.ok(sluggish.ms > quick.ms * 2, `${sluggish.ms}ms should be well above ${quick.ms}ms`)
+  } finally {
+    fast.close(); slow.close(); origin.close()
+  }
+})
+
+test('throughput follows the configured bandwidth, not the chunk size', async () => {
+  const origin = await startOrigin()
+  const proxy = await proxyFor(origin.port, { roundTripMs: 40, rateLimit: mbpsToBytesPerSec(100) })
+  try {
+    const result = await fetchThrough(proxy.port, '/big')
+    // 4 MiB at 100 Mbit/s is ~336ms, plus the round trip. The upper bound is
+    // what fails when the link stops carrying a round trip's worth at once and
+    // degrades into one chunk per delay.
+    assert.equal(result.digest, DIGEST)
+    assert.ok(result.ms >= 300, `expected the cap to bite, got ${result.ms}ms`)
+    assert.ok(result.ms < 900, `expected ~380ms, got ${result.ms}ms — the link is serialising chunks`)
+  } finally {
+    proxy.close(); origin.close()
+  }
+})
+
+test('responses survive intact over reused and concurrent connections', async () => {
+  const origin = await startOrigin()
+  const proxy = await proxyFor(origin.port, { roundTripMs: 20, rateLimit: mbpsToBytesPerSec(200) })
+  const agent = new http.Agent({ keepAlive: true })
+  try {
+    for (let i = 0; i < 10; i++) {
+      const result = await fetchThrough(proxy.port, '/big', agent)
+      assert.equal(result.digest, DIGEST, `keep-alive request ${i} came back truncated`)
+    }
+    const concurrent = await Promise.all(
+      Array.from({ length: 8 }, () => fetchThrough(proxy.port, '/big'))
+    )
+    for (const result of concurrent) assert.equal(result.digest, DIGEST)
+  } finally {
+    agent.destroy(); proxy.close(); origin.close()
+  }
+})
+
+test('megabits convert to bytes per second', () => {
+  assert.equal(mbpsToBytesPerSec(8), 1_000_000)
+  assert.equal(mbpsToBytesPerSec(0), null)
+  assert.equal(mbpsToBytesPerSec(Number.NaN), null)
+})

--- a/benchmarks/package.json
+++ b/benchmarks/package.json
@@ -1,7 +1,8 @@
 {
     "type": "module",
     "scripts": {
-        "benchmark": "node ./index.js"
+        "benchmark": "node ./index.js",
+        "test": "node --test latencyProxy.test.mjs"
     },
     "dependencies": {
         "common-tags": "^1.8.2",

--- a/benchmarks/pnprSection.js
+++ b/benchmarks/pnprSection.js
@@ -1,0 +1,248 @@
+'use strict'
+import crypto from 'crypto'
+import fs from 'fs'
+import path from 'path'
+import commonTags from 'common-tags'
+import prettyMs from 'pretty-ms'
+import { fileURLToPath } from 'url'
+import cmdsMap from './commandsMap.js'
+import recordBenchmark from './recordBenchmark.js'
+import generateSvg from './generateSvg.js'
+import { startLatencyProxy, mbpsToBytesPerSec } from './latencyProxy.js'
+import {
+  installPnpr,
+  pnprVersion,
+  startPnpr,
+  mintToken,
+  populateCache,
+  verifyResolverIsUsed,
+} from './pnprServer.js'
+
+const { stripIndents } = commonTags
+const DIRNAME = path.dirname(fileURLToPath(import.meta.url))
+
+// The emulated link, matching the pnpm monorepo's own pnpr benchmark. The
+// client-to-server latency is deliberately the same as the client-to-registry
+// latency: a faster link to pnpr would flatter it for free, so whatever it
+// wins has to come from making fewer round trips rather than cheaper ones.
+const ROUND_TRIP_MS = 50
+const BANDWIDTH_MBPS = 200
+
+const PNPR_PORT = 7677
+
+// Results are recorded under their own fixture name. The numbers here are
+// measured against a different registry over an emulated link, so they must
+// never be pooled with the main section's runs of the same fixture.
+const FIXTURE = 'alotta-files'
+const RESULTS_FIXTURE = 'alotta-files-pnpr'
+
+const tests = [
+  'firstInstall',
+  'withWarmModules',
+  'withLockfile',
+  'withWarmCacheAndModules',
+  'withWarmCache',
+  'withWarmCacheAndLockfile',
+  'withWarmModulesAndLockfile',
+  'repeatInstall',
+  'updatedDependencies',
+]
+
+const testDescriptions = {
+  firstInstall:               ['clean'],
+  withWarmModules:            ['node_modules'],
+  withLockfile:               ['lockfile'],
+  withWarmCacheAndModules:    ['cache', 'node_modules'],
+  withWarmCache:              ['cache'],
+  withWarmCacheAndLockfile:   ['cache', 'lockfile'],
+  withWarmModulesAndLockfile: ['lockfile', 'node_modules'],
+  repeatInstall:              ['cache', 'lockfile', 'node_modules'],
+  updatedDependencies:        ['update'],
+}
+
+const tableRows = {
+  firstInstall:               { action: 'install', cache: ' ',   lockfile: ' ',   nodeModules: ' '   },
+  withWarmModules:            { action: 'install', cache: ' ',   lockfile: ' ',   nodeModules: '✔', needsNodeModules: true },
+  withLockfile:               { action: 'install', cache: ' ',   lockfile: '✔',   nodeModules: ' '   },
+  withWarmCacheAndModules:    { action: 'install', cache: '✔',   lockfile: ' ',   nodeModules: '✔', needsNodeModules: true },
+  withWarmCache:              { action: 'install', cache: '✔',   lockfile: ' ',   nodeModules: ' '   },
+  withWarmCacheAndLockfile:   { action: 'install', cache: '✔',   lockfile: '✔',   nodeModules: ' '   },
+  withWarmModulesAndLockfile: { action: 'install', cache: ' ',   lockfile: '✔',   nodeModules: '✔', needsNodeModules: true },
+  repeatInstall:              { action: 'install', cache: '✔',   lockfile: '✔',   nodeModules: '✔', needsNodeModules: true },
+  updatedDependencies:        { action: 'update',  cache: 'n/a', lockfile: 'n/a', nodeModules: 'n/a' },
+}
+
+/**
+ * Sends a package manager to a different registry than the one it defaults to.
+ * The flag is what counts: npm, pnpm, and Bun each carry a `--registry` of
+ * their own that would otherwise win over the `.npmrc` written next to the
+ * fixture. Yarn takes no such flag and refuses to run when given one, so it is
+ * left alone and configured through `.yarnrc.yml` instead.
+ */
+const withRegistry = (pm, registry) => pm.name === 'yarn'
+  ? pm
+  : {
+      ...pm,
+      args: [...pm.args.filter((arg) => !arg.startsWith('--registry=')), `--registry=${registry}`],
+    }
+
+/**
+ * Benchmarks every package manager against a pnpr registry over an emulated
+ * network link, and pnpm a second time with resolution offloaded to that same
+ * server. Returns the markdown section and the chart.
+ */
+export default async function pnprSection ({ managersDirs, formattedNow, limitRuns, svgName }) {
+  installPnpr(managersDirs.pnpr)
+  const version = pnprVersion(managersDirs.pnpr)
+
+  const dir = path.join(managersDirs.pnpr, 'server')
+  const proxies = []
+  let server
+  try {
+    // The links come up first: pnpr has to be told the address clients will
+    // really use, so the tarball URLs it serves point across the emulated link
+    // instead of around it.
+    fs.mkdirSync(dir, { recursive: true })
+    const registryLink = await startLatencyProxy({
+      upstreamPort: PNPR_PORT,
+      roundTripMs: ROUND_TRIP_MS,
+      rateLimit: mbpsToBytesPerSec(BANDWIDTH_MBPS),
+      logPath: path.join(dir, 'registry-link.log'),
+    })
+    proxies.push(registryLink)
+    const registry = `http://127.0.0.1:${registryLink.port}`
+
+    // Resolution requests cross a link of their own, at the same round trip.
+    // Only latency is emulated here: the resolve exchange is small, so what it
+    // costs is round trips rather than throughput.
+    const resolverLink = await startLatencyProxy({
+      upstreamPort: PNPR_PORT,
+      roundTripMs: ROUND_TRIP_MS,
+      logPath: path.join(dir, 'resolver-link.log'),
+    })
+    proxies.push(resolverLink)
+    const pnprServer = `http://127.0.0.1:${resolverLink.port}`
+
+    server = await startPnpr({
+      managersDir: managersDirs.pnpr,
+      dir,
+      port: PNPR_PORT,
+      publicUrl: registry,
+    })
+    const authToken = await mintToken(server.url)
+
+    // Warm pnpr's cache before anything is timed. Otherwise whichever manager
+    // ran first would pay to pull every package from npmjs into pnpr, and the
+    // rest would be measured against a registry it had warmed for them.
+    const fixtureDir = path.join(DIRNAME, 'fixtures', FIXTURE)
+    populateCache({
+      pm: withRegistry(cmdsMap.pnpm11, registry),
+      managersDir: managersDirs.pnpm11,
+      dir,
+      registry,
+      fixtureDir,
+    })
+
+    verifyResolverIsUsed({
+      pm: withRegistry(cmdsMap.pnpm11, registry),
+      managersDir: managersDirs.pnpm11,
+      dir,
+      registry,
+      authToken,
+      pnprServer,
+      fixtureDir,
+    })
+
+    const pmConfigs = [
+      { key: 'npm', managersDir: managersDirs.npm },
+      { key: 'pnpm11', managersDir: managersDirs.pnpm11 },
+      { key: 'pnpm12', managersDir: managersDirs.pnpm12 },
+      { key: 'yarn', managersDir: managersDirs.yarn },
+      { key: 'yarn_pnp', managersDir: managersDirs.yarn, hasNodeModules: false },
+      { key: 'bun', managersDir: managersDirs.bun },
+      // The same pnpm as the row above, resolving on the server instead of
+      // walking the graph itself, so the difference is pnpr and nothing else.
+      { key: 'pnpm_pnpr', managersDir: managersDirs.pnpm11, pnprServer, authToken },
+    ]
+
+    const results = {}
+    for (const { key, managersDir, hasNodeModules, ...rest } of pmConfigs) {
+      // The registry has to be forced on the command line as well as in the
+      // config: npm, pnpm, and Bun each carry a `--registry` of their own, and
+      // it would win over the `.npmrc` written next to the fixture.
+      results[key] = min(await recordBenchmark(withRegistry(cmdsMap[key], registry), FIXTURE, {
+        limitRuns,
+        resultsName: RESULTS_FIXTURE,
+        hasNodeModules: hasNodeModules ?? true,
+        managersDir,
+        registry,
+        ...rest,
+      }))
+    }
+
+    return buildSection({ results, pmConfigs, version, formattedNow, svgName })
+  } finally {
+    for (const proxy of proxies) proxy.close()
+    server?.stop()
+  }
+}
+
+function buildSection ({ results, pmConfigs, version, formattedNow, svgName }) {
+  const keys = pmConfigs.map(({ key }) => key)
+  const headerLegends = keys.map((key) => cmdsMap[key].mdLegend ?? cmdsMap[key].legend).join(' | ')
+  const headerSep = keys.map(() => '---').join(' | ')
+
+  // Slowest first, keyed by npm, with the update row pinned to the end.
+  const sorted = [...tests.filter((t) => t !== 'updatedDependencies')]
+    .sort((a, b) => (results.npm[b] || 0) - (results.npm[a] || 0))
+    .concat('updatedDependencies')
+
+  const rows = sorted.map((test) => {
+    const row = tableRows[test]
+    const values = pmConfigs.map(({ key, hasNodeModules }) => {
+      if (row.needsNodeModules && hasNodeModules === false) return 'n/a'
+      return prettyMs(results[key][test])
+    }).join(' | ')
+    return `| ${row.action} | ${row.cache} | ${row.lockfile} | ${row.nodeModules} | ${values} |`
+  }).join('\n')
+
+  const bars = pmConfigs.map(({ key }) => ({ ...cmdsMap[key], key, version }))
+  const resArray = sorted.map((test) => bars.map((bar) => Math.round(results[bar.key][test] / 100) / 10))
+  const svg = generateSvg(resArray, bars, sorted.map((t) => testDescriptions[t]), formattedNow)
+  const svgHash = hashContent(svg)
+
+  const section = stripIndents`
+    ## Installing Through a Registry Server
+
+    The section above installs from the public npm registry over whatever link the benchmark machine happens to have. This one puts every package manager behind the same [pnpr](/pnpr) registry across an emulated ${ROUND_TRIP_MS}ms round trip at ${BANDWIDTH_MBPS} Mbit/s, and adds a row for pnpm resolving its dependency graph [on the server](/pnpr/install-acceleration) instead of walking it itself.
+
+    | action  | cache | lockfile | node_modules| ${headerLegends} |
+    | ---     | ---   | ---      | ---         | ${headerSep} |
+    ${rows}
+
+    <img alt="Graph comparing package managers installing through a pnpr registry" src="/img/benchmarks/${svgName}.svg?v=${svgHash}" />
+
+    How to read these numbers:
+
+    - **They are not comparable to the section above.** A different registry and an emulated network make these runs slower across the board. What they compare is the package managers against each other under one shared, reproducible network, not against their own numbers elsewhere on this page.
+    - **Every manager crosses the same link.** The registry round trip is applied to all of them, and to pnpm's resolution requests as well, so no client gets a cheaper connection than another.
+    - **pnpr's cache is warmed before anything is timed**, so no manager pays to pull the fixture into the registry on behalf of the ones measured after it.
+    - **Server-side resolution pays off when there is a graph to resolve.** Resolving one means walking it level by level, and each level costs a round trip, so the cost is roughly the depth of the graph times the latency. pnpr does that walk next to the registry and answers with the whole resolved lockfile at once, which is why the rows without a lockfile — and the row that changes dependencies — are the ones where it pulls ahead of plain pnpm.
+    - **It costs a round trip when there is not.** pnpm asks the server on every install, including the ones where the lockfile is already up to date and there is nothing to work out. The server answers a question it has been asked before from its cache, in a few milliseconds — what the client pays for is the round trip and having the resolved lockfile streamed back, which plain pnpm never pays because it never asks. That is why the rows with a lockfile come out slightly behind plain pnpm instead of level with it.
+    - Tarballs are still fetched by the client, in parallel and directly, on every row.
+  `
+
+  return { section, svg }
+}
+
+function min (benchmarkResults) {
+  const results = {}
+  for (const test of tests) {
+    results[test] = Math.min(...benchmarkResults.map((res) => res[test]))
+  }
+  return results
+}
+
+function hashContent (content) {
+  return crypto.createHash('sha256').update(content).digest('hex').slice(0, 8)
+}

--- a/benchmarks/pnprSection.js
+++ b/benchmarks/pnprSection.js
@@ -128,6 +128,10 @@ export default async function pnprSection ({ managersDirs, formattedNow, limitRu
       dir,
       port: PNPR_PORT,
       publicUrl: registry,
+      // Logging every request is what lets the check below see whether pnpm
+      // really resolved on the server. It goes to a file, and every manager
+      // faces the same server, so it costs all of them the same.
+      logLevel: 'info',
     })
     const authToken = await mintToken(server.url)
 
@@ -151,6 +155,7 @@ export default async function pnprSection ({ managersDirs, formattedNow, limitRu
       authToken,
       pnprServer,
       fixtureDir,
+      serverLog: server.log,
     })
 
     const pmConfigs = [

--- a/benchmarks/pnprServer.js
+++ b/benchmarks/pnprServer.js
@@ -177,7 +177,7 @@ export function populateCache ({ pm, managersDir, dir, registry, fixtureDir }) {
  * accelerated row into a copy of the plain pnpm row, so it is checked here
  * with one untimed install rather than during a measured one.
  */
-export function verifyResolverIsUsed ({ pm, managersDir, dir, registry, authToken, pnprServer, fixtureDir }) {
+export function verifyResolverIsUsed ({ pm, managersDir, dir, registry, authToken, pnprServer, fixtureDir, serverLog }) {
   const cwd = path.join(dir, 'verify')
   fs.rmSync(cwd, { recursive: true, force: true })
   fs.mkdirSync(cwd, { recursive: true })
@@ -189,6 +189,8 @@ export function verifyResolverIsUsed ({ pm, managersDir, dir, registry, authToke
   fs.writeFileSync(path.join(cwd, '.npmrc'), `registry=${registry}\n${auth}`)
   fs.writeFileSync(path.join(cwd, 'pnpm-workspace.yaml'), `packages:\n  - '.'\npnprServer: ${pnprServer}\n`)
 
+  const resolveCalls = () => (serverLog().match(/uri=\/-\/pnpr\/v0\/resolve/g) ?? []).length
+  const before = resolveCalls()
   const result = spawn.sync(pm.name, [...pm.args, '--no-frozen-lockfile'], {
     cwd,
     env: createEnv(managersDir),
@@ -198,10 +200,13 @@ export function verifyResolverIsUsed ({ pm, managersDir, dir, registry, authToke
   if (result.status !== 0) {
     throw new Error(`Verifying pnpr resolution failed with status code ${result.status}. ${output}`)
   }
-  if (!/pnpr server/i.test(output)) {
+  // The server's own request log is the evidence, rather than anything pnpm
+  // prints: what a package manager writes to its terminal is not a contract,
+  // and a reworded line should not be able to abort a benchmark that is working.
+  if (resolveCalls() === before) {
     throw new Error(
-      'pnpm resolved without the pnpr server, so the accelerated scenario ' +
-      `would measure a plain install. Its output was:\n${output}`
+      'pnpr recorded no resolution request, so pnpm resolved on its own and ' +
+      `the accelerated scenario would measure a plain install. Its output was:\n${output}`
     )
   }
 }

--- a/benchmarks/pnprServer.js
+++ b/benchmarks/pnprServer.js
@@ -1,0 +1,207 @@
+'use strict'
+import fs from 'fs'
+import path from 'path'
+import spawn from 'cross-spawn'
+import { createEnv } from './benchmarkFixture.js'
+
+const USERNAME = 'pnpm-io-benchmark'
+const PASSWORD = 'benchmark'
+
+/**
+ * pnpr is a pnpm-compatible registry server. This section runs every package
+ * manager against it so they all face the same registry, and additionally lets
+ * pnpm offload dependency resolution to it.
+ */
+export function installPnpr (managersDir) {
+  // Like pnpm 12 and Bun, the binary arrives through an install script.
+  const result = spawn.sync('pnpm', ['add', '@pnpm/pnpr@next', '--allow-build=@pnpm/pnpr'], {
+    cwd: managersDir,
+    stdio: 'inherit',
+  })
+  if (result.error) throw result.error
+  if (result.status !== 0) {
+    throw new Error(`Installing pnpr failed with status code ${result.status}`)
+  }
+}
+
+export function pnprVersion (managersDir) {
+  const { status, stdout, stderr } = spawn.sync('pnpr', ['--version'], {
+    cwd: managersDir,
+    env: createEnv(managersDir),
+  })
+  if (status !== 0) {
+    throw new Error(`Couldn't detect the version of pnpr. ${stderr?.toString() ?? ''}`)
+  }
+  return stdout.toString().trim().replace(/^\D+/, '')
+}
+
+/**
+ * Starts a pnpr that proxies the public registry. Its cache is kept for the
+ * whole section so that every manager is measured against the same warm
+ * registry rather than against however much of npmjs happened to be cached
+ * when its turn came.
+ */
+export async function startPnpr ({ managersDir, dir, port, publicUrl, logLevel = 'error' }) {
+  fs.mkdirSync(dir, { recursive: true })
+  const configPath = path.join(dir, 'pnpr.yaml')
+  fs.writeFileSync(configPath, [
+    `storage: ${path.join(dir, 'storage')}`,
+    'auth:',
+    '  htpasswd:',
+    `    file: ${path.join(dir, 'htpasswd')}`,
+    // The benchmark registers its own resolver user on startup.
+    '    max_users: 1',
+    'registries:',
+    '  npmjs:',
+    '    type: upstream',
+    '    url: https://registry.npmjs.org/',
+    '    public: true',
+    'defaultRegistry: npmjs',
+    'resolver:',
+    '  enabled: true',
+    'log:',
+    '  type: stdout',
+    '  format: pretty',
+    `  level: ${logLevel}`,
+    '',
+  ].join('\n'))
+
+  // pnpr's output goes to a file rather than a pipe. Installs are measured with
+  // a synchronous spawn, so nothing in this process drains a pipe while one is
+  // running: the buffer would fill, pnpr would block writing to it, and the
+  // registry would stop answering midway through a scenario.
+  const logPath = path.join(dir, 'pnpr.log')
+  const logFd = fs.openSync(logPath, 'a')
+  const proc = spawn('pnpr', [
+    '-c', configPath,
+    '--listen', `127.0.0.1:${port}`,
+    // pnpr rewrites the tarball URLs it serves to this address. It has to be
+    // the address clients actually use, or every tarball would be fetched on a
+    // link the benchmark isn't emulating — and npm refuses outright to fetch a
+    // tarball from a host other than the registry it was told about.
+    ...(publicUrl ? ['--public-url', publicUrl] : []),
+    // Packuments are fetched from npmjs once and then treated as authoritative,
+    // so no scenario pays for a revalidation another scenario already paid for.
+    '--packument-ttl-secs', '31536000',
+  ], {
+    cwd: managersDir,
+    env: createEnv(managersDir),
+    stdio: ['ignore', logFd, logFd],
+  })
+  fs.closeSync(logFd)
+  proc.on('error', (err) => { throw err })
+
+  const readLog = () => {
+    try {
+      return fs.readFileSync(logPath, 'utf8')
+    } catch {
+      return ''
+    }
+  }
+
+  const url = `http://127.0.0.1:${port}`
+  await waitForPnpr(url, proc, readLog)
+  return {
+    url,
+    log: readLog,
+    stop: () => { proc.kill() },
+  }
+}
+
+async function waitForPnpr (url, proc, getStderr) {
+  const deadline = Date.now() + 30_000
+  while (Date.now() < deadline) {
+    if (proc.exitCode !== null) {
+      throw new Error(`pnpr exited with code ${proc.exitCode}. ${getStderr()}`)
+    }
+    try {
+      const res = await fetch(`${url}/-/ping`)
+      if (res.ok) return
+    } catch {
+      // Not listening yet.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 200))
+  }
+  throw new Error(`pnpr did not start listening on ${url}. ${getStderr()}`)
+}
+
+/**
+ * pnpr serves packages anonymously but requires authentication to resolve, so
+ * the accelerated scenario needs a token.
+ */
+export async function mintToken (url) {
+  const res = await fetch(`${url}/-/user/org.couchdb.user:${USERNAME}`, {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ name: USERNAME, password: PASSWORD }),
+  })
+  if (!res.ok) {
+    throw new Error(`Couldn't register a pnpr user: ${res.status} ${res.statusText}`)
+  }
+  const { token } = await res.json()
+  if (!token) throw new Error('pnpr returned no token')
+  return token
+}
+
+/**
+ * Fills pnpr's cache by installing the fixture once, untimed and without the
+ * emulated link in the way. Without this the first manager measured would pay
+ * for pulling every package from npmjs into pnpr and the rest would not.
+ */
+export function populateCache ({ pm, managersDir, dir, registry, fixtureDir }) {
+  const cwd = path.join(dir, 'populate')
+  fs.rmSync(cwd, { recursive: true, force: true })
+  fs.mkdirSync(cwd, { recursive: true })
+  fs.copyFileSync(path.join(fixtureDir, 'package.json'), path.join(cwd, 'package.json'))
+  fs.writeFileSync(path.join(cwd, '.npmrc'), `registry=${registry}\n`)
+  // Declaring a workspace root stops pnpm walking up into the manager
+  // directory above, whose own lockfile is for pnpr's dependencies and has
+  // nothing to do with the fixture.
+  fs.writeFileSync(path.join(cwd, 'pnpm-workspace.yaml'), "packages:\n  - '.'\n")
+
+  const result = spawn.sync(pm.name, [...pm.args, '--no-frozen-lockfile'], {
+    cwd,
+    env: createEnv(managersDir),
+    stdio: 'inherit',
+  })
+  if (result.error) throw result.error
+  if (result.status !== 0) {
+    throw new Error(`Populating the pnpr cache failed with status code ${result.status}`)
+  }
+}
+
+/**
+ * pnpm resolves on its own whenever it can't use the server, and says so only
+ * in its output — an unusable server leaves no trace in pnpr's storage, which
+ * the registry traffic fills either way. That failure would silently turn the
+ * accelerated row into a copy of the plain pnpm row, so it is checked here
+ * with one untimed install rather than during a measured one.
+ */
+export function verifyResolverIsUsed ({ pm, managersDir, dir, registry, authToken, pnprServer, fixtureDir }) {
+  const cwd = path.join(dir, 'verify')
+  fs.rmSync(cwd, { recursive: true, force: true })
+  fs.mkdirSync(cwd, { recursive: true })
+  fs.copyFileSync(path.join(fixtureDir, 'package.json'), path.join(cwd, 'package.json'))
+  // The resolver answers on a link of its own, so it is a different host than
+  // the registry and needs the credential declared against its own address.
+  const hosts = new Set([registry, pnprServer].map((url) => new URL(url).host))
+  const auth = [...hosts].map((host) => `//${host}/:_authToken=${authToken}\n`).join('')
+  fs.writeFileSync(path.join(cwd, '.npmrc'), `registry=${registry}\n${auth}`)
+  fs.writeFileSync(path.join(cwd, 'pnpm-workspace.yaml'), `packages:\n  - '.'\npnprServer: ${pnprServer}\n`)
+
+  const result = spawn.sync(pm.name, [...pm.args, '--no-frozen-lockfile'], {
+    cwd,
+    env: createEnv(managersDir),
+    encoding: 'utf8',
+  })
+  const output = `${result.stdout ?? ''}${result.stderr ?? ''}`
+  if (result.status !== 0) {
+    throw new Error(`Verifying pnpr resolution failed with status code ${result.status}. ${output}`)
+  }
+  if (!/pnpr server/i.test(output)) {
+    throw new Error(
+      'pnpm resolved without the pnpr server, so the accelerated scenario ' +
+      `would measure a plain install. Its output was:\n${output}`
+    )
+  }
+}

--- a/benchmarks/recordBenchmark.js
+++ b/benchmarks/recordBenchmark.js
@@ -19,7 +19,10 @@ export default async function (pm, fixture, opts) {
   // Tools without an executable to ask (nvm is a shell function) report their
   // version through `opts.getVersion`.
   pm.version = opts.getVersion?.(pm, opts) ?? getPMVersion(pm.name, opts)
-  const resultsFile = path.join(RESULTS, pm.scenario, pm.version, `${fixture}.yaml`)
+  // Results are normally filed under the fixture's own name. A section that
+  // measures the same fixture under different conditions files them elsewhere,
+  // so its runs are never pooled with the plain ones.
+  const resultsFile = path.join(RESULTS, pm.scenario, pm.version, `${opts.resultsName ?? fixture}.yaml`)
   const prevResults = await safeLoadYamlFile(resultsFile) || []
 
   if (prevResults.length >= limitRuns) return prevResults
@@ -27,6 +30,9 @@ export default async function (pm, fixture, opts) {
   const newResults = await runBenchmark(pm, fixture, {
     hasNodeModules: opts.hasNodeModules,
     managersDir: opts.managersDir,
+    registry: opts.registry,
+    authToken: opts.authToken,
+    pnprServer: opts.pnprServer,
   })
   const results = [...prevResults, newResults]
   await writeYamlFile(resultsFile, results)


### PR DESCRIPTION
Adds a section that runs every package manager against the same [pnpr](https://pnpm.io/pnpr) registry, and pnpm a second time with dependency resolution [offloaded to that server](https://pnpm.io/pnpr/install-acceleration).

## Why emulate a network

Resolving a dependency graph means walking it level by level: fetch a package's metadata, read its ranges, fetch the next level. Each level costs a round trip, so the cost is roughly *graph depth × latency*. A registry on the same machine hides that completely, which is exactly the cost pnpr exists to remove. The section puts a **50ms round trip at 200 Mbit/s** in front of it — the values pnpm's own `integrated-benchmark` uses in CI.

## Keeping it fair

- **Every client crosses the same link**, including pnpm's resolution requests and at the *same* round trip. A cheaper link to pnpr would flatter it for free; what it wins has to come from making fewer round trips, not cheaper ones.
- **pnpr's cache is warmed before anything is timed**, so no manager pays to pull the fixture into the registry on behalf of the ones measured after it.
- **The accelerated row runs the same pnpm binary as the plain row**, leaving pnpr as the only difference between them.
- A check fails the run if pnpm resolved without the server, since that would silently turn the accelerated row into a copy of the plain one.

## Notes for review

Three details are load-bearing and easy to undo by accident:

**The proxy runs as its own process.** Installs are measured with a synchronous spawn, which blocks the benchmark's event loop for the whole install — a proxy living in that process would accept no connection until the install it is meant to be serving had already finished.

**Neither the proxy nor pnpr writes to a pipe.** Nothing drains a pipe while a measured install holds the event loop, so a full 64KB buffer blocks the writer and the registry stops answering mid-scenario. This was a real failure: it only appeared late in long runs, and pnpr's log reaches ~560KB in a single section.

**pnpr must be told the proxy's address.** It rewrites the tarball URLs it serves to its `--public-url`, so if that is its own port, every tarball is fetched *around* the emulated link rather than across it — and npm refuses outright with `EALLOWREMOTE`. The proxy therefore has to be started before the server.

## Results namespace

Recorded under their own fixture name (`alotta-files-pnpr`). These runs use a different registry over an emulated network, so pooling them with the main section's runs of the same fixture would average two unrelated things into one `min`.

## Warm-up

Each scenario now runs behind two unmeasured installs. Only the first install of a run pays for a registry answering a question it has never been asked, and that cost was landing on whichever scenario went first — in a single-run local trial it made the accelerated row look 2.5× slower than plain pnpm on lockfile rows, when the steady-state difference is about 15%. It runs twice because an install with a lockfile and one without are different questions, and a server that caches answers has to have been asked both.

This costs one extra clean install per manager per fixture, which is the main CI cost of the change and worth a look.

## What the numbers show

Server-side resolution wins where there is a graph to resolve, and costs a round trip where there is not: with an up-to-date lockfile pnpm still asks the server, which answers from cache in ~15ms, but the client still pays the round trip and the streamed lockfile. Both behaviours are described in the section text on the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added benchmark scenarios comparing npm, pnpm, Yarn, and Bun with a pnpr-backed registry.
  * Added configurable network emulation for latency, bandwidth, and slow-start conditions.
  * Added authenticated registry setup, cache warm-up, resolver verification, and server-backed pnpm resolution.
  * Benchmark results can now be separated by package-manager scenario and version, with isolated warm-up runs.

* **Documentation**
  * Documented benchmark scenarios, fixture naming, network emulation, I/O requirements, and Node.js version management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->