### PR TITLE
fix: run the Docusaurus binary through pnpm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,11 @@ jobs:
           cache: pnpm
       - name: Install dependencies
         run: pnpm install
+      - name: Copy the current docs into the latest version
+        run: pnpm copy-docs
       - name: Build
         # English only: the translations are not part of a pull request, and
-        # building them would cost as much as a deploy.
-        run: pnpm build
-        env:
-          LOCALE_CI: en
+        # building them would cost as much as a deploy. Invoked the way
+        # .github/workflows/deploy.yml invokes it, so that this test covers
+        # the command that ships the site.
+        run: node scripts/build-with-fallback.mjs --locale en

--- a/scripts/build-with-fallback.mjs
+++ b/scripts/build-with-fallback.mjs
@@ -115,7 +115,9 @@ let removedFiles = []
 for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
   console.log(`\n🔨 Build attempt ${attempt}${BUILT_LOCALES.length > 0 ? ` for ${BUILT_LOCALES.join(', ')}` : ''}${removedFiles.length > 0 ? ` (${removedFiles.length} broken translation(s) removed so far)` : ''}...\n`)
   try {
-    execSync(['docusaurus', 'build', ...BUILD_ARGS].join(' '), {
+    // Through pnpm, so that the Docusaurus binary is found no matter whether
+    // this script was started by a package script or directly by node.
+    execSync(['pnpm', 'exec', 'docusaurus', 'build', ...BUILD_ARGS].join(' '), {
       stdio: ['inherit', 'inherit', 'pipe'],
       encoding: 'utf-8',
       maxBuffer: 50 * 1024 * 1024,


### PR DESCRIPTION
Every locale job of the first Deploy run died in the same place:

```
🔨 Build attempt 1 for en...
❌ Build failed with a non-translation error:
/bin/sh: 1: docusaurus: not found
```

`scripts/build-with-fallback.mjs` shells out to a bare `docusaurus`, which only resolves when the script is started *through* pnpm — a package script gets `node_modules/.bin` prepended to `PATH`, a plain `node scripts/…` does not. `pnpm build` therefore worked, and `.github/workflows/deploy.yml`, which calls the script directly so it can pass `--locale`, did not.

The script now runs `pnpm exec docusaurus build`, so it no longer depends on how it was started.

**Verified** in the failing condition — `docusaurus` absent from `PATH`, script invoked directly by node — where it now builds successfully.

The pull request check also switched from `pnpm build` to the exact command the deploy runs (`pnpm copy-docs` + `node scripts/build-with-fallback.mjs --locale en`), so this path is covered before it can reach `main` again. That gap is precisely why the break got through.

Merging this triggers a Deploy run, which is the real test of the rest of the pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
