### PR TITLE
ci: stop asking Crowdin for an export on every deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,20 +56,53 @@ jobs:
         # Crowdin maps the translations of the latest docs version onto this
         # copy, so it has to exist before the download below.
         run: pnpm copy-docs
+      - id: window
+        run: echo "hour=$(date -u +%Y-%m-%dT%H)" >> "$GITHUB_OUTPUT"
+      - name: Reuse a recent download
+        # Every push to the default branch deploys, and asking Crowdin to
+        # export the project that often is what its rate limit is there to
+        # stop. One export an hour is plenty: the translations move at the
+        # pace of the translators, not of the commits.
+        id: reuse
+        uses: actions/cache/restore@v4
+        with:
+          path: i18n
+          key: translations-${{ steps.window.outputs.hour }}
+          restore-keys: translations-
       - name: Download the translations
-        # Once for the whole project: a download per locale runs into
-        # Crowdin's rate limits.
-        run: pnpm exec crowdin download --no-progress --no-colors
+        if: steps.reuse.outputs.cache-hit != 'true'
+        # Crowdin refuses an export that comes too soon after the last one,
+        # and answers 429 rather than waiting, so give it a few chances.
+        id: download
+        continue-on-error: true
+        run: |
+          for attempt in 1 2 3; do
+            if pnpm exec crowdin download --no-progress --no-colors; then exit 0; fi
+            echo "Crowdin refused the export (attempt $attempt of 3)"
+            test "$attempt" = 3 || sleep $((attempt * 120))
+          done
+          exit 1
         env:
           CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID || '302994' }}
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+      - name: Keep the download for the next deploys
+        if: steps.download.outcome == 'success'
+        uses: actions/cache/save@v4
+        with:
+          path: i18n
+          key: translations-${{ steps.window.outputs.hour }}
       - name: Check that every locale arrived
         # A locale missing here would build from the English sources and reach
         # the site as an untranslated page.
+        env:
+          DOWNLOAD: ${{ steps.download.outcome }}
         run: |
+          if [ "$DOWNLOAD" = 'failure' ]; then
+            echo '::warning::Crowdin would not export; deploying the translations of the last download.'
+          fi
           missing=$(jq -r '.[] | select(.crowdinLanguage) | .locale' locales.json |
             while read -r locale; do test -d "i18n/$locale" || echo "$locale"; done)
-          test -z "$missing" || { echo "Crowdin returned no translations for: $missing"; exit 1; }
+          test -z "$missing" || { echo "No translations for: $missing"; exit 1; }
       - uses: actions/upload-artifact@v4
         with:
           name: translations

--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ Push to the default branch, the website will be deployed automatically by the
 Docusaurus builds one locale after another, and this site has 13 of them, so the
 workflow builds each locale in its own job instead. The translations are
 downloaded from Crowdin once, by a job of its own that shares them with the
-rest, and each locale job runs `docusaurus build --locale <locale>`. The
+rest, and each locale job runs `docusaurus build --locale <locale>`. That
+download is reused for an hour, because Crowdin rate limits how often it will
+export a project and the default branch is deployed more often than that. The
 resulting trees are stitched back together by `scripts/assemble-site.mjs` and
 shipped to Vercel with `vercel deploy --prebuilt`, as a single deployment.
 


### PR DESCRIPTION
The last deploy was refused by Crowdin on its **only** request:

```
✔️  Building ZIP archive with the latest translations
❌ Building translations
❌ Failed to build translation. Please contact our support team for help
❌ Too Many Requests
```

Downloading once per run (#891) was necessary but not sufficient. The quota had already been spent by the run before it, where twelve jobs each asked Crowdin to build an export. And every push to `main` deploys, so even one export per push is more often than Crowdin is willing to serve. Crowdin documents a 20-concurrent-request limit but no number for exports, so this works around the behaviour rather than tuning to a published figure.

Three changes to the `translations` job:

- **Reuse the download for an hour.** The export is cached under an hourly key, with `restore-keys` so an older one is still restored when the hour rolls over. Translations move at the pace of translators, not of commits, so an hour of staleness costs nothing.
- **Retry when refused.** Three attempts, backing off 2 then 4 minutes, since Crowdin answers 429 instead of waiting.
- **Fall back to the last good download.** If Crowdin will not export at all, the deploy proceeds on the restored translations and logs a warning, rather than blocking a docs change on a rate limit. The completeness check still fails the job if there is nothing to fall back to, so an untranslated site can never be published this way.

To force a fresh export sooner — right after a `pnpm crowdin:sync`, say — delete the `translations-*` entry from the repository's Actions caches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)