### PR TITLE
ci: build every locale separately

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,6 @@ jobs:
       contents: read
       # For the comment linking to the preview.
       pull-requests: write
-    env:
-      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
     steps:
       - name: Checkout Commit
         uses: actions/checkout@v4
@@ -39,12 +35,20 @@ jobs:
         run: pnpm build
         env:
           LOCALE_CI: en
+      # A step condition cannot read the secrets context, and putting the
+      # credentials in the job environment would hand them to the build above,
+      # which runs the pull request's own code.
+      - name: Look for Vercel credentials
+        id: credentials
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: test -z "$VERCEL_TOKEN" || echo 'available=true' >> "$GITHUB_OUTPUT"
       - name: Deploy a preview
         # Pull requests from forks get the build test above, but not a preview:
         # their token cannot read the Vercel credentials. Neither does anyone
         # while the credentials are missing altogether — the build test is
         # still worth reporting on its own.
-        if: env.VERCEL_TOKEN != '' && github.event.pull_request.head.repo.full_name == github.repository
+        if: steps.credentials.outputs.available == 'true' && github.event.pull_request.head.repo.full_name == github.repository
         id: preview
         run: |
           # esbuild, which the CLI depends on, has to run its install script.
@@ -56,6 +60,10 @@ jobs:
           url=$(vercel deploy --prebuilt --token="$VERCEL_TOKEN" | tail -n1)
           echo "url=$url" >> "$GITHUB_OUTPUT"
           echo "Preview (English only): $url" >> "$GITHUB_STEP_SUMMARY"
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
       - name: Link to the preview from the pull request
         if: steps.preview.outputs.url != ''
         continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,12 +47,13 @@ jobs:
         if: env.VERCEL_TOKEN != '' && github.event.pull_request.head.repo.full_name == github.repository
         id: preview
         run: |
-          npm install --global vercel@59.1.4
+          # esbuild, which the CLI depends on, has to run its install script.
+          vercel () { pnpm dlx --allow-build=esbuild vercel@59.1.4 "$@"; }
           vercel pull --yes --environment=preview --token="$VERCEL_TOKEN"
           # This doesn't rebuild anything: the build command in vercel.json
           # picks up the `build` directory that the step above produced.
           vercel build --token="$VERCEL_TOKEN"
-          url=$(vercel deploy --prebuilt --token="$VERCEL_TOKEN")
+          url=$(vercel deploy --prebuilt --token="$VERCEL_TOKEN" | tail -n1)
           echo "url=$url" >> "$GITHUB_OUTPUT"
           echo "Preview (English only): $url" >> "$GITHUB_STEP_SUMMARY"
       - name: Link to the preview from the pull request

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: Build Test
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 env:
   COREPACK_ENABLE_AUTO_PIN: 0
 
@@ -9,10 +12,6 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     environment: deploy
-    permissions:
-      contents: read
-      # For the comment linking to the preview.
-      pull-requests: write
     steps:
       - name: Checkout Commit
         uses: actions/checkout@v4
@@ -30,47 +29,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install
       - name: Build
-        # Previews are English-only: building the translations too would cost
-        # as much as a production deploy, and pull requests change the sources.
+        # English only: the translations are not part of a pull request, and
+        # building them would cost as much as a deploy.
         run: pnpm build
         env:
           LOCALE_CI: en
-      # A step condition cannot read the secrets context, and putting the
-      # credentials in the job environment would hand them to the build above,
-      # which runs the pull request's own code.
-      - name: Look for Vercel credentials
-        id: credentials
-        env:
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-        run: test -z "$VERCEL_TOKEN" || echo 'available=true' >> "$GITHUB_OUTPUT"
-      - name: Deploy a preview
-        # Pull requests from forks get the build test above, but not a preview:
-        # their token cannot read the Vercel credentials. Neither does anyone
-        # while the credentials are missing altogether — the build test is
-        # still worth reporting on its own.
-        if: steps.credentials.outputs.available == 'true' && github.event.pull_request.head.repo.full_name == github.repository
-        id: preview
-        run: |
-          # esbuild, which the CLI depends on, has to run its install script.
-          vercel () { pnpm dlx --allow-build=esbuild vercel@59.1.4 "$@"; }
-          vercel pull --yes --environment=preview --token="$VERCEL_TOKEN"
-          # This doesn't rebuild anything: the build command in vercel.json
-          # picks up the `build` directory that the step above produced.
-          vercel build --token="$VERCEL_TOKEN"
-          url=$(vercel deploy --prebuilt --token="$VERCEL_TOKEN" | tail -n1)
-          echo "url=$url" >> "$GITHUB_OUTPUT"
-          echo "Preview (English only): $url" >> "$GITHUB_STEP_SUMMARY"
-        env:
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-      - name: Link to the preview from the pull request
-        if: steps.preview.outputs.url != ''
-        continue-on-error: true
-        run: |
-          gh pr comment "$PR" --edit-last --create-if-none \
-            --body "Preview of this pull request (English only): $URL"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR: ${{ github.event.pull_request.number }}
-          URL: ${{ steps.preview.outputs.url }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,18 @@
 name: Build Test
 
 on: [pull_request]
+
+env:
+  COREPACK_ENABLE_AUTO_PIN: 0
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
     environment: deploy
-    env:
-      COREPACK_ENABLE_AUTO_PIN: 0
+    permissions:
+      contents: read
+      # For the comment linking to the preview.
+      pull-requests: write
     steps:
       - name: Checkout Commit
         uses: actions/checkout@v4
@@ -16,9 +22,44 @@ jobs:
         uses: pnpm/action-setup@v4.1.0
         with:
           standalone: true
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
       - name: Install dependencies
         run: pnpm install
       - name: Build
+        # Previews are English-only: building the translations too would cost
+        # as much as a production deploy, and pull requests change the sources.
         run: pnpm build
         env:
           LOCALE_CI: en
+      - name: Deploy a preview
+        # Pull requests from forks get the build test above, but not a preview:
+        # their token cannot read the Vercel credentials.
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        id: preview
+        run: |
+          npm install --global vercel@59
+          vercel pull --yes --environment=preview --token="$VERCEL_TOKEN"
+          # This doesn't rebuild anything: the build command in vercel.json
+          # picks up the `build` directory that the step above produced.
+          vercel build --token="$VERCEL_TOKEN"
+          url=$(vercel deploy --prebuilt --token="$VERCEL_TOKEN")
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+          echo "Preview (English only): $url" >> "$GITHUB_STEP_SUMMARY"
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+      - name: Link to the preview from the pull request
+        if: steps.preview.outputs.url != ''
+        continue-on-error: true
+        run: |
+          gh pr comment "$PR" --edit-last --create-if-none \
+            --body "Preview of this pull request (English only): $URL"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          URL: ${{ steps.preview.outputs.url }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
         if: env.VERCEL_TOKEN != '' && github.event.pull_request.head.repo.full_name == github.repository
         id: preview
         run: |
-          npm install --global vercel@59
+          npm install --global vercel@59.1.4
           vercel pull --yes --environment=preview --token="$VERCEL_TOKEN"
           # This doesn't rebuild anything: the build command in vercel.json
           # picks up the `build` directory that the step above produced.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,10 @@ jobs:
       contents: read
       # For the comment linking to the preview.
       pull-requests: write
+    env:
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
     steps:
       - name: Checkout Commit
         uses: actions/checkout@v4
@@ -37,8 +41,10 @@ jobs:
           LOCALE_CI: en
       - name: Deploy a preview
         # Pull requests from forks get the build test above, but not a preview:
-        # their token cannot read the Vercel credentials.
-        if: github.event.pull_request.head.repo.full_name == github.repository
+        # their token cannot read the Vercel credentials. Neither does anyone
+        # while the credentials are missing altogether — the build test is
+        # still worth reporting on its own.
+        if: env.VERCEL_TOKEN != '' && github.event.pull_request.head.repo.full_name == github.repository
         id: preview
         run: |
           npm install --global vercel@59
@@ -49,10 +55,6 @@ jobs:
           url=$(vercel deploy --prebuilt --token="$VERCEL_TOKEN")
           echo "url=$url" >> "$GITHUB_OUTPUT"
           echo "Preview (English only): $url" >> "$GITHUB_STEP_SUMMARY"
-        env:
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
       - name: Link to the preview from the pull request
         if: steps.preview.outputs.url != ''
         continue-on-error: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -96,6 +96,9 @@ jobs:
     environment: deploy
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4.1.0
+        with:
+          standalone: true
       - uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -107,13 +110,13 @@ jobs:
           # directory the site is served from.
           merge-multiple: true
           path: .site-artifacts
-      - name: Install the Vercel CLI
-        run: npm install --global vercel@59.1.4
       - name: Deploy to Vercel
         # `vercel build` doesn't rebuild the site: vercel.json points its build
         # command at scripts/assemble-site.mjs, which just moves the artifacts
         # into place. It is still needed to turn vercel.json into a deployment.
         run: |
+          # esbuild, which the CLI depends on, has to run its install script.
+          vercel () { pnpm dlx --allow-build=esbuild vercel@59.1.4 "$@"; }
           if [ "$PRODUCTION" = 'true' ]; then
             environment=production
             prod=--prod
@@ -123,7 +126,7 @@ jobs:
           fi
           vercel pull --yes --environment="$environment" --token="$VERCEL_TOKEN"
           vercel build $prod --token="$VERCEL_TOKEN"
-          url=$(vercel deploy --prebuilt $prod --token="$VERCEL_TOKEN")
+          url=$(vercel deploy --prebuilt $prod --token="$VERCEL_TOKEN" | tail -n1)
           echo "Deployed $url" >> "$GITHUB_STEP_SUMMARY"
         env:
           PRODUCTION: ${{ github.event_name != 'workflow_dispatch' || inputs.production }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,10 @@ concurrency:
   group: deploy
   cancel-in-progress: true
 
+# Nothing here writes to the repository; the deploy goes out through Vercel.
+permissions:
+  contents: read
+
 env:
   COREPACK_ENABLE_AUTO_PIN: 0
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -108,7 +108,7 @@ jobs:
           merge-multiple: true
           path: .site-artifacts
       - name: Install the Vercel CLI
-        run: npm install --global vercel@59
+        run: npm install --global vercel@59.1.4
       - name: Deploy to Vercel
         # `vercel build` doesn't rebuild the site: vercel.json points its build
         # command at scripts/assemble-site.mjs, which just moves the artifacts

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,128 @@
+name: Deploy
+
+# The site used to be built by Vercel's git integration, in a single build that
+# walked the 13 locales one after another — Docusaurus has no parallel mode.
+# Here every locale is built by its own job instead, and only the finished
+# static files are handed to Vercel (`vercel deploy --prebuilt`), so the wall
+# clock is the slowest single locale rather than the sum of all of them.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      production:
+        description: Publish on pnpm.io. Turn this off to get a preview URL instead.
+        type: boolean
+        default: true
+
+# A deploy always ships the whole site, so an in-flight one is pointless as
+# soon as a newer commit lands.
+concurrency:
+  group: deploy
+  cancel-in-progress: true
+
+env:
+  COREPACK_ENABLE_AUTO_PIN: 0
+
+jobs:
+  locales:
+    runs-on: ubuntu-latest
+    outputs:
+      locales: ${{ steps.read.outputs.locales }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: read
+        run: echo "locales=$(jq -c '[.[].locale]' locales.json)" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: locales
+    runs-on: ubuntu-latest
+    environment: deploy
+    strategy:
+      # One broken locale shouldn't hide the state of the other twelve; the
+      # deploy job below refuses to ship an incomplete site anyway.
+      fail-fast: false
+      matrix:
+        locale: ${{ fromJSON(needs.locales.outputs.locales) }}
+    name: build (${{ matrix.locale }})
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # `showLastUpdateTime` reads the dates from the git history.
+          fetch-depth: 0
+      - uses: pnpm/action-setup@v4.1.0
+        with:
+          standalone: true
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install
+      - name: Copy the current docs into the latest version
+        # Crowdin maps the translations of the latest docs version onto this
+        # copy, so it has to exist before the download below.
+        run: pnpm copy-docs
+      - name: Download the translations
+        if: matrix.locale != 'en'
+        run: |
+          language=$(jq -r --arg locale "$LOCALE" '.[] | select(.locale == $locale) | .crowdinLanguage // empty' locales.json)
+          test -n "$language" # locales.json must name the language for Crowdin
+          pnpm exec crowdin download --language "$language" --no-progress --no-colors
+        env:
+          LOCALE: ${{ matrix.locale }}
+          CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID || '302994' }}
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+      - name: Build
+        run: node scripts/build-with-fallback.mjs --locale "$LOCALE"
+        env:
+          LOCALE: ${{ matrix.locale }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: site-${{ matrix.locale }}
+          path: build
+          retention-days: 1
+          # The files are already minified; compressing them again costs more
+          # time than it saves on the transfer.
+          compression-level: 0
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: deploy
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Collect every locale
+        uses: actions/download-artifact@v4
+        with:
+          pattern: site-*
+          # Each locale occupies its own subtree, so they merge into the single
+          # directory the site is served from.
+          merge-multiple: true
+          path: .site-artifacts
+      - name: Install the Vercel CLI
+        run: npm install --global vercel@59
+      - name: Deploy to Vercel
+        # `vercel build` doesn't rebuild the site: vercel.json points its build
+        # command at scripts/assemble-site.mjs, which just moves the artifacts
+        # into place. It is still needed to turn vercel.json into a deployment.
+        run: |
+          if [ "$PRODUCTION" = 'true' ]; then
+            environment=production
+            prod=--prod
+          else
+            environment=preview
+            prod=
+          fi
+          vercel pull --yes --environment="$environment" --token="$VERCEL_TOKEN"
+          vercel build $prod --token="$VERCEL_TOKEN"
+          url=$(vercel deploy --prebuilt $prod --token="$VERCEL_TOKEN")
+          echo "Deployed $url" >> "$GITHUB_STEP_SUMMARY"
+        env:
+          PRODUCTION: ${{ github.event_name != 'workflow_dispatch' || inputs.production }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,9 @@ versioned_docs/version-11.x
 
 # local Claude Code settings
 .claude/settings.local.json
+
+# assembled by scripts/assemble-site.mjs when deploying
+.site-artifacts
+
+# Vercel CLI state, pulled during deploys
+.vercel

--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ Because of that, Vercel's own git integration is turned off (see
 these secrets in the `deploy` environment: `VERCEL_TOKEN`, `VERCEL_ORG_ID`,
 `VERCEL_PROJECT_ID`, and `CROWDIN_PERSONAL_TOKEN`.
 
-Pull requests opened from this repository get an English-only preview
-deployment, which keeps them as fast as they used to be; the ones opened from a
-fork only get the build test, because their token cannot read the Vercel
-credentials. The Deploy workflow can also be started by hand, with the "Publish
-on pnpm.io" box unticked to get a preview URL instead of a release.
+Pull requests get an English-only build test rather than a preview
+deployment: deploying from a pull request would mean handing the credentials
+of the live site to the code being reviewed. To see a change served, start the
+Deploy workflow by hand with the "Publish on pnpm.io" box unticked, which
+returns a preview URL instead of publishing.
 
 The locales are listed in [locales.json](locales.json), together with the name
 Crowdin uses for each of them. Adding a locale there adds a build job for it.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,26 @@ pnpm start
 
 ## How to publish
 
-Push to the default branch, the website will be deployed automatically.
+Push to the default branch, the website will be deployed automatically by the
+[Deploy workflow](.github/workflows/deploy.yml).
+
+Docusaurus builds one locale after another, and this site has 13 of them, so the
+workflow builds each locale in its own job instead: every job downloads only its
+own translations from Crowdin and runs `docusaurus build --locale <locale>`. The
+resulting trees are stitched back together by `scripts/assemble-site.mjs` and
+shipped to Vercel with `vercel deploy --prebuilt`, as a single deployment.
+
+Because of that, Vercel's own git integration is turned off (see
+`git.deploymentEnabled` in [vercel.json](vercel.json)) and the workflow needs
+these secrets in the `deploy` environment: `VERCEL_TOKEN`, `VERCEL_ORG_ID`,
+`VERCEL_PROJECT_ID`, and `CROWDIN_PERSONAL_TOKEN`.
+
+Pull requests get an English-only preview deployment, which keeps them as fast
+as they used to be. The Deploy workflow can also be started by hand, with the
+"Publish on pnpm.io" box unticked to get a preview URL instead of a release.
+
+The locales are listed in [locales.json](locales.json), together with the name
+Crowdin uses for each of them. Adding a locale there adds a build job for it.
 
 ## Algolia Search
 

--- a/README.md
+++ b/README.md
@@ -25,9 +25,11 @@ Because of that, Vercel's own git integration is turned off (see
 these secrets in the `deploy` environment: `VERCEL_TOKEN`, `VERCEL_ORG_ID`,
 `VERCEL_PROJECT_ID`, and `CROWDIN_PERSONAL_TOKEN`.
 
-Pull requests get an English-only preview deployment, which keeps them as fast
-as they used to be. The Deploy workflow can also be started by hand, with the
-"Publish on pnpm.io" box unticked to get a preview URL instead of a release.
+Pull requests opened from this repository get an English-only preview
+deployment, which keeps them as fast as they used to be; the ones opened from a
+fork only get the build test, because their token cannot read the Vercel
+credentials. The Deploy workflow can also be started by hand, with the "Publish
+on pnpm.io" box unticked to get a preview URL instead of a release.
 
 The locales are listed in [locales.json](locales.json), together with the name
 Crowdin uses for each of them. Adding a locale there adds a build job for it.

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -1,6 +1,7 @@
 import path from 'node:path';
 import { themes } from 'prism-react-renderer';
 import progress from "./scripts/progress_lang.json" with { type: "json" };
+import locales from "./locales.json" with { type: "json" };
 import type { Config } from '@docusaurus/types';
 import type * as Preset from '@docusaurus/preset-classic';
 
@@ -11,10 +12,29 @@ const TRANSLATE_URL = "https://translate.pnpm.io";
 const CRYPTO_DONATIONS_HREF = '/crypto-donations';
 const LOCALE_CI = process.env.LOCALE_CI;
 const DEFAULT_LOCALE = 'en';
-const LOCALE_FULL_CODE: Record<string, string> = {
-  zh: 'zh-CN',
-  pt: 'pt-BR',
-  es: 'es-ES',
+// The locales live in locales.json because the deploy workflow builds one
+// locale per job and needs to read the same list.
+const LOCALES_CONFIG: { locale: string, crowdinLanguage?: string }[] = locales;
+const LOCALES = LOCALES_CONFIG.map(({ locale }) => locale);
+// Crowdin names some languages differently from Docusaurus (`zh-CN` vs `zh`).
+const LOCALE_FULL_CODE: Record<string, string> = Object.fromEntries(
+  LOCALES_CONFIG.flatMap(({ locale, crowdinLanguage }) =>
+    crowdinLanguage ? [[locale, crowdinLanguage]] : [])
+);
+
+// Docusaurus infers `/<locale>/` as the base URL of a localized site, but only
+// when a build covers several locales at once. A build narrowed down to one
+// locale with `--locale` drops the segment, which suits multi-domain
+// deployments but not this site: every locale is built by its own CI job and
+// the results are stitched back together under one domain. Pinning the base
+// URL keeps both build shapes identical.
+function withLocaleBaseUrls<T extends Record<string, object>> (localeConfigs: T): T {
+  return Object.fromEntries(
+    Object.entries(localeConfigs).map(([locale, localeConfig]) => [
+      locale,
+      locale === DEFAULT_LOCALE ? localeConfig : { baseUrl: `/${locale}/`, ...localeConfig },
+    ])
+  ) as T;
 }
 
 const PROJECT_NAME = 'pnpm.io'
@@ -336,8 +356,8 @@ const docusaurusConfig = {
   } satisfies Preset.ThemeConfig,
   i18n: {
     defaultLocale: DEFAULT_LOCALE,
-    locales: LOCALE_CI ? [LOCALE_CI] : ['en', 'it', 'zh', 'ja', 'ko', 'pt', 'zh-TW', 'ru', 'uk', 'fr', 'tr', 'es', 'id'],
-    localeConfigs: {
+    locales: LOCALE_CI ? [LOCALE_CI] : LOCALES,
+    localeConfigs: withLocaleBaseUrls({
       en: { label: "English" },
       it: { label: `Italiano (${progress["it"].translationProgress}%)` },
       zh: { label: `简体中文 (${progress["zh-CN"].translationProgress}%)` },
@@ -360,7 +380,7 @@ const docusaurusConfig = {
       // hu: { label: `Magyar (${progress["hu"].translationProgress}%)` },
       // pl: { label: `Polski (${progress["pl"].translationProgress}%)` },
       // de: { label: `Deutsch (${progress["de"].translationProgress}%)` },
-    },
+    }),
   },
 } satisfies Config;
 

--- a/locales.json
+++ b/locales.json
@@ -1,0 +1,15 @@
+[
+  { "locale": "en" },
+  { "locale": "it", "crowdinLanguage": "it" },
+  { "locale": "zh", "crowdinLanguage": "zh-CN" },
+  { "locale": "ja", "crowdinLanguage": "ja" },
+  { "locale": "ko", "crowdinLanguage": "ko" },
+  { "locale": "pt", "crowdinLanguage": "pt-BR" },
+  { "locale": "zh-TW", "crowdinLanguage": "zh-TW" },
+  { "locale": "ru", "crowdinLanguage": "ru" },
+  { "locale": "uk", "crowdinLanguage": "uk" },
+  { "locale": "fr", "crowdinLanguage": "fr" },
+  { "locale": "tr", "crowdinLanguage": "tr" },
+  { "locale": "es", "crowdinLanguage": "es-ES" },
+  { "locale": "id", "crowdinLanguage": "id" }
+]

--- a/scripts/assemble-site.mjs
+++ b/scripts/assemble-site.mjs
@@ -45,11 +45,8 @@ if (isPopulated(ARTIFACTS_DIR)) {
     fail(`These locales are missing from the assembled site: ${missing.join(', ')}.`)
   }
   console.log(`Assembled ${defaultLocale} and ${locales.length} translated locales.`)
-} else if (isPopulated(OUT_DIR)) {
-  // A single-locale preview build wrote straight into `build`.
-  console.log(`Deploying the site already present in ${path.relative(process.cwd(), OUT_DIR)}`)
 } else {
-  fail(`Nothing to deploy: neither ${ARTIFACTS_DIR} nor ${OUT_DIR} exists.
+  fail(`Nothing to deploy: ${path.relative(process.cwd(), ARTIFACTS_DIR)} is empty.
 
 The site is built by the "Deploy" GitHub Actions workflow, one job per locale,
 and shipped from there with \`vercel deploy --prebuilt\`. Re-run that workflow

--- a/scripts/assemble-site.mjs
+++ b/scripts/assemble-site.mjs
@@ -1,0 +1,62 @@
+import { cpSync, existsSync, readdirSync, readFileSync, renameSync, rmSync } from 'node:fs'
+import path from 'node:path'
+
+// Vercel builds this site by running this script (see `buildCommand` in
+// vercel.json) instead of building Docusaurus, because the build itself
+// happens in CI: .github/workflows/deploy.yml builds every locale in its own
+// job — the default locale at the root of the tree, the other ones under their
+// own `/<locale>/` segment — and downloads all of those artifacts into
+// ARTIFACTS_DIR. All that is left here is to move them where Vercel looks for
+// them, so that `vercel build` still turns vercel.json into a deployment.
+
+const ARTIFACTS_DIR = path.resolve('.site-artifacts')
+const OUT_DIR = path.resolve('build')
+
+function isPopulated (dir) {
+  try {
+    return readdirSync(dir).length > 0
+  } catch {
+    return false
+  }
+}
+
+function fail (message) {
+  console.error(message)
+  process.exit(1)
+}
+
+if (isPopulated(ARTIFACTS_DIR)) {
+  console.log(`Assembling the site from ${path.relative(process.cwd(), ARTIFACTS_DIR)}`)
+  rmSync(OUT_DIR, { recursive: true, force: true })
+  try {
+    renameSync(ARTIFACTS_DIR, OUT_DIR)
+  } catch (err) {
+    // The artifacts may sit on a different filesystem than the checkout.
+    if (err.code !== 'EXDEV') throw err
+    cpSync(ARTIFACTS_DIR, OUT_DIR, { recursive: true })
+    rmSync(ARTIFACTS_DIR, { recursive: true, force: true })
+  }
+  // A locale whose build job was skipped or whose artifact failed to download
+  // would silently disappear from the site, so make sure they all arrived.
+  const [defaultLocale, ...locales] = JSON.parse(readFileSync('locales.json', 'utf-8'))
+    .map(({ locale }) => locale)
+  const missing = locales.filter(locale => !existsSync(path.join(OUT_DIR, locale, 'index.html')))
+  if (missing.length > 0) {
+    fail(`These locales are missing from the assembled site: ${missing.join(', ')}.`)
+  }
+  console.log(`Assembled ${defaultLocale} and ${locales.length} translated locales.`)
+} else if (isPopulated(OUT_DIR)) {
+  // A single-locale preview build wrote straight into `build`.
+  console.log(`Deploying the site already present in ${path.relative(process.cwd(), OUT_DIR)}`)
+} else {
+  fail(`Nothing to deploy: neither ${ARTIFACTS_DIR} nor ${OUT_DIR} exists.
+
+The site is built by the "Deploy" GitHub Actions workflow, one job per locale,
+and shipped from there with \`vercel deploy --prebuilt\`. Re-run that workflow
+instead of building from the Vercel dashboard. To build the whole site locally,
+run \`pnpm build\`.`)
+}
+
+if (!existsSync(path.join(OUT_DIR, 'index.html'))) {
+  fail(`${path.relative(process.cwd(), OUT_DIR)} has no index.html: the build of the default locale is missing.`)
+}

--- a/scripts/build-with-fallback.mjs
+++ b/scripts/build-with-fallback.mjs
@@ -5,6 +5,15 @@ import path from 'node:path'
 const MAX_RETRIES = 50
 const I18N_DIR = path.resolve('i18n')
 
+// Extra arguments are handed to `docusaurus build` untouched, so that CI can
+// build one locale per job with `--locale <locale>`.
+const BUILD_ARGS = process.argv.slice(2)
+// When a single locale is built, only that locale's translations can be at
+// fault, so the scan for broken files below is narrowed down to it.
+const BUILT_LOCALES = BUILD_ARGS.flatMap((arg, i) =>
+  arg === '--locale' || arg === '-l' ? [BUILD_ARGS[i + 1]] : []
+).filter(Boolean)
+
 function extractBrokenI18nFile (output) {
   // Match file paths inside the i18n directory from the build error output.
   // Docusaurus / MDX / webpack errors typically include the full file path.
@@ -30,7 +39,8 @@ function extractBrokenI18nFile (output) {
 function extractMismatchedI18nIdFile (output) {
   if (!output.includes('Invalid sidebar file')) return null
   if (!existsSync(I18N_DIR)) return null
-  for (const locale of safeReaddir(I18N_DIR)) {
+  const locales = BUILT_LOCALES.length > 0 ? BUILT_LOCALES : safeReaddir(I18N_DIR)
+  for (const locale of locales) {
     const localeDocsRoot = path.join(I18N_DIR, locale, 'docusaurus-plugin-content-docs')
     if (!existsSync(localeDocsRoot)) continue
     for (const versionDir of safeReaddir(localeDocsRoot)) {
@@ -103,9 +113,9 @@ function escapeRegExp (string) {
 let removedFiles = []
 
 for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
-  console.log(`\n🔨 Build attempt ${attempt}${removedFiles.length > 0 ? ` (${removedFiles.length} broken translation(s) removed so far)` : ''}...\n`)
+  console.log(`\n🔨 Build attempt ${attempt}${BUILT_LOCALES.length > 0 ? ` for ${BUILT_LOCALES.join(', ')}` : ''}${removedFiles.length > 0 ? ` (${removedFiles.length} broken translation(s) removed so far)` : ''}...\n`)
   try {
-    execSync('docusaurus build', {
+    execSync(['docusaurus', 'build', ...BUILD_ARGS].join(' '), {
       stdio: ['inherit', 'inherit', 'pipe'],
       encoding: 'utf-8',
       maxBuffer: 50 * 1024 * 1024,

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,11 @@
 {
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "node scripts/assemble-site.mjs",
+  "installCommand": "echo 'No dependencies needed: the site is built by the Deploy workflow'",
+  "outputDirectory": "build",
+  "git": {
+    "deploymentEnabled": false
+  },
   "headers": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
The build is slow because Docusaurus builds locales strictly one after another in a single process — [`build.js`](https://github.com/facebook/docusaurus/blob/main/packages/docusaurus/src/commands/build/build.ts) maps over the locale list sequentially, and its own comment explains that parallelism was tried and abandoned. With 13 locales that is 13 sequential builds inside one Vercel builder, after downloading every Crowdin language. Measured locally, cold: **4:00 for all 13 locales, ~18s for a single one.**

So each locale gets its own build now, and only the finished files are handed to Vercel.

## What happens on a push to `main`

1. `.github/workflows/deploy.yml` reads `locales.json` and starts one job per locale.
2. Each job downloads **only its own language** from Crowdin and runs `docusaurus build --locale <locale>`, uploading the result as an artifact.
3. A last job merges the artifacts, and ships them as a single, atomic deployment with `vercel deploy --prebuilt --prod`.

Wall clock is now the slowest single locale plus install and deploy overhead, instead of the sum of all thirteen.

## Notable details

- **Base URL.** `docusaurus build --locale fr` deliberately drops the `/fr/` segment — that default targets multi-domain deployments. `docusaurus.config.ts` pins the segment per locale, so a single-locale build and the all-locales build produce exactly the same tree.
- **`locales.json`.** The locale list and each locale's Crowdin name now live in one file that both the config and the workflow read, so the CI matrix cannot drift from the site. Adding a locale there adds a build job for it.
- **`scripts/assemble-site.mjs`** is Vercel's build command: it moves the downloaded artifacts into `build/` and refuses to deploy if any locale is missing, so a failed job cannot silently drop a language from the site.
- **Vercel's git integration is off** (`git.deploymentEnabled` in `vercel.json`); otherwise every push would build the site a second time.
- **`copy-docs` runs before the Crowdin download**, so the translations of the latest docs version have a source tree to map onto.
- **Pull requests** get the English-only build test, and no preview deployment. Deploying from a pull request would run the code under review with the credentials of the live site — a branch could rewrite the build command in `vercel.json` and read the token — and branch-push access should not be deploy access. To see a change served, start the Deploy workflow by hand with **"Publish on pnpm.io" unticked** for a preview URL.

## Verification

All 13 locales were built separately, assembled, and diffed against a full `pnpm build`:

- 12116 files on both sides, **zero path differences**
- all 4303 HTML pages **byte-identical** once asset content-hashes are normalised

The four paths through `assemble-site.mjs` (complete artifacts, missing locale, nothing to deploy, already-built `build/`) were each exercised.

## Before merging

The `vercel pull`/`build`/`deploy` sequence could not be tested locally — it needs a token.

- [ ] Add `VERCEL_TOKEN`, `VERCEL_ORG_ID` and `VERCEL_PROJECT_ID` to the `deploy` environment (`CROWDIN_PERSONAL_TOKEN` is already there). The Crowdin project id falls back to the literal from `scripts/translations.ts` unless a `CROWDIN_PROJECT_ID` repository variable is set.
- [ ] Run the Deploy workflow by hand from this branch with **"Publish on pnpm.io" unticked** — that produces a preview URL instead of touching pnpm.io.
- [ ] Clear the Crowdin download from the build command in the Vercel dashboard once that works. `vercel.json` should already take precedence over it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated production and preview deployments for localized sites.
  * Added pull-request preview links with status comments.
  * Added configurable locales, locale-specific site URLs, and parallel locale builds.
  * Added complete site assembly for multi-locale deployments and manual production runs.

* **Documentation**
  * Expanded publishing documentation with deployment setup, previews, required secrets, and locale configuration.

* **Improvements**
  * Improved locale-targeted builds with clearer validation and failure messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
