### PR TITLE
docs: document pnpm v12.0.0-rc.6

### DIFF
--- a/blog/2026-08-10-whats-different-in-pnpm-12.md
+++ b/blog/2026-08-10-whats-different-in-pnpm-12.md
@@ -8,7 +8,7 @@ tags: [release]
 
 pnpm 12 is a rewrite of pnpm in Rust, and it is currently a **release candidate**. Upgrading is not meant to be a migration: apart from the differences below, it keeps the commands, flags, settings, and lockfile format of pnpm 11, and the [documentation](/motivation) applies to both versions.
 
-Four things differ, and one of them — a removed flag — fails outright rather than behaving differently. This post collects them in one place.
+Five things differ, and one of them — a removed flag — fails outright rather than behaving differently. This post collects them in one place.
 
 <!--truncate-->
 
@@ -42,6 +42,26 @@ git config --global url."git@github.com:".insteadOf https://github.com/
 ```
 
 pnpm shells out to `git`, so the rewrite applies to all of its Git operations automatically. Details, including how unknown hosts and credentialed URLs are handled, are in [How Git dependencies are resolved](/package-sources#how-git-dependencies-are-resolved).
+
+## Naming a package manager
+
+Since v12.0.0-rc.6, pnpm installs the other package managers too — npm, Yarn Classic, Yarn Berry, Yarn 6 (`yarnpkg/zpm`) and Bun — so naming one means the tool itself rather than the npm package that shares its name.
+
+The reason is that those npm packages are not the tool: `yarn` on npm stops at Classic, Yarn 4 is published as `@yarnpkg/cli-dist`, Yarn 6 is not on npm at all, and `node` / `deno` there are wrappers that download a build. So `pnx yarn@4 install` used to fail with a missing version, and `pnpm add -g yarn` gave you Yarn 1.
+
+| | pnpm 11 | pnpm 12 |
+|---|---|---|
+| `pnpm add yarn` | installs the npm package `yarn` | records the project's package manager in `packageManager` / `devEngines.packageManager` |
+| `pnpm add -g yarn` | installs Yarn Classic | installs the current Yarn line |
+| `pnpm add -g node` / `pnpm add -g deno` | installs a wrapper package | installs that Node.js or Deno release |
+| `pnx node@22` / `pnx deno` | runs the wrapper package | runs that release |
+| a globally installed package manager | always the global copy | defers to a project's pin where there is one |
+
+A specifier that locates a package rather than asking for a released version still installs what it names — `pnpm add yarn@npm:yarn@1.22.22`, `pnx yarn@yarnpkg/berry`.
+
+Two more things follow from it. A git-hosted dependency is prepared with the package manager *it* asks for, so a repository built with Yarn installs on a machine that has only pnpm. And [`pnpm shim add yarn`](/cli/shim) links a `yarn` command that runs whatever version the current project pins — a shim is never created as a side effect of `pnpm setup` or an install, since it shadows the rest of your `PATH`.
+
+The full description is in [Other package managers](/package-managers).
 
 ## Lockfiles of cyclic dependency graphs
 

--- a/docs/cli/add.md
+++ b/docs/cli/add.md
@@ -28,6 +28,22 @@ pnpm supports installing packages from various sources. See the [Supported packa
 - Remote tarballs
 - Git repositories (with semver, subdirectories, and more)
 
+## Adding a package manager or a runtime
+
+Added in: v12.0.0-rc.6 (pnpm v12 only)
+
+Naming a [package manager](../package-managers.md) — `npm`, `yarn` or `bun` — records which one the project uses instead of installing the npm package that shares the name:
+
+```sh
+pnpm add yarn@4
+```
+
+writes `"packageManager": "yarn@4.18.0"`, and every other package manager is recorded as a range in [`devEngines.packageManager`](../package_json.md#devenginespackagemanager). Naming a runtime (`node`, `deno`, `bun`) records it under `engines.runtime`, as the explicit `node@runtime:22` spelling already did.
+
+Globally, `pnpm add -g yarn` installs the current Yarn line rather than the Classic-only `yarn` package, and `pnpm add -g node@22` installs that Node.js release rather than a wrapper that downloads one.
+
+A specifier that locates a package rather than asking for a released version — `pnpm add yarn@npm:yarn@1.22.22`, `pnpm add yarn@yarnpkg/berry` — installs what it names, as an ordinary dependency.
+
 ## Options
 
 ### --save-prod, -P, -p

--- a/docs/cli/add.md
+++ b/docs/cli/add.md
@@ -38,7 +38,7 @@ Naming a [package manager](../package-managers.md) — `npm`, `yarn` or `bun` �
 pnpm add yarn@4
 ```
 
-writes `"packageManager": "yarn@4.18.0"`, and every other package manager is recorded as a range in [`devEngines.packageManager`](../package_json.md#devenginespackagemanager). Naming a runtime (`node`, `deno`, `bun`) records it under `engines.runtime`, as the explicit `node@runtime:22` spelling already did.
+writes `"packageManager": "yarn@4.18.0"`, and every other package manager is recorded as a range in [`devEngines.packageManager`](../package_json.md#devenginespackagemanager). Naming a runtime (`node`, `deno`) records it under `engines.runtime`, as the explicit `node@runtime:22` spelling already did — `bun` is both, and is declared as the project's package manager unless you ask for the runtime (`pnpm add bun@runtime:1.3.0`).
 
 Globally, `pnpm add -g yarn` installs the current Yarn line rather than the Classic-only `yarn` package, and `pnpm add -g node@22` installs that Node.js release rather than a wrapper that downloads one.
 

--- a/docs/cli/cache-path.md
+++ b/docs/cli/cache-path.md
@@ -1,0 +1,27 @@
+---
+id: cache-path
+title: pnpm cache path
+---
+
+Added in: v11.22.0
+
+Prints the directory pnpm uses for its metadata cache, mirroring [`pnpm store path`](./store.md#path). The path is printed absolute and lexically cleaned, so a relative [`cacheDir`](../settings/other.md#cachedir) yields a path other tools can consume.
+
+```sh
+pnpm cache path
+```
+
+pnpm derives this directory from the platform and the `cacheDir` setting, so a CI setup that wants to cache it no longer has to mirror that resolution by hand:
+
+```yaml title=".github/workflows/ci.yaml"
+- name: Get the cache directory
+  run: echo "PNPM_CACHE_DIR=$(pnpm cache path)" >> $GITHUB_ENV
+```
+
+Besides registry metadata and the [`pnpm dlx`](./pnx.md) cache, that directory holds the lockfile verification log — the record of which lockfile passed which [supply-chain policies](../supply-chain-security.md). Restoring it lets a job skip re-verifying an unchanged lockfile against the registry, which is the dominant cost of an install in CI. Since v11.22.0, [`pnpm store prune`](./store.md#prune) no longer deletes that log.
+
+:::important
+
+Only cache this directory in locations writable by trusted jobs. See the [`cacheDir`](../settings/other.md#cachedir) setting for details.
+
+:::

--- a/docs/cli/cache-path.md
+++ b/docs/cli/cache-path.md
@@ -18,7 +18,7 @@ pnpm derives this directory from the platform and the `cacheDir` setting, so a C
   run: echo "PNPM_CACHE_DIR=$(pnpm cache path)" >> $GITHUB_ENV
 ```
 
-Besides registry metadata and the [`pnpm dlx`](./pnx.md) cache, that directory holds the lockfile verification log — the record of which lockfile passed which [supply-chain policies](../supply-chain-security.md). Restoring it lets a job skip re-verifying an unchanged lockfile against the registry, which is the dominant cost of an install in CI. Since v11.22.0, [`pnpm store prune`](./store.md#prune) no longer deletes that log.
+Besides registry metadata and the [`pnpm dlx`](./pnx.md) cache, that directory holds the lockfile verification log — the record of which lockfile passed which [supply-chain policies](../supply-chain-security.md). Restoring it lets a job skip re-verifying a lockfile the log already covers under the policies currently configured — the dominant cost of an install in CI once the store is warm. Since v11.22.0, [`pnpm store prune`](./store.md#prune) no longer deletes that log.
 
 :::important
 

--- a/docs/cli/cache.md
+++ b/docs/cli/cache.md
@@ -8,3 +8,4 @@ Commands:
 * [cache list-registries](/cli/cache-list-registries.md)
 * [cache delete](/cli/cache-delete.md)
 * [cache view](/cli/cache-view.md)
+* [cache path](/cli/cache-path.md)

--- a/docs/cli/pnx.md
+++ b/docs/cli/pnx.md
@@ -28,6 +28,34 @@ The `catalog:` protocol is also supported, allowing you to use versions defined 
 pnx shx@catalog:
 ```
 
+## Running a package manager or a runtime
+
+Added in: v12.0.0-rc.6 (pnpm v12 only)
+
+Naming one of the [package managers pnpm provisions](../package-managers.md) (`npm`, `yarn`, `bun`), or a runtime (`node`, `deno`, `bun`), provisions the real thing instead of installing the npm package that shares its name:
+
+```
+pnx yarn@4 install
+pnx npm@11 ci
+pnx bun@1.3.0 install
+pnx node@22 --version
+```
+
+Those npm packages are either a different line of the tool or a wrapper that downloads it, so this is what naming them was always meant to do: `pnx yarn@4` used to fail with a missing version, since Yarn 4 is published as `@yarnpkg/cli-dist`, and `pnx node@22` used to run a wrapper that downloads a Node.js build rather than that release itself.
+
+A specifier that locates a package rather than asking for a released version installs what it names, unchanged:
+
+```
+pnx yarn@npm:yarn@1.22.22
+pnx yarn@yarnpkg/berry
+```
+
+`--package` naming a package manager picks which of its commands to run:
+
+```
+pnx --package npm@11 npx create-something
+```
+
 ## Options
 
 ### --package &lt;name\>

--- a/docs/cli/runtime.md
+++ b/docs/cli/runtime.md
@@ -29,6 +29,12 @@ Since v11.0.0, installing a Node.js runtime (via `pnpm runtime set node …` or 
 
 :::
 
+:::info
+
+Since v11.22.0, resolving a Node.js version (through [`devEngines.runtime`](../package_json.md#devenginesruntime) or a `runtime:` specifier) is much faster. The per-version release metadata is cached in the [cache directory](./cache-path.md) after its signature is verified, and an exact stable version such as `runtime:22.23.2` no longer downloads the Node.js release index. A pinned runtime whose metadata was fetched once resolves without any network access, which removes the delay on the first `node` invocation in a project pinning an already-downloaded runtime.
+
+:::
+
 #### Examples
 
 Install Node.js v22 globally:

--- a/docs/cli/shim.md
+++ b/docs/cli/shim.md
@@ -64,7 +64,7 @@ A shim resolves the project you are standing in, walking up from the current wor
 
 If nothing in the project provides the command, the globally installed version runs — a shim never makes a command fail merely because dispatch did not apply.
 
-The [trust rules](../global-packages.md#trust) of project-aware global bins apply here too: an npm-published package manager is verified against npm's signature for its exact version and switches without asking, while Bun and Yarn 6 arrive as checksum-pinned platform archives and go through the confirmation prompt once per project.
+The [trust rules](../global-packages.md#trust) of project-aware global bins apply here too: an npm-published package manager is verified against npm's signature for its exact version and switches without asking, while Bun and Yarn 6 arrive as checksum-pinned platform archives and go through the confirmation prompt. That answer is remembered per project *and* per binary, so moving the project's pin to another version asks again.
 
 ## Related
 

--- a/docs/cli/shim.md
+++ b/docs/cli/shim.md
@@ -1,0 +1,73 @@
+---
+id: shim
+title: "pnpm shim <cmd>"
+---
+
+Added in: v12.0.0-rc.6 (pnpm v12 only)
+
+Manage project-aware command shims.
+
+A shim created by this command has no global installation behind it. It exists only to let the project you are standing in decide what runs: `pnpm shim add yarn` links a `yarn` command that runs whatever version the current project pins, and provisions that version on demand. On a machine that has only pnpm, that is what makes `yarn` work inside a Yarn project.
+
+Creating a shim is always deliberate — nothing writes one as a side effect of [`pnpm setup`](./setup.md) or an install, because a shim shadows whatever the rest of your `PATH` resolved before it.
+
+## Commands
+
+### add
+
+```
+pnpm shim add <pkg>...
+```
+
+Links a shim for every bin of each package into the global bin directory (`pnpm bin -g`), and records the package in the [`globalShims`](../settings/other.md#globalshims) setting so the shims actually dispatch.
+
+```sh
+pnpm shim add yarn
+```
+
+The [package managers pnpm provisions](../package-managers.md) — `npm`, `yarn`, `bun` — need no lookup: their bins are known up front, aliases included (`yarn` and `yarnpkg`, `npm` and `npx`). For any other package, the bins are read from the package's published manifest; a package that publishes no bin fails with `ERR_PNPM_SHIM_NO_BINS`.
+
+A bin that is already in the global bin directory belongs to something else — a globally installed package, or another package's shim — so the command refuses with `ERR_PNPM_SHIM_BIN_CONFLICT` rather than taking a working command away.
+
+Adding a shim while `globalShims: false` is set fails with `ERR_PNPM_SHIMS_DISABLED`: that setting turns every project-aware shim off, so the shim would sit on `PATH` doing nothing.
+
+### rm
+
+```
+pnpm shim rm <pkg>...
+```
+
+Aliases: `remove`, `uninstall`
+
+Removes the package's shims and the `globalShims` entry that `add` recorded for it.
+
+### ls
+
+```
+pnpm shim ls
+```
+
+Alias: `list`
+
+Lists every shim in the global bin directory with the policy governing it:
+
+```text
+yarn (auto): yarn, yarnpkg
+```
+
+## How a version is chosen
+
+A shim resolves the project you are standing in, walking up from the current working directory:
+
+* For a **package manager**, the project's [`packageManager`](../package_json.md) or [`devEngines.packageManager`](../package_json.md#devenginespackagemanager) pin decides the version, and pnpm provisions it. The pin outranks a copy of that package manager installed globally, because it is the project's own statement of what installs it.
+* For **any other package**, the project's `node_modules/.bin/<name>` is used.
+
+If nothing in the project provides the command, the globally installed version runs — a shim never makes a command fail merely because dispatch did not apply.
+
+The [trust rules](../global-packages.md#trust) of project-aware global bins apply here too: an npm-published package manager is verified against npm's signature for its exact version and switches without asking, while Bun and Yarn 6 arrive as checksum-pinned platform archives and go through the confirmation prompt once per project.
+
+## Related
+
+* [Other package managers](../package-managers.md)
+* [Project-aware global bins](../global-packages.md#project-aware-global-bins)
+* [`globalShims`](../settings/other.md#globalshims)

--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -35,14 +35,22 @@ in place of pnpm, so every `pnpm` call starts Node.js to run the shim before pnp
 itself starts — a cost paid on each invocation, and CI jobs make many of them.
 Installing pnpm itself avoids that entirely.
 
-Corepack also cannot install pnpm 12: it expects the package to contain a
-`bin/pnpm.mjs`, which the native pnpm 12 package does not have.
-
 :::
 
 :::note
 
 In all the provided configuration files the store is cached. However, this is not required, and it is not guaranteed that caching the store will make installation faster. So feel free to not cache the pnpm store in your job.
+
+:::
+
+:::tip Cache the metadata cache too
+
+Since v11.22.0, [`pnpm cache path`](./cli/cache-path.md) prints the directory pnpm
+uses for its metadata cache, so a job can cache it without mirroring pnpm's own
+path resolution. That directory also holds the lockfile verification log, which
+lets a job skip re-checking an unchanged lockfile against the configured
+[supply-chain policies](./supply-chain-security.md) — the dominant cost of an
+install in CI once the store is warm.
 
 :::
 

--- a/docs/global-packages.md
+++ b/docs/global-packages.md
@@ -162,6 +162,7 @@ No shell hooks, `.bashrc` edits, or `use`-style commands are involved — the sh
 pnpm walks up from the current working directory to the nearest project that provides the command, then:
 
 * For the **runtimes** (`node`, `deno`, `bun`), only the manifest pin counts — [`devEngines.runtime`](./package_json.md#devenginesruntime), then `engines.runtime`. The pinned version is downloaded into the [global virtual store](./global-virtual-store.md) on demand and executed directly. The project's `node_modules/.bin` is never consulted for a runtime, so a dependency cannot supply the `node` you run.
+* For the **[package managers](./package-managers.md)** (`npm`, `yarn`, `bun`), added in v12.0.0-rc.6, the project's `packageManager` or [`devEngines.packageManager`](./package_json.md#devenginespackagemanager) pin counts, and pnpm provisions that version on demand. The pin outranks a copy of that package manager installed globally, because it is the project's own statement of what installs it.
 * For **any other package**, the project's `node_modules/.bin/<name>` is used.
 
 Directories inside the pnpm home are skipped, since global installs are not projects.
@@ -193,7 +194,9 @@ There is one more guard that applies regardless of policy: the project's command
 
 ### Which packages participate
 
-Only the runtimes participate by default. Enable others with [`globalShims`](./settings/other.md#globalshims), keyed by the providing package's name:
+Only the runtimes participate by default. Since v12.0.0-rc.6, installing a package manager globally (`pnpm add -g yarn`) also adds an entry for it, so it follows a project's pin the way a globally installed Node.js already follows `devEngines.runtime`. An entry you set yourself, including `false`, is left as you set it.
+
+Enable others with [`globalShims`](./settings/other.md#globalshims), keyed by the providing package's name:
 
 ```yaml title="~/.config/pnpm/config.yaml"
 globalShims:
@@ -211,6 +214,8 @@ Turning a package *off* needs no reinstall — the setting is re-read on every d
 ```sh
 PNPM_SHIM_BYPASS=1 node --version
 ```
+
+A package that is not installed globally at all can still get a dispatching command, with [`pnpm shim add`](./cli/shim.md) — that is what makes `yarn` work inside a Yarn project on a machine that has only pnpm.
 
 :::note
 

--- a/docs/package-managers.md
+++ b/docs/package-managers.md
@@ -1,0 +1,113 @@
+---
+id: package-managers
+title: Other package managers
+---
+
+Added in: v12.0.0-rc.6 (pnpm v12 only)
+
+pnpm installs the other package managers, not just itself: **npm**, **Yarn Classic**, **Yarn Berry**, **Yarn 6** (`yarnpkg/zpm`) and **Bun**. Each of them is resolved and fetched through the trusted package-manager registries, and an npm-published one is verified against npm's signature for its exact version before it is executed — the same standard that lets pnpm switch its own version without asking.
+
+A JavaScript package manager on a machine without Node.js gets a managed LTS runtime to run on, so none of this requires a Node.js installation of your own.
+
+Three things use it:
+
+* a **git-hosted dependency** is prepared with the package manager it asks for — see [Preparing a git-hosted dependency](#preparing-a-git-hosted-dependency);
+* [`pnpm dlx`](./cli/pnx.md#running-a-package-manager-or-a-runtime) (`pnx`) runs one for a single command;
+* [`pnpm shim add`](./cli/shim.md) links a command that runs whatever version the current project pins.
+
+## Where each one comes from
+
+| Package manager | Provided by |
+|---|---|
+| npm | the `npm` package on the registry |
+| Yarn Classic (`<2`) | the `yarn` package on the registry |
+| Yarn Berry (`2` – `5`) | the `@yarnpkg/cli-dist` package on the registry |
+| Yarn 6 | `yarnpkg/zpm` release archives |
+| Bun | `oven-sh/bun` release archives |
+
+The registry-published ones go through the same resolve, verify and install pipeline as pnpm's own engine. The ones that ship as platform archives are pinned by a publisher checksum, like the [managed runtimes](./cli/runtime.md).
+
+Each package manager resolves into its own environment lockfile under the pnpm home, so one package manager's pins never rewrite another's.
+
+## Declaring the package manager of a project
+
+Naming a package manager in `pnpm add` records which one the project uses instead of installing the npm package that shares the name:
+
+```sh
+pnpm add yarn@4
+```
+
+The declaration goes where the package manager reads it:
+
+* **Yarn** is started from a project pin through the `packageManager` field, which accepts only an exact version. So the requested line is resolved before it is written: `pnpm add yarn@4` records `"packageManager": "yarn@4.18.0"`, carrying the `+sha512.…` integrity for the Yarn Classic line, whose pinned artifact is the npm tarball.
+* **Every other package manager** is recorded in [`devEngines.packageManager`](./package_json.md#devenginespackagemanager), which holds a range.
+
+Only one of the two fields is ever left behind: they declare the same thing, and a project whose two declarations disagree is one the version switchers refuse to run.
+
+```json title="package.json"
+{
+  "devEngines": {
+    "packageManager": {
+      "name": "npm",
+      "version": "^11.0.0"
+    }
+  }
+}
+```
+
+Two things are deliberately not covered by this:
+
+* **pnpm itself.** Changing pnpm's own pin makes the next command switch the running CLI, which is [`pnpm self-update`](./cli/self-update.md)'s job to do deliberately rather than an `add`'s to do as a side effect.
+* **A filtered selection.** Which package manager a project uses is that project's own declaration, so `pnpm add yarn --filter …` fails with `ERR_PNPM_PACKAGE_MANAGER_IN_SELECTION`. Run the command in the project itself.
+
+A specifier that locates a *package* rather than asking for a released version still installs what it names, as an ordinary dependency:
+
+```sh
+pnpm add yarn@npm:yarn@1.22.22
+pnpm add yarn@yarnpkg/berry
+```
+
+### Runtimes
+
+`pnpm add` follows the same rule for the runtimes: naming `node`, `deno` or `bun` records it under `engines.runtime`, the way the explicit `node@runtime:22` spelling already did.
+
+## Installing one globally
+
+```sh
+pnpm add -g yarn
+```
+
+installs the current Yarn line — not the Classic-only `yarn` package on npm — and `pnpm add -g node@22` / `pnpm add -g deno@2` install that Node.js or Deno release rather than a wrapper package that downloads one.
+
+A globally installed package manager also follows a project's pin, the way a globally installed Node.js already follows [`devEngines.runtime`](./package_json.md#devenginesruntime): the pinned version runs where a project pins one, and the globally installed copy is the fallback everywhere else. pnpm records this by adding a [`globalShims`](./settings/other.md#globalshims) entry for the package manager, unless you already decided about it — an explicit entry, including `false`, is left as you set it.
+
+See [Project-aware global bins](./global-packages.md#project-aware-global-bins) for how a version is chosen and when pnpm asks for confirmation.
+
+## Running one for a single command
+
+```sh
+pnx yarn@4 install
+pnx npm@11 ci
+pnx bun@1.3.0 install
+```
+
+See [Running a package manager or a runtime](./cli/pnx.md#running-a-package-manager-or-a-runtime).
+
+## Preparing a git-hosted dependency
+
+A [git-hosted dependency](./package-sources.md#git-repository) that has to be built before it can be installed is prepared with the package manager it asks for, rather than with whatever the host happens to have:
+
+* its `packageManager` / `devEngines.packageManager` pin is honored;
+* failing a pin, the lockfile it ships names the package manager — and a `yarn.lock` written by Yarn Classic is no longer installed by Yarn Berry. Berry stamps `__metadata:` into every lockfile it writes and neither line can read the other's, so which one wrote it is a constraint, not a preference.
+
+pnpm provides that package manager when the dependency pinned a version, or when the host cannot satisfy what the dependency needs — so a repository built with Yarn now installs on a machine that has only pnpm, while a host that already has a suitable one keeps using its own.
+
+## What changes for a project coming from v11
+
+| Command | v11 | v12 |
+|---|---|---|
+| `pnpm add yarn` | installs the npm package named `yarn` | records the project's package manager (the package is still reachable as `pnpm add yarn@npm:yarn@1.22.22`) |
+| `pnpm add -g yarn` | installs Yarn Classic | installs the current Yarn line |
+| `pnpm add -g node` / `pnpm add -g deno` | installs a wrapper package that downloads a build | installs that Node.js or Deno release |
+| `pnx node` / `pnx deno` | runs the wrapper package | runs that release |
+| a globally installed package manager | always the global copy | defers to a project's pin where there is one |

--- a/docs/package-managers.md
+++ b/docs/package-managers.md
@@ -5,7 +5,7 @@ title: Other package managers
 
 Added in: v12.0.0-rc.6 (pnpm v12 only)
 
-pnpm installs the other package managers, not just itself: **npm**, **Yarn Classic**, **Yarn Berry**, **Yarn 6** (`yarnpkg/zpm`) and **Bun**. Each of them is resolved and fetched through the trusted package-manager registries, and an npm-published one is verified against npm's signature for its exact version before it is executed — the same standard that lets pnpm switch its own version without asking.
+pnpm installs the other package managers, not just itself: **npm**, **Yarn Classic**, **Yarn Berry**, **Yarn 6** (`yarnpkg/zpm`) and **Bun**. The npm-published ones are resolved and fetched through the trusted package-manager registries, and verified against npm's signature for the exact version before that version is executed — the same standard that lets pnpm switch its own version without asking. Yarn 6 and Bun ship as platform archives from their own projects instead, pinned by a publisher checksum.
 
 A JavaScript package manager on a machine without Node.js gets a managed LTS runtime to run on, so none of this requires a Node.js installation of your own.
 
@@ -39,7 +39,7 @@ pnpm add yarn@4
 
 The declaration goes where the package manager reads it:
 
-* **Yarn** is started from a project pin through the `packageManager` field, which accepts only an exact version. So the requested line is resolved before it is written: `pnpm add yarn@4` records `"packageManager": "yarn@4.18.0"`, carrying the `+sha512.…` integrity for the Yarn Classic line, whose pinned artifact is the npm tarball.
+* **Yarn** is started from a project pin through the `packageManager` field, which accepts only an exact version. So the requested line is resolved before it is written: `pnpm add yarn@4` records `"packageManager": "yarn@4.18.0"`. On the Yarn Classic line (`<2`), where the pinned artifact is the npm tarball, the value also carries that tarball's `+sha512.…` integrity — `"packageManager": "yarn@1.22.22+sha512.…"`.
 * **Every other package manager** is recorded in [`devEngines.packageManager`](./package_json.md#devenginespackagemanager), which holds a range.
 
 Only one of the two fields is ever left behind: they declare the same thing, and a project whose two declarations disagree is one the version switchers refuse to run.
@@ -67,9 +67,13 @@ pnpm add yarn@npm:yarn@1.22.22
 pnpm add yarn@yarnpkg/berry
 ```
 
+The resolved version of a package manager other than pnpm is not written to `pnpm-lock.yaml`: it is pinned in an environment lockfile of its own under the pnpm home. Only pnpm's own pin is recorded in the project's lockfile, under `packageManagerDependencies`.
+
 ### Runtimes
 
-`pnpm add` follows the same rule for the runtimes: naming `node`, `deno` or `bun` records it under `engines.runtime`, the way the explicit `node@runtime:22` spelling already did.
+`pnpm add` follows the same rule for the runtimes: naming `node` or `deno` records it under `engines.runtime`, the way the explicit `node@runtime:22` spelling already did.
+
+`bun` is both a runtime and a package manager, and the package manager answers first: `pnpm add bun` declares it as the project's package manager. To add it as a runtime, ask for one — `pnpm add bun@runtime:1.3.0`.
 
 ## Installing one globally
 

--- a/docs/package-sources.md
+++ b/docs/package-sources.md
@@ -235,3 +235,14 @@ A URL that does not point at a known host (a self-hosted GitLab, Gitea, or any i
 In pnpm v11 and earlier, resolution probed the network to decide between HTTPS and SSH. That could record whichever transport happened to work on the machine that ran the install — most often an `ssh://` URL that then failed on CI runners without SSH keys. pnpm v12 removes the probing. Existing lockfile entries are left untouched; the rules above apply when an entry is added or re-resolved.
 
 :::
+
+#### How a Git dependency is built
+
+Added in: v12.0.0-rc.6 (pnpm v12 only)
+
+A Git-hosted dependency that ships sources rather than a built package has to be prepared — its dependencies installed and its build script run — before it can be installed. pnpm prepares it with the package manager the dependency itself asks for, instead of assuming the host has the right one:
+
+* the dependency's own `packageManager` / [`devEngines.packageManager`](./package_json.md#devenginespackagemanager) pin wins — that is what its authors test against;
+* failing a pin, the lockfile it ships names the package manager. A `yarn.lock` also names *which* Yarn line: Yarn Berry stamps `__metadata:` into every lockfile it writes and neither line can read the other's, so a Classic lockfile is no longer installed by Berry.
+
+pnpm [provides that package manager](./package-managers.md) when the dependency pinned a version, or when the host cannot satisfy what the dependency needs. A repository built with Yarn therefore installs on a machine that has only pnpm, while a host that already has a suitable package manager — under every name the build may invoke — keeps using its own.

--- a/docs/package_json.md
+++ b/docs/package_json.md
@@ -140,6 +140,8 @@ When pnpm is declared via the legacy `packageManager` field (not `devEngines.pac
 
 :::
 
+Since v12.0.0-rc.6, the field can also name [another package manager](./package-managers.md) — `npm`, `yarn` or `bun` — which is what `pnpm add npm@11` writes. For those, nothing is recorded in `pnpm-lock.yaml`: `packageManagerDependencies` holds pnpm's own pin, and another package manager is pinned in an environment lockfile of its own under the pnpm home.
+
 To override the `onFail` behavior without editing the manifest, see the [`pmOnFail`](./settings/cli.md#pmonfail) setting.
 
 ## dependenciesMeta

--- a/docs/settings/other.md
+++ b/docs/settings/other.md
@@ -92,6 +92,8 @@ The supported policies are:
 | `always` | Always switch, never ask. Usable in CI, where a prompt would fall back to the global version. |
 | `false` | Disable the project-aware shim for this package. |
 
+Since v12.0.0-rc.6, two commands write entries here for you: [`pnpm shim add <pkg>`](../cli/shim.md) records the package it links a shim for, and installing a [package manager](../package-managers.md) globally (`pnpm add -g yarn`) records that package manager so it follows a project's pin. Neither overwrites an entry you set yourself — including `false`, and including a `globalShims: false` that turns every shim off.
+
 Layers merge key by key over the built-in defaults, so a single entry can change one package without restating the rest — `globalShims: { bun: false }` leaves `node` and `deno` at `auto`.
 
 The scalar shorthands replace the whole map instead of merging: `globalShims: false` disables every project-aware shim, and `globalShims: true` resets to the defaults.

--- a/pnpr-docs/install-acceleration.md
+++ b/pnpr-docs/install-acceleration.md
@@ -62,6 +62,22 @@ For frozen restores with an already-fresh lockfile, pnpm can use
 `POST /-/pnpr/v0/verify-lockfile` to get only the server-side trust verdict
 instead of resolving again.
 
+## What a configured server does not cost
+
+Since pnpm v12.0.0-rc.6, an install skips the exchanges it doesn't need, so a
+configured `pnprServer` no longer makes an up-to-date project pay a round trip
+that a direct install would have answered locally:
+
+- The repeat-install "Already up to date" fast path runs with a pnpr server
+  configured. Changing the `trustPolicy*`, `minimumReleaseAgeStrict`, or
+  `minimumReleaseAgeExclude` settings still invalidates it.
+- An install whose `pnpm-lock.yaml` already satisfies every manifest skips the
+  resolve exchange and materializes `node_modules` from the on-disk lockfile.
+- The verification round trip is skipped when the local
+  `lockfile-verified.jsonl` cache already covers the lockfile under the current
+  policy. Server-verified and server-resolved lockfiles are recorded into that
+  cache, so the next install can use it.
+
 See [pnpm/pnpm#12230](https://github.com/pnpm/pnpm/issues/12230) and
 [pnpm/pnpm#12234](https://github.com/pnpm/pnpm/issues/12234) for background.
 

--- a/sidebars.json
+++ b/sidebars.json
@@ -106,6 +106,7 @@
         "label": "Manage environments",
         "items": [
           "cli/runtime",
+          "cli/shim",
           "cli/env"
         ]
       },
@@ -116,7 +117,8 @@
           "cli/cache-list",
           "cli/cache-list-registries",
           "cli/cache-view",
-          "cli/cache-delete"
+          "cli/cache-delete",
+          "cli/cache-path"
         ]
       },
       {
@@ -179,6 +181,7 @@
       "finders",
       "global-packages",
       "global-virtual-store",
+      "package-managers",
       "versioning"
     ],
     "Recipes": [


### PR DESCRIPTION
Documents [pnpm v12.0.0-rc.6](https://github.com/pnpm/pnpm/releases/tag/v12.0.0-rc.6).

## New pages

- **[Other package managers](docs/package-managers.md)** — pnpm provisions npm, Yarn Classic, Yarn Berry, Yarn 6 (`yarnpkg/zpm`) and Bun: where each comes from, how they are verified, what naming one in `pnpm add` records and in which manifest field, that a globally installed one defers to a project's pin, and a table of the v11 behaviors that change.
- **[`pnpm shim`](docs/cli/shim.md)** — `add|rm|ls`, bin conflicts, `ERR_PNPM_SHIMS_DISABLED`, how a version is chosen, and the trust rules that apply.
- **[`pnpm cache path`](docs/cli/cache-path.md)** — the command (also in v11.22.0) and what caching that directory buys a CI job.

## Updated

- `pnx` — running a package manager or a runtime, and what a specifier that locates a package still does.
- `pnpm add` — naming a package manager or a runtime.
- Package sources — how a git dependency is built: the pin wins, the `yarn.lock` names the Yarn line, and when pnpm provides the package manager rather than using the host's.
- Global packages / `globalShims` — package managers in the dispatch rules, and the two commands that write entries.
- Continuous integration — a tip about caching the metadata cache, and the removal of a claim about pnpm 12 that no longer holds.
- `pnpm runtime` — cached, signature-verified release metadata.
- pnpr install acceleration — the server exchanges an up-to-date project no longer pays for.
- "What's different in pnpm 12" — a fifth difference: naming a package manager.

`pnpm build` passes; the one broken link it reports (`/cli/pn` in the 11.0 release post) predates this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added comprehensive guidance for pnpm 12 package-manager and runtime support, including project-specific versions, global installations, one-off execution, and Git dependencies.
  - Documented the project-aware `pnpm shim` command for adding, removing, and listing command shims.
  - Added guidance for `pnpm cache path`, cache usage, pruning, trusted locations, and CI workflows.
  - Expanded documentation on runtime resolution, package-manager dispatch, installation acceleration, and configuration behavior.
  - Updated the pnpm 12 overview and documentation navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->