### PR TITLE
ci: download the translations once for all locales

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,8 +39,45 @@ jobs:
       - id: read
         run: echo "locales=$(jq -c '[.[].locale]' locales.json)" >> "$GITHUB_OUTPUT"
 
+  translations:
+    runs-on: ubuntu-latest
+    environment: deploy
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4.1.0
+        with:
+          standalone: true
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install
+      - name: Copy the current docs into the latest version
+        # Crowdin maps the translations of the latest docs version onto this
+        # copy, so it has to exist before the download below.
+        run: pnpm copy-docs
+      - name: Download the translations
+        # Once for the whole project: a download per locale runs into
+        # Crowdin's rate limits.
+        run: pnpm exec crowdin download --no-progress --no-colors
+        env:
+          CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID || '302994' }}
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+      - name: Check that every locale arrived
+        # A locale missing here would build from the English sources and reach
+        # the site as an untranslated page.
+        run: |
+          missing=$(jq -r '.[] | select(.crowdinLanguage) | .locale' locales.json |
+            while read -r locale; do test -d "i18n/$locale" || echo "$locale"; done)
+          test -z "$missing" || { echo "Crowdin returned no translations for: $missing"; exit 1; }
+      - uses: actions/upload-artifact@v4
+        with:
+          name: translations
+          path: i18n
+          retention-days: 1
+
   build:
-    needs: locales
+    needs: [locales, translations]
     runs-on: ubuntu-latest
     environment: deploy
     strategy:
@@ -63,20 +100,12 @@ jobs:
           node-version: 22
           cache: pnpm
       - run: pnpm install
-      - name: Copy the current docs into the latest version
-        # Crowdin maps the translations of the latest docs version onto this
-        # copy, so it has to exist before the download below.
-        run: pnpm copy-docs
-      - name: Download the translations
-        if: matrix.locale != 'en'
-        run: |
-          language=$(jq -r --arg locale "$LOCALE" '.[] | select(.locale == $locale) | .crowdinLanguage // empty' locales.json)
-          test -n "$language" # locales.json must name the language for Crowdin
-          pnpm exec crowdin download --language "$language" --no-progress --no-colors
-        env:
-          LOCALE: ${{ matrix.locale }}
-          CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID || '302994' }}
-          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+      - run: pnpm copy-docs
+      - name: Collect the translations
+        uses: actions/download-artifact@v4
+        with:
+          name: translations
+          path: i18n
       - name: Build
         run: node scripts/build-with-fallback.mjs --locale "$LOCALE"
         env:

--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ Push to the default branch, the website will be deployed automatically by the
 [Deploy workflow](.github/workflows/deploy.yml).
 
 Docusaurus builds one locale after another, and this site has 13 of them, so the
-workflow builds each locale in its own job instead: every job downloads only its
-own translations from Crowdin and runs `docusaurus build --locale <locale>`. The
+workflow builds each locale in its own job instead. The translations are
+downloaded from Crowdin once, by a job of its own that shares them with the
+rest, and each locale job runs `docusaurus build --locale <locale>`. The
 resulting trees are stitched back together by `scripts/assemble-site.mjs` and
 shipped to Vercel with `vercel deploy --prebuilt`, as a single deployment.
 


### PR DESCRIPTION
Thirteen jobs each asking Crowdin for one language at the same moment runs into its rate limits.

A `translations` job now downloads the whole project once — a single export, the way the Vercel build used to do it — and hands the result to the locale jobs as an artifact. The locale jobs no longer touch Crowdin, or its token, at all; only this one job holds `CROWDIN_PERSONAL_TOKEN`.

That job also fails if any locale is absent from the download. Without the check, a partial download would build those locales from the English sources and publish them as untranslated pages, silently.

**Wall clock:** the download now sits ahead of the matrix instead of running inside it, so the total is one download plus the slowest locale, rather than the slowest (locale + its own download). A shared export should be quicker per job than a per-language one, so this may come out even.

Neither this nor the rest of the pipeline can be fully exercised before it is on `main` — the Deploy workflow only triggers on a push there, and the pull request check covers the build command but not the Crowdin or Vercel steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Streamlined the publishing workflow by downloading translations once and sharing them across locale builds.
  * Improved build consistency and efficiency for translated documentation.
* **Documentation**
  * Updated publishing guidance to describe the shared translation workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->