### PR TITLE
docs: document the registries declaration setting

### DIFF
--- a/docs/registries.md
+++ b/docs/registries.md
@@ -1,0 +1,141 @@
+---
+id: registries
+title: Registries
+---
+
+Added in: v11.23.0
+
+The [`registries`](./settings/dependency-resolution.md#registries) setting in `pnpm-workspace.yaml` declares each registry a project installs from — once, keyed by the registry's URL. Everything pnpm knows about a registry lives in its entry: the scopes routed to it, the bare-specifier prefix it answers to, and what the server behind it is like.
+
+```yaml title="pnpm-workspace.yaml"
+registries:
+  https://npm.corp.example.com/:
+    serverType: artifactory
+    scopes: ["@acme", "@corp-tools"]
+    prefix: work
+  https://registry.npmjs.org/:
+    prefix: npmjs
+```
+
+The URL is the key because every fact in an entry is a fact about that server. If the tarball layout were keyed by scope instead, it would be bound to whoever the scope currently points at, and two developers whose scope resolves differently would write lockfiles that disagree about which URLs may be omitted.
+
+An entry may carry:
+
+| Field                                     | Type       | What it declares                                                     |
+|-------------------------------------------|------------|----------------------------------------------------------------------|
+| [`scopes`](#scopes)                       | `string[]` | The package scopes routed to this registry.                          |
+| [`prefix`](#prefix)                       | `string`   | The bare-specifier prefix this registry answers to.                  |
+| [`serverType`](#servertype)               | `string`   | How the server lays out tarball URLs: `npm` or `artifactory`.        |
+| [`supportsTimeField`](#supportstimefield) | `boolean`  | Whether the server's abbreviated metadata carries the `time` field.  |
+
+Any other field is rejected. In particular, credentials (`_authToken`, `_auth`, `_password`, `username`, `tokenHelper`) and TLS material (`ca`, `cafile`, `cert`, `certfile`, `key`, `keyfile`) are refused rather than silently ignored — `pnpm-workspace.yaml` is committed to the repository, so they belong in [`.npmrc`](./npmrc.md) (e.g. `//npm.corp.example.com/:_authToken=...`). A URL key that embeds `user:pass@` credentials is refused for the same reason.
+
+## Routing packages to a registry
+
+### scopes
+
+The scopes whose packages resolve from this registry, `@`-prefixed. A bare `"@"` routes the scope-less default registry — the same registry the `registry` setting names:
+
+```yaml title="pnpm-workspace.yaml"
+registries:
+  https://npm.corp.example.com/:
+    scopes: ["@acme"]
+  https://registry.internal.example.com/:
+    scopes: ["@"]
+```
+
+A scope resolves to exactly one registry, so routing the same scope from two entries is an error.
+
+### prefix
+
+The [named-registry](./package-sources.md#named-registries) prefix this registry answers to, as in `"lib": "work:^2.0.0"`:
+
+```yaml title="pnpm-workspace.yaml"
+registries:
+  https://npm.work.example.com/:
+    prefix: work
+```
+
+```sh
+pnpm add work:@corp/lib@^2.0.0
+```
+
+Each entry declares at most one prefix, and two entries cannot declare the same one: the prefix is the registry's identity in a lockfile package key (`foo@work:1.0.0`), so a second spelling would key the same package from the same registry twice.
+
+Prefixes declared here follow the same rules as the deprecated [`namedRegistries`](./settings/dependency-resolution.md#namedregistries) setting they replace: the built-in `gh:` and `npmjs:` aliases can be overridden by declaring their prefix on your own URL, [reserved names](./settings/dependency-resolution.md#reserved-alias-names) are rejected, and packages resolved through a prefix get [registry-qualified lockfile keys](./settings/dependency-resolution.md#named-registries-in-the-lockfile).
+
+## Describing the server
+
+### serverType
+
+Registries do not all lay out tarball URLs the way the npm registry does. pnpm omits a tarball URL from `pnpm-lock.yaml` when it can rebuild the URL from the package's name, version, and registry — the lockfile then carries no host-specific URL for that package, and renaming or moving the registry does not churn the lockfile. Whether pnpm can rebuild a URL depends on the server, and `serverType` is where you declare it. It has three states:
+
+| `serverType`  | Meaning                                                                                                                                                                                                                                                                       |
+|---------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| *undeclared*  | Strict: a tarball URL is omitted only when it is exactly the canonical npm-layout URL (`<registry>/<name>/-/<scopeless-name>-<version>.tgz`). This is how every registry but `registry.npmjs.org` is read by default.                                                          |
+| `npm`         | The server behaves like `registry.npmjs.org`, which serves a scoped package from the percent-encoded path (`/@acme%2Fwidget/...`) as well as the unencoded one. A faithful mirror or caching proxy of the public registry is this. Built in for `registry.npmjs.org` itself.   |
+| `artifactory` | The server repeats the scope in a scoped package's tarball filename: `@acme/widget/-/@acme/widget-1.0.0.tgz`, where the npm layout strips it (`@acme/widget/-/widget-1.0.0.tgz`).                                                                                              |
+
+For a JFrog Artifactory registry this is the difference between a lockfile that records a host-specific tarball URL for **every scoped package** and one that records none of them:
+
+```yaml title="pnpm-workspace.yaml"
+registries:
+  https://acme.jfrog.example.com/artifactory/api/npm/npm-virtual/:
+    serverType: artifactory
+    scopes: ["@acme"]
+```
+
+Values for common servers:
+
+| Server                                                | `serverType`                                                                                                              |
+|-------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------|
+| JFrog Artifactory                                     | `artifactory`                                                                                                              |
+| GitLab package registry                               | `artifactory` — it uses the same layout, repeating the scope in the filename.                                              |
+| A faithful mirror or caching proxy of the npm registry | `npm`                                                                                                                      |
+| Verdaccio, Sonatype Nexus, Azure Artifacts            | None needed — they serve the exact canonical npm layout, which the strict default already reconstructs.                    |
+| GitHub Packages                                       | None — its download URLs contain a content digest that cannot be derived from the package's identity, so they are kept in the lockfile. |
+
+The layout is declared, never inferred: a virtual repository can serve both layouts at once, depending on whether each package was synced from an upstream or published locally, so there is no registry-level signal pnpm could sniff. Declaring it also keeps a wrong value a fixable misconfiguration instead of a silent breakage.
+
+:::caution
+
+`serverType` is a claim about the server that only its operator can make, and the lockfile depends on it: an omitted tarball URL is rebuilt using the declared layout on every install, including `--frozen-lockfile` installs. Declare a layout the server actually serves, and expect a one-time lockfile diff after declaring one — URLs that pnpm can now rebuild disappear from the lockfile on the next install that writes it.
+
+:::
+
+### supportsTimeField
+
+Whether this registry's abbreviated metadata carries the `time` field. `registry.npmjs.org`'s does not, which is why the default is `false` and why time-based resolution features such as [`minimumReleaseAge`](./settings/dependency-resolution.md#minimumreleaseage) fall back to the far larger full metadata documents. A registry that does carry it — Verdaccio v5.15.1+ and several proxies — is worth declaring:
+
+```yaml title="pnpm-workspace.yaml"
+registries:
+  https://verdaccio.corp.example.com/:
+    scopes: ["@"]
+    supportsTimeField: true
+```
+
+This is the per-registry form of the [`registrySupportsTimeField`](./settings/other.md#registrysupportstimefield) setting. The fallback is decided per registry: one registry that needs full metadata no longer costs it at the others, and `registrySupportsTimeField` remains the answer for every registry the project does not describe.
+
+## Where the setting may live
+
+The setting belongs in `pnpm-workspace.yaml` rather than `.npmrc` or the global config because the lockfile depends on it: one developer omitting tarball URLs that another reconstructs differently would break a frozen install.
+
+The [global configuration file](./cli/config.md) (`config.yaml`) may declare the *routes* — `scopes` and `prefix` — so that a scope or an alias like `work:` applies to every project on the machine. The server descriptions (`serverType` and `supportsTimeField`) are read only from `pnpm-workspace.yaml`, for the reason above.
+
+An entry that declares no routes describes a registry configured elsewhere — for example, the default registry set in `.npmrc`. Such an entry only takes effect when its URL is one the project actually resolves from; pnpm warns about entries that match no configured registry, since they would otherwise sit there inert (a stale URL, a scope that moved).
+
+Environment variables are **not** expanded in the URL keys of this setting, for the same reason they are not expanded in other [registry URLs in `pnpm-workspace.yaml`](./settings.md): the file is committed, and expanding env variables into a request destination could leak secrets to an attacker-controlled host. A key containing a `${...}` placeholder is ignored.
+
+## The older shapes
+
+Before v11.23.0, `registries` mapped scopes to URLs, with the `default` key naming the main registry:
+
+```yaml title="pnpm-workspace.yaml"
+registries:
+  default: https://registry.npmjs.org/
+  "@acme": https://npm.corp.example.com/
+```
+
+This shape is still accepted and behaves as before. The two shapes cannot be mixed in one map — an entry whose value is a string is a scope route, and a scope route keyed by a URL is an error.
+
+The [`namedRegistries`](./settings/dependency-resolution.md#namedregistries) setting is deprecated in favor of `prefix`. It is still read, but only for prefixes that `registries` does not declare; when both declare prefixes, pnpm warns.

--- a/docs/registries.md
+++ b/docs/registries.md
@@ -13,8 +13,9 @@ registries:
     serverType: artifactory
     scopes: ["@acme", "@corp-tools"]
     prefix: work
-  https://registry.npmjs.org/:
-    prefix: npmjs
+  https://verdaccio.corp.example.com/:
+    scopes: ["@"]
+    supportsTimeField: true
 ```
 
 The URL is the key because every fact in an entry is a fact about that server. If the tarball layout were keyed by scope instead, it would be bound to whoever the scope currently points at, and two developers whose scope resolves differently would write lockfiles that disagree about which URLs may be omitted.

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -28,7 +28,7 @@ Values in the configuration files may contain env variables using the `${NAME}` 
 
 :::warning
 
-Since v11.5.3, env variables are **not** expanded in settings of `pnpm-workspace.yaml` that define registry URLs: `registry` and the URL values of [`registries`](./settings/dependency-resolution.md#registries) and [`namedRegistries`](./settings/dependency-resolution.md#namedregistries). Values containing a `${...}` placeholder in these settings are ignored. Because `pnpm-workspace.yaml` is committed to the repository, expanding env variables in registry URLs could be exploited by a malicious repository to leak secrets from the environment to an attacker-controlled registry. Configure dynamic registry URLs in a trusted location instead: the global configuration file or CLI options.
+Since v11.5.3, env variables are **not** expanded in settings of `pnpm-workspace.yaml` that define registry URLs: `registry` and the URL values of [`registries`](./settings/dependency-resolution.md#registries) and [`namedRegistries`](./settings/dependency-resolution.md#namedregistries). Values containing a `${...}` placeholder in these settings are ignored. In the [registry declaration shape](./registries.md) of `registries` (since v11.23.0), the URL is the key rather than the value, and the same rule applies to the keys. Because `pnpm-workspace.yaml` is committed to the repository, expanding env variables in registry URLs could be exploited by a malicious repository to leak secrets from the environment to an attacker-controlled registry. Configure dynamic registry URLs in a trusted location instead: the global configuration file or CLI options.
 
 :::
 

--- a/docs/settings/dependency-resolution.md
+++ b/docs/settings/dependency-resolution.md
@@ -400,9 +400,19 @@ Exotic sources include:
 Added in: v11.0.0
 
 * Default: **undefined**
-* Type: **Record&lt;string, string&gt;**
+* Type: **Record&lt;string, RegistryDeclaration&gt;** or **Record&lt;string, string&gt;**
 
-Configure registries for scoped packages in `pnpm-workspace.yaml`. The `default` key sets the main registry (equivalent to the `registry` `.npmrc` setting). Scoped keys configure registries for specific package scopes.
+Declares the registries the project installs from. Since v11.23.0, each registry is declared once, keyed by its URL, with everything pnpm knows about it in the entry: the `scopes` routed to it, the bare-specifier `prefix` it answers to, and how the server lays out tarball URLs (`serverType`, `supportsTimeField`). The full description of each field is on the dedicated [Registries](../registries.md) page.
+
+```yaml
+registries:
+  https://npm.corp.example.com/:
+    serverType: artifactory
+    scopes: ["@my-org", "@internal"]
+    prefix: work
+```
+
+The older shape, mapping scopes to URLs, is still accepted. The `default` key sets the main registry (equivalent to the `registry` `.npmrc` setting), and scoped keys configure registries for specific package scopes:
 
 ```yaml
 registries:
@@ -411,7 +421,9 @@ registries:
   "@internal": https://nexus.corp.com/
 ```
 
-Since v11.11.0, this setting may also be defined in the [global configuration file](../cli/config.md) (`config.yaml`), which is useful for registries that should apply to every project on the machine rather than to a single repository.
+The two shapes cannot be mixed in one map.
+
+Since v11.11.0, this setting may also be defined in the [global configuration file](../cli/config.md) (`config.yaml`), which is useful for registries that should apply to every project on the machine rather than to a single repository. Only the routes (`scopes` and `prefix`) are read from there; `serverType` and `supportsTimeField` shape the lockfile, so they are read only from `pnpm-workspace.yaml` — see [where the setting may live](../registries.md#where-the-setting-may-live).
 
 ### namedRegistries
 
@@ -419,6 +431,12 @@ Added in: v11.1.0
 
 * Default: **undefined**
 * Type: **Record&lt;string, string&gt;**
+
+:::note
+
+Deprecated since v11.23.0: declare a `prefix` in [`registries`](#registries) instead — see the [Registries](../registries.md) page. `namedRegistries` is still read, but only for prefixes that `registries` does not declare; when both settings declare prefixes, pnpm warns. Everything below about aliases — the built-in ones, reserved names, and the lockfile keys — applies to `prefix`-declared aliases the same way.
+
+:::
 
 Defines named registry aliases that can be used as a prefix when installing packages, in the style of [vlt's named-registry aliases](https://docs.vlt.sh/cli/registries). For example, with the following configuration:
 

--- a/docs/settings/dependency-resolution.md
+++ b/docs/settings/dependency-resolution.md
@@ -511,6 +511,6 @@ There is no setting to keep the old behavior — the old shape is the vulnerabil
 
 :::
 
-Every alias that the lockfile references must stay in `namedRegistries`. Reading an entry whose alias is gone fails with `ERR_PNPM_MISSING_NAMED_REGISTRY` rather than falling back to the default registry, since that would fetch a different package. Renaming an alias re-resolves the packages that used it.
+Every non-built-in alias that the lockfile references must stay declared — through `prefix` in [`registries`](#registries) or through `namedRegistries`. Reading an entry whose alias is gone fails with `ERR_PNPM_MISSING_NAMED_REGISTRY` rather than falling back to the default registry, since that would fetch a different package. Renaming an alias re-resolves the packages that used it.
 
-Tarball URLs that follow the standard registry layout are no longer written to the lockfile for named-registry packages; they are recomputed from `namedRegistries` on demand.
+Tarball URLs that follow the standard registry layout are no longer written to the lockfile for named-registry packages; they are recomputed from the alias's declared URL on demand.

--- a/docs/settings/other.md
+++ b/docs/settings/other.md
@@ -212,7 +212,7 @@ Only the dependencies declared in `package.json` count as direct here. A peer de
 * Default: **false**
 * Type: **Boolean**
 
-Set this to `true` if the registry that you are using returns the "time" field in the abbreviated metadata. As of now, only [Verdaccio] from v5.15.1 supports this.
+Set this to `true` if the registry that you are using returns the "time" field in the abbreviated metadata. [Verdaccio] supports this from v5.15.1, as do some registry proxies.
 
 Since v11.23.0, this can also be declared per registry, through the `supportsTimeField` field of a [registry declaration](../registries.md#supportstimefield). A registry's own declaration wins; this setting is the answer for every registry the project does not describe.
 

--- a/docs/settings/other.md
+++ b/docs/settings/other.md
@@ -214,6 +214,8 @@ Only the dependencies declared in `package.json` count as direct here. A peer de
 
 Set this to `true` if the registry that you are using returns the "time" field in the abbreviated metadata. As of now, only [Verdaccio] from v5.15.1 supports this.
 
+Since v11.23.0, this can also be declared per registry, through the `supportsTimeField` field of a [registry declaration](../registries.md#supportstimefield). A registry's own declaration wins; this setting is the answer for every registry the project does not describe.
+
 ### extendNodePath
 
 * Default: **true**

--- a/sidebars.json
+++ b/sidebars.json
@@ -112,6 +112,15 @@
       },
       {
         "type": "category",
+        "label": "Inspect the store",
+        "items": [
+          "cli/cat-file",
+          "cli/cat-index",
+          "cli/find-hash"
+        ]
+      },
+      {
+        "type": "category",
         "label": "Manage cache",
         "items": [
           "cli/cache-list",

--- a/sidebars.json
+++ b/sidebars.json
@@ -172,6 +172,7 @@
     ],
     "Features": [
       "package-sources",
+      "registries",
       "workspaces",
       "catalogs",
       "config-dependencies",

--- a/versioned_sidebars/version-11.x-sidebars.json
+++ b/versioned_sidebars/version-11.x-sidebars.json
@@ -306,6 +306,10 @@
           "label": "Manage environments",
           "items": [
             "cli/runtime",
+            {
+              "type": "doc",
+              "id": "cli/shim"
+            },
             "cli/env"
           ]
         },
@@ -347,6 +351,10 @@
             {
               "type": "doc",
               "id": "cli/cache-delete"
+            },
+            {
+              "type": "doc",
+              "id": "cli/cache-path"
             }
           ]
         },
@@ -544,6 +552,10 @@
         {
           "type": "doc",
           "id": "global-virtual-store"
+        },
+        {
+          "type": "doc",
+          "id": "package-managers"
         },
         {
           "type": "doc",

--- a/versioned_sidebars/version-11.x-sidebars.json
+++ b/versioned_sidebars/version-11.x-sidebars.json
@@ -507,6 +507,10 @@
         },
         {
           "type": "doc",
+          "id": "registries"
+        },
+        {
+          "type": "doc",
           "id": "workspaces"
         },
         {


### PR DESCRIPTION
## Summary

The `registries` setting's declaration shape ([pnpm/pnpm#13942](https://github.com/pnpm/pnpm/pull/13942)) gets a dedicated Features page, `docs/registries.md`:

- the URL-keyed entry shape and why the URL is the key (a scope-keyed layout would let two developers write lockfiles that disagree about which tarball URLs may be omitted);
- routing with `scopes` (bare `"@"` = the default registry) and `prefix`, which inherits all the named-registry rules — built-in `gh:`/`npmjs:` overriding, reserved names, registry-qualified lockfile keys;
- `serverType`, framed around when tarball URLs land in the lockfile, with values for common servers (JFrog Artifactory and GitLab → `artifactory`; faithful npmjs mirrors → `npm`; Verdaccio/Nexus/Azure Artifacts need none; GitHub Packages can have none) and the declared-never-inferred rationale;
- `supportsTimeField` as the per-registry form of `registrySupportsTimeField`;
- what is refused (credential fields, URL keys with userinfo, env placeholders in keys), what the global config may and may not contribute, and the older shapes.

The settings reference points at it: the `registries` section describes both shapes and the no-mixing rule, `namedRegistries` is marked deprecated in favor of `prefix`, `registrySupportsTimeField` notes its per-registry form, and the env-expansion warning now covers URL keys as well as values.

Annotated as **v11.23.0**: the feature is on pnpm main behind pending minor changesets, and pnpm 12 inherits it (first shipped in v12.0.0-rc.7). The "What's different in pnpm 12" post is deliberately untouched — this is not a divergence between the lines.

## Verification

`docusaurus build --locale en` succeeds; the only broken-anchor warnings are the 14 pre-existing ones in old blog posts and archived 10.x docs. The GitLab layout claim is verified against the GitLab package registry API docs, and the Verdaccio/Nexus/npm-mirror rows against live registry metadata.

## Sidebar fixes

The registries page initially appeared in no sidebar: the site serves the 11.x docs at the root path from the committed `versioned_sidebars/version-11.x-sidebars.json`, while `sidebars.json` only drives the (unbuilt) next docs. Fixing that surfaced broader drift between the two files, reconciled here:

- added to the 11.x sidebar: `registries`, plus the v12.0.0-rc.6 pages that had the same bug — `cli/shim`, `cli/cache-path`, `package-managers`;
- added to `sidebars.json`: the "Inspect the store" category (`cli/cat-file`, `cli/cat-index`, `cli/find-hash`), which existed only in the versioned file.

`faq`, `only-allow-pnpm`, `production`, and `cli/cache` remain unlisted in every sidebar; the first two are deliberate (navbar link, explicit removal), and the latter two look historical rather than intentional but are left as they were.

---
Written by an agent (Claude Code, claude-fable-5).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for configuring URL-keyed registries, including routing, metadata, credentials, TLS, environment variables, and server layouts.
  * Documented registry-specific settings such as scopes, prefixes, server types, and time-field support.
  * Clarified global configuration behavior, legacy format compatibility, deprecations, fallback behavior, and warnings.
  * Added the registries documentation page to the Features navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
