### PR TITLE
fix: give pnpr a port of its own for each run

### DIFF
--- a/benchmarks/pnprSection.js
+++ b/benchmarks/pnprSection.js
@@ -16,6 +16,7 @@ import {
   mintToken,
   populateCache,
   verifyResolverIsUsed,
+  reservePort,
 } from './pnprServer.js'
 
 const { stripIndents } = commonTags
@@ -27,8 +28,6 @@ const DIRNAME = path.dirname(fileURLToPath(import.meta.url))
 // wins has to come from making fewer round trips rather than cheaper ones.
 const ROUND_TRIP_MS = 50
 const BANDWIDTH_MBPS = 200
-
-const PNPR_PORT = 7677
 
 // Results are recorded under their own fixture name. The numbers here are
 // measured against a different registry over an emulated link, so they must
@@ -103,8 +102,12 @@ export default async function pnprSection ({ managersDirs, formattedNow, limitRu
     // really use, so the tarball URLs it serves point across the emulated link
     // instead of around it.
     fs.mkdirSync(dir, { recursive: true })
+    // A port the system says is free, rather than a fixed one: a fixed port is
+    // still held by the pnpr of an earlier run in the same job, and that older
+    // server answers for it.
+    const pnprPort = await reservePort()
     const registryLink = await startLatencyProxy({
-      upstreamPort: PNPR_PORT,
+      upstreamPort: pnprPort,
       roundTripMs: ROUND_TRIP_MS,
       rateLimit: mbpsToBytesPerSec(BANDWIDTH_MBPS),
       logPath: path.join(dir, 'registry-link.log'),
@@ -116,7 +119,7 @@ export default async function pnprSection ({ managersDirs, formattedNow, limitRu
     // Only latency is emulated here: the resolve exchange is small, so what it
     // costs is round trips rather than throughput.
     const resolverLink = await startLatencyProxy({
-      upstreamPort: PNPR_PORT,
+      upstreamPort: pnprPort,
       roundTripMs: ROUND_TRIP_MS,
       logPath: path.join(dir, 'resolver-link.log'),
     })
@@ -126,7 +129,7 @@ export default async function pnprSection ({ managersDirs, formattedNow, limitRu
     server = await startPnpr({
       managersDir: managersDirs.pnpr,
       dir,
-      port: PNPR_PORT,
+      port: pnprPort,
       publicUrl: registry,
       // Logging every request is what lets the check below see whether pnpm
       // really resolved on the server. It goes to a file, and every manager

--- a/benchmarks/pnprServer.js
+++ b/benchmarks/pnprServer.js
@@ -1,8 +1,29 @@
 'use strict'
 import fs from 'fs'
+import net from 'net'
 import path from 'path'
 import spawn from 'cross-spawn'
 import { createEnv } from './benchmarkFixture.js'
+
+/**
+ * Takes a port the operating system says is free.
+ *
+ * Starting pnpr on a fixed port meant colliding with one left behind by an
+ * earlier run of the benchmark in the same job, and the collision did not look
+ * like one: the new server failed to bind and exited, the old one answered the
+ * health check, and the run carried on against a registry whose tarball URLs
+ * pointed at a proxy that had been shut down with the run that created it.
+ */
+export function reservePort () {
+  return new Promise((resolve, reject) => {
+    const probe = net.createServer()
+    probe.on('error', reject)
+    probe.listen(0, '127.0.0.1', () => {
+      const { port } = probe.address()
+      probe.close(() => resolve(port))
+    })
+  })
+}
 
 const USERNAME = 'pnpm-io-benchmark'
 const PASSWORD = 'benchmark'
@@ -114,7 +135,15 @@ export async function startPnpr ({ managersDir, dir, port, publicUrl, logLevel =
         `pnpr exited (code ${exit.code}, signal ${exit.signal}). Its log:\n${readLog().slice(-4000)}`
       )
     },
-    stop: () => { proc.kill() },
+    // A registry that outlives its run is what made the second benchmark of a
+    // job fail: it held the port, answered the next run's health check, and
+    // served tarball URLs pointing at a proxy that no longer existed. Make sure
+    // it is gone rather than merely asked to leave.
+    stop: () => {
+      if (exit) return
+      proc.kill()
+      setTimeout(() => { if (!exit) proc.kill('SIGKILL') }, 2_000).unref()
+    },
   }
 }
 
@@ -126,8 +155,23 @@ async function waitForPnpr (url, proc, getStderr) {
     }
     try {
       const res = await fetch(`${url}/-/ping`)
-      if (res.ok) return
-    } catch {
+      if (res.ok) {
+        // Something answering is not the same as our server answering. A server
+        // left behind by an earlier run replies at once, well before the process
+        // started here has had time to discover it cannot have the port and
+        // exit, so the reply alone proves nothing — give it long enough to fail
+        // and then insist it is still running.
+        await new Promise((resolve) => setTimeout(resolve, 500))
+        if (proc.exitCode !== null) {
+          throw new Error(
+            `pnpr exited with code ${proc.exitCode} yet ${url} still answers, so another ` +
+            `server holds that port and the benchmark would run against it. ${getStderr()}`
+          )
+        }
+        return
+      }
+    } catch (err) {
+      if (err.message?.startsWith('pnpr exited')) throw err
       // Not listening yet.
     }
     await new Promise((resolve) => setTimeout(resolve, 200))


### PR DESCRIPTION
The benchmark on `main` still failed after #876, with the same `ECONNREFUSED` wall. The cause is different from what I guessed there, and the [job log](https://github.com/pnpm/pnpm.io/actions/runs/31756127841/job/94632125954) shows it outright.

## What actually happens

The workflow runs `pnpm --dir=benchmarks run benchmark` three times in one job.

- **First invocation: zero refusals.** The pnpr section completes normally.
- **Second invocation: refused from the very first request**, before any load — immediately after `installPnpr`, not after a storm.

The give-away is the port. `40991` appears **55 times in the first invocation, working**, and then again in the second, refused. One port, two runs.

`PNPR_PORT` was hardcoded to `7677`:

1. The first run's pnpr survives the run and keeps the port.
2. The second run's pnpr cannot bind, and exits.
3. `waitForPnpr` only asked *whether something was listening*. The **old** server answered `200`, so startup looked successful.
4. The whole run then used a registry belonging to a finished run — one still advertising `--public-url` pointing at the **first** run's latency proxy, which was shut down along with it.
5. Every tarball URL therefore pointed at a dead port.

So the proxy was never the problem here. It was doing its job; it had simply been told about by a server that outlived the run that configured it.

## Changes

- **pnpr takes a port the system says is free**, so the collision cannot happen.
- **The health check no longer accepts somebody else's server as proof of its own.** A stale server answers instantly, well before the new process discovers it cannot have the port, so the wait now gives it time to fail and then insists it is still running.
- **Shutdown follows up with a `SIGKILL`**, since a registry outliving its run is what started this.

## Verification

A test harness that starts two sections in sequence, as the job does: distinct ports each time, and a deliberate collision on an occupied port is now **rejected** — `pnpr exited with code 1 yet http://127.0.0.1:34009 still answers, so another server holds that port` — where before it was silently accepted.

`pnpm --dir=benchmarks test` — 4 passing.

## Note on #876

That change was not wasted, but it did not fix this and I should not have implied it would. Its liveness checks and logging still matter — they are why this run failed at `populateCache` with a clear stack instead of grinding on. But my `EMFILE` reasoning there was wrong: the proxy never ran out of anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)