### PR TITLE
fix: stop the latency proxy dying silently under load

### DIFF
--- a/benchmarks/latencyProxy.js
+++ b/benchmarks/latencyProxy.js
@@ -152,7 +152,16 @@ function listen ({ upstreamPort, roundTripMs, rateLimit, slowStart }) {
     upstream.on('close', () => { toClient.flushed().finally(() => client.destroy()) })
     client.on('close', () => { toUpstream.flushed().finally(() => upstream.destroy()) })
   })
-  server.on('error', (err) => { throw err })
+  // Accepting a connection can fail without the listener being finished — most
+  // of all by running out of file descriptors, which a proxy is twice as prone
+  // to as anything else because every connection through it needs two. Throwing
+  // from here would end the process, and a proxy that dies takes the run with
+  // it: every fetch after it fails, the package managers spend minutes retrying
+  // against a closed port, and nothing says why. Staying up and recording it
+  // leaves the benchmark able to finish or to fail with a reason.
+  server.on('error', (err) => {
+    console.error(`latency proxy: server error: ${err.stack ?? err}`)
+  })
   return server
 }
 
@@ -179,12 +188,32 @@ export async function startLatencyProxy ({ upstreamPort, roundTripMs, rateLimit 
   ], { stdio: ['ignore', logFd, logFd] })
   fs.closeSync(logFd)
 
+  let exit = null
+  proc.on('exit', (code, signal) => { exit = { code, signal } })
+
   const deadline = Date.now() + 15_000
   while (Date.now() < deadline) {
     const log = fs.readFileSync(logPath, 'utf8')
     const port = log.match(/^port=(\d+)$/m)?.[1]
     if (port) {
-      return { port: Number(port), close: () => { proc.kill() } }
+      return {
+        port: Number(port),
+        /**
+         * A proxy that dies mid-run doesn't stop the benchmark, it ruins it:
+         * every request after it is refused, package managers retry for minutes
+         * against a closed port, and whatever times come out are meaningless.
+         * Checking between scenarios turns that into an immediate failure that
+         * says what happened.
+         */
+        assertAlive: () => {
+          if (!exit) return
+          throw new Error(
+            `The latency proxy on port ${port} exited (code ${exit.code}, signal ${exit.signal}). ` +
+            `Everything measured after it would be meaningless. Its log:\n${fs.readFileSync(logPath, 'utf8').slice(-4000)}`
+          )
+        },
+        close: () => { proc.kill() },
+      }
     }
     if (proc.exitCode !== null) {
       throw new Error(`The latency proxy exited with code ${proc.exitCode}. ${log}`)
@@ -199,6 +228,16 @@ export async function startLatencyProxy ({ upstreamPort, roundTripMs, rateLimit 
 
 // Running this file directly is what `startLatencyProxy` spawns.
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  // Whatever goes wrong in here has to end up written down. The parent is
+  // blocked in a synchronous spawn and cannot be told, so a proxy that exits
+  // quietly leaves nothing behind but connection refusals in a package
+  // manager's output.
+  process.on('uncaughtException', (err) => {
+    console.error(`latency proxy: uncaught: ${err.stack ?? err}`)
+  })
+  process.on('unhandledRejection', (err) => {
+    console.error(`latency proxy: unhandled rejection: ${err?.stack ?? err}`)
+  })
   const arg = (name) => Number(process.argv.find((a) => a.startsWith(`--${name}=`))?.split('=')[1] ?? 0)
   const rateLimit = arg('rate-limit')
   const server = listen({

--- a/benchmarks/pnprSection.js
+++ b/benchmarks/pnprSection.js
@@ -147,6 +147,12 @@ export default async function pnprSection ({ managersDirs, formattedNow, limitRu
       fixtureDir,
     })
 
+    // Warming the cache is the first thing to put real load on the link, and a
+    // link that dies here would otherwise be discovered much later, after a
+    // package manager had spent minutes retrying against a closed port.
+    for (const proxy of proxies) proxy.assertAlive()
+    server.assertAlive()
+
     verifyResolverIsUsed({
       pm: withRegistry(cmdsMap.pnpm11, registry),
       managersDir: managersDirs.pnpm11,
@@ -183,6 +189,11 @@ export default async function pnprSection ({ managersDirs, formattedNow, limitRu
         registry,
         ...rest,
       }))
+      // Checked after every manager rather than only at the end, so a link or a
+      // registry that died is reported against the run that lost it instead of
+      // silently devaluing everything measured afterwards.
+      for (const proxy of proxies) proxy.assertAlive()
+      server.assertAlive()
     }
 
     return buildSection({ results, pmConfigs, version, formattedNow, svgName })

--- a/benchmarks/pnprServer.js
+++ b/benchmarks/pnprServer.js
@@ -99,11 +99,21 @@ export async function startPnpr ({ managersDir, dir, port, publicUrl, logLevel =
     }
   }
 
+  let exit = null
+  proc.on('exit', (code, signal) => { exit = { code, signal } })
+
   const url = `http://127.0.0.1:${port}`
   await waitForPnpr(url, proc, readLog)
   return {
     url,
     log: readLog,
+    /** A registry that died mid-run makes everything measured after it worthless. */
+    assertAlive: () => {
+      if (!exit) return
+      throw new Error(
+        `pnpr exited (code ${exit.code}, signal ${exit.signal}). Its log:\n${readLog().slice(-4000)}`
+      )
+    },
     stop: () => { proc.kill() },
   }
 }


### PR DESCRIPTION
The scheduled benchmark on `main` failed with hundreds of these:

```
[WARN] GET http://127.0.0.1:34703/ajv-keywords/-/ajv-keywords-3.5.2.tgz error (ECONNREFUSED). Will retry in 1 minute.
```

`34703` is the latency proxy. Nothing was listening on it, so the proxy process had died.

## What happened

From [the run's log](https://github.com/pnpm/pnpm.io/actions/runs/31754108913/job/94626081521): the pnpr section started normally, pnpr came up, and the link served **packuments** fine — pnpm got as far as `resolved 592`. It went away as soon as tarball fetching began, which is the moment connection count jumps.

`latencyProxy.js` had:

```js
server.on('error', (err) => { throw err })
```

Throwing from an event handler is an uncaught exception, so **any** accept-time error ended the process. A proxy is twice as exposed to descriptor exhaustion as an ordinary server, because every connection through it needs two — one in, one out — and this fixture pulls ~1600 packages.

I can't prove `EMFILE` from the logs, because **the crash reason was never recorded**: the proxy writes to a file in a temp directory on the runner, which never reaches the job output. That gap is most of what this PR fixes. Locally `ulimit -n` is 1048576, which is why this never showed up in development.

## Changes

- **Accept errors no longer kill the proxy.** They are recorded and it keeps listening, so it recovers when descriptors free up instead of taking the run down.
- **Anything else uncaught is written to the log** rather than vanishing.
- **Both servers can be asked whether they are still alive**, and the section asks after warming the cache and after every package manager. A dead link now fails immediately, with the tail of its log in the error, instead of being discovered minutes later through connection refusals.

The last point matters most: a benchmark that can't measure should say so. Before this, a dead proxy produced retry storms and timings that meant nothing.

## Not affected

No bad numbers can reach the site — the workflow's commit step only runs if every benchmark step succeeds, so a run that hits this fails rather than publishing.

## Verification

`pnpm --dir=benchmarks test` — 4 passing. The proxy's calibration tests (round trip, throughput against the configured cap, response integrity over reused and concurrent connections) still hold.

If this recurs, the failure will now name the cause and quote the log, so the next step won't be guesswork.

🤖 Generated with [Claude Code](https://claude.com/claude-code)