### PR TITLE
docs: document pnpm 11.21 and 11.22

### DIFF
--- a/blog/releases/10.15.md
+++ b/blog/releases/10.15.md
@@ -9,7 +9,7 @@ date: 2025-08-19
 
 ### New setting for catalogs
 
-Added the [`cleanupUnusedCatalogs`](/settings/other#cleanupunusedcatalogs) configuration. When set to `true`, pnpm will remove unused catalog entries during installation [#9793](https://github.com/pnpm/pnpm/pull/9793).
+Added the [`cleanupUnusedCatalogs`](/settings/other#catalogprune) configuration. When set to `true`, pnpm will remove unused catalog entries during installation [#9793](https://github.com/pnpm/pnpm/pull/9793).
 
 <!-- truncate -->
 

--- a/blog/releases/11.21-11.22.md
+++ b/blog/releases/11.21-11.22.md
@@ -1,0 +1,86 @@
+---
+title: pnpm 11.21-11.22
+authors: zkochan
+tags: [release]
+date: 2026-08-18
+---
+
+pnpm 11.21 and 11.22 teach `pnpm install` to update the lockfile in place for most everyday changes instead of re-resolving the whole dependency graph, stop recording SSH URLs that break installs on CI, make global installs switch over atomically and global interactive updates select whole install groups, add `pnpm cache path`, and take away a project's ability to relocate pnpm's machine-level state through `pnpm-workspace.yaml`.
+
+<!-- truncate -->
+
+## Minor Changes
+
+### A project can no longer relocate machine-level state
+
+A repository you clone should not decide where pnpm keeps your credentials, its own installation, or the registry it downloads its next version from. Since v11.22.0, `bin`, `configDir`, `dir`, `globalBinDir`, `globalDir`, `npmrcAuthFile`, `pnpmHomeDir`, `stateDir`, `userconfig`, and `workspaceDir` are ignored in a project's `pnpm-workspace.yaml`, with a warning; `cacheDir` and `storeDir` are unaffected ([#13629](https://github.com/pnpm/pnpm/issues/13629)).
+
+Two companions keep the rule visible: `pnpm config set` now refuses to write such a setting into `pnpm-workspace.yaml` (`ERR_PNPM_CONFIG_SET_NOT_A_PROJECT_SETTING`, naming where the setting belongs), and the `--config.` spellings of these flags no longer take effect through the project-manifest merge — they were never a supported way to set those directories.
+
+### A warning when global commands run under sudo
+
+pnpm keeps global packages and configuration in the invoking user's home directory, so running `pnpm setup`, `pnpm self-update`, or `pnpm add --global` through `sudo` silently operates on the root user's home instead of yours. Since v11.21.0 these commands print a warning when run as root; in pnpm v12 they fail with `ERR_PNPM_SUDO_NOT_SUPPORTED`. Read-only global commands such as `pnpm bin --global` are unaffected.
+
+### Interactive global updates select install groups
+
+`pnpm update --global --interactive` now presents each [isolated install group](/global-packages#isolated-installations) as one selectable item. Packages that share a global installation resolve against each other, so they update together as a unit; the update is then restricted to the groups you selected.
+
+### `pnpm cache path`
+
+The new [`pnpm cache path`](/cli/cache-path) command prints the directory pnpm uses for its metadata cache. CI setups can persist that directory — including the lockfile verification log, which lets a job skip re-checking an unchanged lockfile against the configured supply-chain policies. `pnpm store prune` also no longer deletes that log. See [Continuous Integration](/continuous-integration) for the recipe.
+
+### Pruning stale release-age exclusions
+
+The new [`minimumReleaseAgeExcludePrune`](/settings/dependency-resolution#minimumreleaseageexcludeprune) setting makes `pnpm add`, `pnpm update`, and `pnpm remove` drop `minimumReleaseAgeExclude` entries that the freshly written lockfile no longer resolves, so the exclusion list shrinks back as the pinned versions age out. Name patterns (`@myorg/*`) are always kept.
+
+In the same spirit, `cleanupUnusedCatalogs` is renamed to [`catalogPrune`](/settings/other#catalogprune), so catalog pruning and release-age exclude pruning use one vocabulary. The old spelling keeps working; when both are set, `catalogPrune` wins.
+
+### Faster runtime resolution
+
+Resolving a Node.js runtime version (`devEngines.runtime` / `runtime:` specifiers) is much faster: per-version release metadata is cached after its signature is verified, and an exact stable version such as `runtime:22.23.2` no longer downloads the Node.js release index. A pinned runtime whose metadata was fetched once resolves without any network access, which removes the noticeable delay on the first `node` invocation in a project pinning an already-downloaded runtime ([#13899](https://github.com/pnpm/pnpm/issues/13899)).
+
+## Patch Changes
+
+### Most everyday changes no longer re-resolve the dependency graph
+
+Previously, many routine edits forced `pnpm install` to re-resolve the whole dependency graph, even when the lockfile already contained everything needed. Across these two releases, the lockfile is now updated in place — no registry round-trips, no churn beyond the entries that actually changed — for:
+
+* removing a dependency, including pruning what it alone made reachable and dropping a catalog entry that lost its last referent;
+* `pnpm add` of a version the lockfile already holds — promoting a transitive dependency to a direct one, or adding to a second workspace package what a first one already uses ([#13696](https://github.com/pnpm/pnpm/issues/13696));
+* moving a dependency between `dependencies`, `devDependencies`, and `optionalDependencies`;
+* adding a new workspace package whose dependencies are all locked for a sibling;
+* widening or changing a range that an already-locked version satisfies — now picking the highest satisfying locked version, matching what a full resolution records ([#13778](https://github.com/pnpm/pnpm/issues/13778));
+* changing a catalog entry to a different exact version, and combinations of catalog and `pnpm.overrides` edits with other changes ([#13799](https://github.com/pnpm/pnpm/issues/13799));
+* changing `pnpm.overrides` to a satisfiable range, and parent-scoped overrides (`"parent>child": "2.0.0"`) ([#13795](https://github.com/pnpm/pnpm/issues/13795));
+* adding, editing, or removing `patchedDependencies` entries and `ignoredOptionalDependencies` patterns;
+* flipping `autoInstallPeers`, `dedupePeers`, `peersSuffixMaxLength`, `excludeLinksFromLockfile`, or `injectWorkspacePackages` when the lockfile proves the setting cannot affect the resolution.
+
+Projects with a pnpmfile use these fast paths too, as long as the recorded `pnpmfileChecksum` proves the pnpmfile is unchanged. Every case that could change the resolution — a peer reached through the edited package, a dist tag, an exotic specifier — still falls back to a full resolution.
+
+### Git dependencies work on CI runners without SSH keys
+
+Since v11.21.0, the Git resolver no longer records an SSH URL unless the specifier explicitly asks for one (`git+ssh://` or `git@host:...`). A shorthand like `github:owner/repo` resolves and records over HTTPS, so a lockfile written on a machine with SSH keys no longer fails on a CI runner with `Permission denied (publickey)` ([#13276](https://github.com/pnpm/pnpm/issues/13276)). The repository visibility probe also retries throttled responses, and a repository that cannot be confirmed public keeps a regular `git` resolution so installs can use ambient credentials.
+
+v11.22.0 improves what you see when Git resolution or fetching still fails: errors carry the `ERR_PNPM_GIT_RESOLVE_FAILED` / `ERR_PNPM_GIT_FETCH_FAILED` codes, name the dependency instead of printing a bare `git` invocation, redact credentials embedded in repository URLs, and explain how to route HTTPS URLs over SSH on machines that need it ([#13743](https://github.com/pnpm/pnpm/issues/13743)). An SSH URL recorded by a pre-11.21 lockfile can be re-recorded over HTTPS with `pnpm update <package>`.
+
+### Global installs switch over atomically
+
+The command shims in the global bin directory now point at a stable per-package link rather than at the directory a particular install produced, so `pnpm add -g` and `pnpm update -g` activate a new version by moving one link instead of rewriting every shim. A command can no longer be missing from `PATH` while an install is in progress, and a failed install leaves the previous version in place.
+
+### The automatic `packageManager` switch works behind feed proxies
+
+The automatic version switch works again on registries whose tarball URLs point at a different host than the registry itself (load-balanced feed proxies, Artifactory-style mirrors) ([#13619](https://github.com/pnpm/pnpm/issues/13619)), and registries that strip npm's signature metadata no longer break it or `pnpm self-update`: when the configured registry cannot provide a verifiable signature, pnpm fetches one from `registry.npmjs.org` and verifies it against the same embedded npm keys over the installed integrity ([#13147](https://github.com/pnpm/pnpm/issues/13147)).
+
+### Other notable fixes
+
+* `resolutionMode: lowest-direct` and `time-based` work again while `minimumReleaseAge` is in effect — including its built-in default, which previously forced the highest version silently ([#13752](https://github.com/pnpm/pnpm/issues/13752)).
+* `pnpm update` without saving no longer records a version the manifest's range excludes, which the next `pnpm install --frozen-lockfile` rejected ([#12764](https://github.com/pnpm/pnpm/issues/12764)).
+* `pnpm deploy` injects workspace dependencies again, so the deploy directory is self-contained instead of symlinking back into the source workspace ([#13754](https://github.com/pnpm/pnpm/issues/13754)).
+* `pnpm add <pkg>@<version>` under a non-manual `catalogMode` now moves the catalog entry's resolution instead of silently doing nothing, and `catalogMode: strict` accepts a version the catalog's range covers ([#13715](https://github.com/pnpm/pnpm/issues/13715)).
+* `syncInjectedDepsAfterScripts` survives FIFOs and file/directory swaps in workspace packages, removes bin links a build step stopped declaring, and identifies files by device as well as inode ([#13550](https://github.com/pnpm/pnpm/issues/13550)).
+* `pnpm root -g` and `pnpm bin -g` print warnings to stderr, keeping stdout a clean machine-readable path ([#13672](https://github.com/pnpm/pnpm/issues/13672)).
+* Lockfile verification honors offline mode, using cached registry metadata instead of reaching the registry.
+* `pnpm audit --fix` no longer adds `minimumReleaseAgeExclude` entries for patched versions old enough to pass the age gate anyway ([#11563](https://github.com/pnpm/pnpm/issues/11563)).
+* Shorthand Git dependencies, `minimumReleaseAge` dist-tag fallbacks, held-back-update warnings, `link:` dependencies under the global virtual store, and installs that only drop packages all received correctness fixes — the full lists are in the release notes.
+
+For everything else in these releases, see the full notes for [v11.21.0](https://github.com/pnpm/pnpm/releases/tag/v11.21.0) and [v11.22.0](https://github.com/pnpm/pnpm/releases/tag/v11.22.0).

--- a/docs/catalogs.md
+++ b/docs/catalogs.md
@@ -166,6 +166,6 @@ import CatalogMode from './settings/_catalogMode.mdx'
 
 <CatalogMode />
 
-import CleanupUnusedCatalogs from './settings/_cleanupUnusedCatalogs.mdx'
+import CatalogPrune from './settings/_catalogPrune.mdx'
 
-<CleanupUnusedCatalogs />
+<CatalogPrune />

--- a/docs/cli/config.md
+++ b/docs/cli/config.md
@@ -59,6 +59,8 @@ pnpm config set --location=project --json catalog '{ "react": "19" }'
 
 The `set` command does not accept a property path.
 
+Since v11.22.0, `pnpm config set` refuses to write a setting to a project's `pnpm-workspace.yaml` that pnpm does not read from there — `configDir`, `pnpmHomeDir`, `stateDir`, and the other settings that name machine-level state. The command fails with `ERR_PNPM_CONFIG_SET_NOT_A_PROJECT_SETTING`, naming where the setting belongs when it belongs somewhere. `pnpm config delete` still clears such a key from a file that already carries it.
+
 ### get &lt;key>
 
 Print the config value for the provided key.

--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -119,6 +119,8 @@ Don't update packages in `optionalDependencies`.
 
 Show outdated dependencies and select which ones to update.
 
+Since v11.21.0, combined with `--global`, each [isolated install group](../global-packages.md#isolated-installations) is presented as one selectable item: packages that share a global installation update together as a unit.
+
 ### --no-save
 
 Don't update the ranges in `package.json`.

--- a/docs/global-packages.md
+++ b/docs/global-packages.md
@@ -17,6 +17,12 @@ For example:
 pnpm add -g typescript prettier eslint
 ```
 
+:::caution
+
+Do not run these commands through `sudo`. pnpm keeps global packages and configuration in the invoking user's home directory, so under `sudo` they silently operate on the root user's home instead of yours. Since v11.21.0, `pnpm setup`, `pnpm self-update`, and every command that modifies the global installation print a warning when run as root, and pnpm v12 fails with `ERR_PNPM_SUDO_NOT_SUPPORTED`. Read-only commands such as `pnpm bin -g` are unaffected.
+
+:::
+
 ## Isolated installations
 
 Each globally installed package (or group of packages installed together) gets its own isolated installation directory with its own `package.json`, `node_modules/`, and lockfile. This prevents global packages from interfering with each other through peer dependency conflicts, hoisting changes, or version resolution shifts.

--- a/docs/package-sources.md
+++ b/docs/package-sources.md
@@ -216,6 +216,8 @@ Each resolves through the host's canonical HTTPS URL, and the lockfile records o
 
 pnpm never records an SSH URL for these hosts. Which transport a given machine uses to reach the host is that machine's Git configuration, not a property of the project.
 
+pnpm 11 keeps the specifier's transport as part of the recorded URL, but since v11.21.0 it records an SSH URL only when the specifier itself asks for one (`git+ssh://` or `git@host:...`): a shorthand like `owner/repo` resolves and records over HTTPS, so a lockfile written on a machine with SSH keys still installs on a CI runner without them. An SSH URL recorded by an older pnpm can be re-recorded over HTTPS with `pnpm update <package>`.
+
 ##### Using SSH for private repositories
 
 Configure the rewrite in Git itself, on the machine:

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -32,6 +32,12 @@ Since v11.5.3, env variables are **not** expanded in settings of `pnpm-workspace
 
 :::
 
+:::note
+
+Since v11.22.0, a project's `pnpm-workspace.yaml` cannot choose where pnpm keeps its credentials, its own installation, or other machine-level state: `bin`, `configDir`, `dir`, `globalBinDir`, `globalDir`, `npmrcAuthFile`, `pnpmHomeDir`, `stateDir`, `userconfig`, and `workspaceDir` are ignored there, with a warning. Set them in the [global configuration file](./cli/config.md), in `.npmrc`, or on the command line instead. `cacheDir` and `storeDir` are unaffected.
+
+:::
+
 [INI-formatted]: https://en.wikipedia.org/wiki/INI_file
 
 ## packages
@@ -130,6 +136,7 @@ Every setting is listed below, grouped by topic. Follow a setting to read its do
 * [ignoredOptionalDependencies](./settings/dependency-resolution.md#ignoredoptionaldependencies)
 * [minimumReleaseAge](./settings/dependency-resolution.md#minimumreleaseage)
 * [minimumReleaseAgeExclude](./settings/dependency-resolution.md#minimumreleaseageexclude)
+* [minimumReleaseAgeExcludePrune](./settings/dependency-resolution.md#minimumreleaseageexcludeprune)
 * [minimumReleaseAgeIgnoreMissingTime](./settings/dependency-resolution.md#minimumreleaseageignoremissingtime)
 * [minimumReleaseAgeStrict](./settings/dependency-resolution.md#minimumreleaseagestrict)
 * [trustPolicy](./settings/dependency-resolution.md#trustpolicy)
@@ -307,7 +314,7 @@ Every setting is listed below, grouped by topic. Follow a setting to read its do
 * [shellEmulator](./settings/other.md#shellemulator)
 * [catalogMode](./settings/other.md#catalogmode)
 * [ci](./settings/other.md#ci)
-* [cleanupUnusedCatalogs](./settings/other.md#cleanupunusedcatalogs)
+* [catalogPrune](./settings/other.md#catalogprune)
 
 ### Workspace Settings
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -34,7 +34,7 @@ Since v11.5.3, env variables are **not** expanded in settings of `pnpm-workspace
 
 :::note
 
-Since v11.22.0, a project's `pnpm-workspace.yaml` cannot choose where pnpm keeps its credentials, its own installation, or other machine-level state: `bin`, `configDir`, `dir`, `globalBinDir`, `globalDir`, `npmrcAuthFile`, `pnpmHomeDir`, `stateDir`, `userconfig`, and `workspaceDir` are ignored there, with a warning. Set them in the [global configuration file](./cli/config.md), in `.npmrc`, or on the command line instead. `cacheDir` and `storeDir` are unaffected.
+Since v11.22.0, a project's `pnpm-workspace.yaml` cannot choose where pnpm keeps its credentials, its own installation, or other machine-level state: `bin`, `configDir`, `dir`, `globalBinDir`, `globalDir`, `npmrcAuthFile`, `pnpmHomeDir`, `stateDir`, `userconfig`, and `workspaceDir` are ignored there, with a warning. Set them in the [global configuration file](./cli/config.md) or on the command line instead. `cacheDir` and `storeDir` are unaffected.
 
 :::
 

--- a/docs/settings/_catalogPrune.mdx
+++ b/docs/settings/_catalogPrune.mdx
@@ -1,0 +1,12 @@
+<a id="cleanupunusedcatalogs"></a>
+
+### catalogPrune
+
+Added in: v11.22.0 (as `cleanupUnusedCatalogs` since v10.15.0)
+
+* Default: **false**
+* Type: **Boolean**
+
+When set to `true`, pnpm will remove unused catalog entries during installation.
+
+`cleanupUnusedCatalogs` is the deprecated spelling of this setting and continues to work; when both are set, `catalogPrune` wins.

--- a/docs/settings/_cleanupUnusedCatalogs.mdx
+++ b/docs/settings/_cleanupUnusedCatalogs.mdx
@@ -1,9 +1,0 @@
-### cleanupUnusedCatalogs
-
-Added in: v10.15.0
-
-* Default: **false**
-* Type: **Boolean**
-
-When set to `true`, pnpm will remove unused catalog entries during installation.
-

--- a/docs/settings/dependency-resolution.md
+++ b/docs/settings/dependency-resolution.md
@@ -302,6 +302,17 @@ minimumReleaseAgeExclude:
 - webpack@4.47.0 || 5.102.1
 ```
 
+### minimumReleaseAgeExcludePrune
+
+Added in: v11.22.0
+
+* Default: **false**
+* Type: **Boolean**
+
+When set to `true`, `pnpm add`, `pnpm update`, and `pnpm remove` prune the entries of [`minimumReleaseAgeExclude`](#minimumreleaseageexclude) in `pnpm-workspace.yaml` that the freshly written lockfile no longer resolves: a version that is gone is dropped (an entry is removed once none of its versions remain), and an entry for a package that is no longer in the lockfile is removed too. Name patterns (`@myorg/*`) are always kept.
+
+The cleanup is skipped when the install's lockfile does not cover the whole workspace ([`sharedWorkspaceLockfile: false`](../workspaces.md#sharedworkspacelockfile)), since entries another project still needs would look stale.
+
 ### minimumReleaseAgeIgnoreMissingTime
 
 Added in: v11.0.0

--- a/docs/settings/other.md
+++ b/docs/settings/other.md
@@ -325,6 +325,6 @@ Added in: v10.12.1
 
 This setting explicitly tells pnpm whether the current environment is a CI (Continuous Integration) environment.
 
-import CleanupUnusedCatalogs from './_cleanupUnusedCatalogs.mdx'
+import CatalogPrune from './_catalogPrune.mdx'
 
-<CleanupUnusedCatalogs />
+<CatalogPrune />


### PR DESCRIPTION
## Summary

Adds the missing release blog post for pnpm 11.21 and 11.22 (`blog/releases/11.21-11.22.md`, following the combined-post format of 11.11-11.14), and documents the changes from those two versions that the docs did not carry yet:

- **`minimumReleaseAgeExcludePrune`** — new section in the dependency-resolution settings, plus the settings index entry.
- **`cleanupUnusedCatalogs` → `catalogPrune`** — the shared partial is renamed and documents the deprecated spelling ("when both are set, `catalogPrune` wins"); the old anchor is kept via a raw `<a id>` for external deep links, and the 10.15 release post now links the new heading so the broken-anchor checker stays clean.
- **Machine-level settings hardening** ([pnpm/pnpm#13629](https://github.com/pnpm/pnpm/issues/13629)) — a note on the settings page listing the ten settings `pnpm-workspace.yaml` ignores since v11.22.0, and the `pnpm config set` refusal (`ERR_PNPM_CONFIG_SET_NOT_A_PROJECT_SETTING`) on the config page.
- **`pnpm update --global --interactive`** — documents that each isolated install group is one selectable item since v11.21.0.
- **sudo warning** — a caution on the global-packages page: warning since v11.21.0, `ERR_PNPM_SUDO_NOT_SUPPORTED` in pnpm v12.
- **Git transport recording** — package-sources now notes pnpm 11's since-v11.21.0 rule (SSH recorded only when the specifier asks for it) alongside the v12 identity semantics, including the `pnpm update <package>` re-record hint.

Already documented, so only referenced from the blog post: `pnpm cache path`, the runtime metadata cache, and the CI verification-log recipe.

## Verification

`docusaurus build --locale en` succeeds with only the 14 pre-existing broken-anchor warnings (archived 10.x docs and old blog posts) — the anchor rename introduces no new ones. Release content is sourced from the v11.21.0 and v11.22.0 GitHub release notes and cross-checked against the implementing commits where behavior needed describing (e.g. install-group selection in pnpm/pnpm#13428).

---
Written by an agent (Claude Code, claude-fable-5).