### PR TITLE
docs: explain how to disable progress output

### DIFF
--- a/docs/settings/cli.md
+++ b/docs/settings/cli.md
@@ -28,6 +28,37 @@ Controls colors in the output.
 Any logs at or higher than the given level will be shown.
 You can instead pass `--silent` to turn off all output logs.
 
+### progress
+
+* Default: **true**
+* Type: **Boolean**
+
+Controls dependency and download progress in the default reporter. Set this to
+`false` to hide progress while keeping warnings, lifecycle output, and command
+summaries. This setting does not affect the `ndjson` reporter.
+
+Disable progress for one command with `--no-progress`:
+
+```sh
+pnpm install --no-progress
+```
+
+To disable progress for every project on the machine, update the global config:
+
+```sh
+pnpm config set --global progress false
+```
+
+It can also be set with `PNPM_CONFIG_PROGRESS` or in `pnpm-workspace.yaml`:
+
+```sh
+PNPM_CONFIG_PROGRESS=false pnpm install
+```
+
+```yaml title="pnpm-workspace.yaml"
+progress: false
+```
+
 ### useBetaCli
 
 * Default: **false**

--- a/docs/settings/cli.md
+++ b/docs/settings/cli.md
@@ -33,9 +33,14 @@ You can instead pass `--silent` to turn off all output logs.
 * Default: **true**
 * Type: **Boolean**
 
-Controls dependency and download progress in the default reporter. Set this to
-`false` to hide progress while keeping warnings, lifecycle output, and command
-summaries. This setting does not affect the `ndjson` reporter.
+Controls dependency and download progress, including output such as:
+
+```text
+Progress: resolved 12, reused 10, downloaded 2, added 12
+```
+
+Set this to `false` to hide progress without hiding warnings, lifecycle script
+output, or command summaries.
 
 Disable progress for one command with `--no-progress`:
 
@@ -43,20 +48,10 @@ Disable progress for one command with `--no-progress`:
 pnpm install --no-progress
 ```
 
-To disable progress for every project on the machine, update the global config:
+To disable progress globally:
 
 ```sh
 pnpm config set --global progress false
-```
-
-It can also be set with `PNPM_CONFIG_PROGRESS` or in `pnpm-workspace.yaml`:
-
-```sh
-PNPM_CONFIG_PROGRESS=false pnpm install
-```
-
-```yaml title="pnpm-workspace.yaml"
-progress: false
 ```
 
 ### useBetaCli


### PR DESCRIPTION
Users may need clean command output without losing warnings, lifecycle script output, or command summaries. Document the `progress` setting and `--no-progress` flag added by [pnpm/pnpm#14065](https://github.com/pnpm/pnpm/pull/14065).

---
Written by an agent (Codex, GPT-5).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an example of progress output to the CLI settings guide.
  * Clarified which messages remain visible when progress reporting is disabled.
  * Updated the documented configuration options for progress reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->