### PR TITLE
docs: clarify global config setting scope

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -18,6 +18,21 @@ The relevant configuration files are:
 * Per-project configuration file: `/path/to/my/project/pnpm-workspace.yaml`
 * [Global configuration file](./cli/config.md)
 
+## Global config support
+
+The global `config.yaml` is intended for machine-wide preferences and defaults. It is not a second workspace manifest: settings that describe a project's dependency graph, linking strategy, workspace layout, or publish behavior must stay in the project's `pnpm-workspace.yaml`.
+
+If `config.yaml` contains a setting that cannot be set globally, pnpm ignores it and prints a warning. Move those settings to `pnpm-workspace.yaml`. To share project policy across multiple repositories, use [config dependencies](./config-dependencies.md).
+
+Examples of settings that can be set globally include:
+
+* network and registry defaults such as `registry`, `registries`, `namedRegistries`, `httpProxy`, `httpsProxy`, and `noproxy`
+* cache, store, and state locations such as `cacheDir`, `storeDir`, `stateDir`, `globalDir`, `globalBinDir`, `globalVirtualStoreDir`, and `virtualStoreDir`
+* install and supply-chain preferences such as `minimumReleaseAge`, `minimumReleaseAgeExclude`, `minimumReleaseAgeStrict`, `trustPolicy`, `trustPolicyExclude`, `trustLockfile`, `blockExoticSubdeps`, `verifyStoreIntegrity`, and `strictDepBuilds`
+* CLI and UX preferences such as `color`, `loglevel`, `reporter`, `scriptShell`, `shellEmulator`, `updateNotifier`, and `useStderr`
+
+Examples of workspace-only settings include `nodeLinker`, `hoist`, `hoistPattern`, `publicHoistPattern`, `linkWorkspacePackages`, `sharedWorkspaceLockfile`, `catalog`, `catalogs`, `packageExtensions`, `overrides`, and `configDependencies`.
+
 :::note
 
 Authorization-related settings are handled via [`.npmrc`](./npmrc.md).


### PR DESCRIPTION
## Summary
- Clarify that global `config.yaml` is for machine-wide preferences, not a second workspace manifest.
- Document that unsupported global settings are ignored with a warning and should move to `pnpm-workspace.yaml` or config dependencies.
- Add examples of settings that are accepted globally and settings that are workspace-only.

Related to pnpm/pnpm#11585.

## Validation
- `git diff --check`

Notes:
- `pnpm install --frozen-lockfile` could not complete in this workspace because package installation ran out of disk space (`ENOSPC`) after supply-chain policy verification passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for configuring machine-wide defaults in `config.yaml`.
  * Clarified which dependency and workspace settings remain project-specific.
  * Documented warnings for unsupported global settings and configuration sharing through dependencies.
  * Added examples of globally supported and workspace-only settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->