### PR TITLE
docs: remove more references to corepack

### DIFF
--- a/docs/cli/deploy.md
+++ b/docs/cli/deploy.md
@@ -37,7 +37,7 @@ Usage in a docker image. After building everything in your monorepo, do this in 
 FROM workspace as pruned
 RUN pnpm --filter <your package name> --prod deploy pruned
 
-FROM node:18-alpine
+FROM node:22-alpine
 WORKDIR /app
 
 ENV NODE_ENV=production

--- a/docs/cli/fetch.md
+++ b/docs/cli/fetch.md
@@ -23,7 +23,7 @@ RUN pnpm runtime set node 22 -g
 WORKDIR /app
 
 # Files required by pnpm install
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .pnpmfile.mjs ./
 
 # If you patched any package, include patches before install too
 COPY patches patches

--- a/docs/cli/fetch.md
+++ b/docs/cli/fetch.md
@@ -16,14 +16,14 @@ From that guide, we learn to write an optimized Dockerfile for projects using
 pnpm, which looks like
 
 ```Dockerfile
-FROM node:20
+FROM ghcr.io/pnpm/pnpm:11
 
-WORKDIR /path/to/somewhere
+RUN pnpm runtime set node 22 -g
 
-RUN corepack enable pnpm && corepack install -g pnpm@latest-11
+WORKDIR /app
 
 # Files required by pnpm install
-COPY .npmrc package.json pnpm-lock.yaml pnpm-workspace.yaml .pnpmfile.mjs ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 
 # If you patched any package, include patches before install too
 COPY patches patches
@@ -37,7 +37,7 @@ EXPOSE 8080
 CMD [ "node", "server.js" ]
 ```
 
-As long as there are no changes to `.npmrc`, `package.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`,
+As long as there are no changes to `package.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`,
 `.pnpmfile.mjs`, docker build cache is still valid up to the layer of
 `RUN pnpm install --frozen-lockfile --prod`, which cost most of the time
 when building a docker image.
@@ -51,14 +51,14 @@ It's also hard to maintain a Dockerfile that builds a monorepo project, it may
 look like
 
 ```Dockerfile
-FROM node:20
+FROM ghcr.io/pnpm/pnpm:11
 
-WORKDIR /path/to/somewhere
+RUN pnpm runtime set node 22 -g
 
-RUN corepack enable pnpm && corepack install -g pnpm@latest-11
+WORKDIR /app
 
 # Files required by pnpm install
-COPY .npmrc package.json pnpm-lock.yaml pnpm-workspace.yaml .pnpmfile.mjs ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .pnpmfile.mjs ./
 
 # If you patched any package, include patches before install too
 COPY patches patches
@@ -85,11 +85,11 @@ sub-packages.
 to load packages into the virtual store using only information from a lockfile and a configuration file (`pnpm-workspace.yaml`).
 
 ```Dockerfile
-FROM node:20
+FROM ghcr.io/pnpm/pnpm:11
 
-WORKDIR /path/to/somewhere
+RUN pnpm runtime set node 22 -g
 
-RUN corepack enable pnpm && corepack install -g pnpm@latest-11
+WORKDIR /app
 
 # pnpm fetch does require only lockfile
 COPY pnpm-lock.yaml pnpm-workspace.yaml ./

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -32,19 +32,7 @@ Supported platforms: `linux/amd64`, `linux/arm64`.
 
 ### Installing Node.js
 
-Use [`pnpm runtime set`](./cli/runtime.md) with the global flag so the `node` binary is discoverable on `PATH` in subsequent layers and at runtime:
-
-```dockerfile
-FROM ghcr.io/pnpm/pnpm:11
-RUN pnpm runtime set node 22 -g
-WORKDIR /app
-COPY package.json pnpm-lock.yaml ./
-RUN pnpm install --frozen-lockfile
-COPY . .
-CMD ["node", "index.js"]
-```
-
-Or let pnpm install Node.js automatically from [`devEngines.runtime`](./package_json.md#devenginesruntime) in your `package.json`:
+Let pnpm install Node.js automatically from [`devEngines.runtime`](./package_json.md#devenginesruntime) in your `package.json`:
 
 ```json title="package.json"
 {
@@ -58,19 +46,18 @@ Or let pnpm install Node.js automatically from [`devEngines.runtime`](./package_
 }
 ```
 
-```diff
+```dockerfile
 FROM ghcr.io/pnpm/pnpm:11
--RUN pnpm runtime set node 22 -g
 WORKDIR /app
 COPY package.json pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile
 COPY . .
-CMD ["node", "index.js"]
+CMD ["pnpm", "start"]
 ```
 
 ### When to use this image
 
-- You want the Node.js version to be pinned by your project (via `pnpm runtime set` or `devEngines.runtime`) rather than by the base image.
+- You want the Node.js version to be pinned by your project via `devEngines.runtime` rather than by the base image.
 - You want to upgrade pnpm and Node.js independently.
 - You prefer a minimal Debian base without the Node.js build toolchain.
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -38,8 +38,9 @@ Use [`pnpm runtime set`](./cli/runtime.md) with the global flag so the `node` bi
 FROM ghcr.io/pnpm/pnpm:11
 RUN pnpm runtime set node 22 -g
 WORKDIR /app
-COPY . .
+COPY package.json pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile
+COPY . .
 CMD ["node", "index.js"]
 ```
 
@@ -57,13 +58,14 @@ Or let pnpm install Node.js automatically from [`devEngines.runtime`](./package_
 }
 ```
 
-```dockerfile
+```diff
 FROM ghcr.io/pnpm/pnpm:11
+-RUN pnpm runtime set node 22 -g
 WORKDIR /app
 COPY package.json pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile
 COPY . .
-CMD ["pnpm", "start"]
+CMD ["node", "index.js"]
 ```
 
 ### When to use this image

--- a/docs/podman.md
+++ b/docs/podman.md
@@ -24,11 +24,11 @@ Only mount a host pnpm store into containers you trust. A container with write a
 Below is an example container setup for demonstration:
 
 ```dockerfile title="Dockerfile"
-FROM node:20-slim
+FROM ghcr.io/pnpm/pnpm:11
 
-# corepack is an experimental feature in Node.js v20 which allows
-# installing and managing versions of pnpm, npm, yarn
-RUN corepack enable
+RUN pnpm runtime set node 22 -g
+
+WORKDIR /app
 
 VOLUME [ "/pnpm-store", "/app/node_modules" ]
 RUN pnpm config --global set store-dir /pnpm-store
@@ -36,7 +36,6 @@ RUN pnpm config --global set store-dir /pnpm-store
 # You may need to copy more files than just package.json in your code
 COPY package.json /app/package.json
 
-WORKDIR /app
 RUN pnpm install
 RUN pnpm run build
 ```

--- a/docs/podman.md
+++ b/docs/podman.md
@@ -23,10 +23,10 @@ Only mount a host pnpm store into containers you trust. A container with write a
 
 Below is an example container setup for demonstration:
 
+Declare Node.js in [`devEngines.runtime`](./package_json.md#devenginesruntime) in your `package.json`. The `pnpm install` command below will install the declared version automatically.
+
 ```dockerfile title="Dockerfile"
 FROM ghcr.io/pnpm/pnpm:11
-
-RUN pnpm runtime set node 22 -g
 
 WORKDIR /app
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Docker deployment examples to use Node.js 22 and the latest pnpm container image.
  * Revised Docker and Podman instructions to use `/app` as the working directory and document current runtime configuration.
  * Simplified container examples by removing outdated Corepack and unnecessary configuration-file steps.
  * Updated dependency caching guidance to reflect the current installation process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->