### PR TITLE
docs: document reading a two-document pnpm-lock.yaml

### DIFF
--- a/docs/config-dependencies.md
+++ b/docs/config-dependencies.md
@@ -11,7 +11,7 @@ If your config dependency is named following the `pnpm-plugin-*`, `@*/pnpm-plugi
 
 ## How to Add a Config Dependency
 
-Config dependencies are defined in your `pnpm-workspace.yaml`. Their integrity checksums are stored in `pnpm-lock.yaml` (in a dedicated env lockfile document).
+Config dependencies are defined in your `pnpm-workspace.yaml`. Their integrity checksums are stored in `pnpm-lock.yaml` (in a dedicated [env lockfile document](./lockfile.md)).
 
 For example, running `pnpm add --config my-configs` will add this entry to your `pnpm-workspace.yaml`:
 

--- a/docs/lockfile.md
+++ b/docs/lockfile.md
@@ -9,7 +9,7 @@ or two:
 
 | Document | Contents |
 | --- | --- |
-| The **env lockfile** (first, when present) | [Config dependencies] and the pnpm version resolved for the project, under `configDependencies` and `packageManagerDependencies`, with the `packages` and `snapshots` entries those need |
+| The **env lockfile** (first, when present) | [Config dependencies] and the pnpm version resolved for the project, under `configDependencies` and `packageManagerDependencies`, with the `packages` and `snapshots` entries they need |
 | The **project lockfile** (last, always present) | The project's own dependency graph: `importers` with their `dependencies`, and the matching `packages` and `snapshots` |
 
 Both documents declare the same `lockfileVersion`. That field describes the
@@ -59,24 +59,53 @@ snapshots:
   # ...
 ```
 
-## Take the last document
+## Which document you need
 
-Read all documents and use the last one:
+That depends on what your tool is for:
+
+- **The project's dependency graph** — dependency update bots, graph builders,
+  anything that asks "what does this project depend on": the **last** document.
+- **Everything the lockfile installs** — vulnerability scanners and SBOM
+  generators: **every** document. Config dependencies are real npm packages,
+  installed into `node_modules/.pnpm-config`, and they appear only in the env
+  document.
+
+Either way, load the file with a multi-document API. A single-document one
+(`load()` in js-yaml, `yaml.safe_load` in Python, `yaml.Unmarshal` into one
+value in Go) either raises an error or silently gives you the first document —
+which, in a two-document lockfile, is the env document.
+
+### The project's dependency graph
+
+Take the last document:
 
 ```js
+import { readFile } from 'node:fs/promises'
 import { loadAll } from 'js-yaml'
 
 const lockfile = loadAll(await readFile('pnpm-lock.yaml', 'utf8')).at(-1)
 ```
 
 This is correct for both shapes, and for every `pnpm-lock.yaml` pnpm has ever
-written. Loading the file with a single-document API instead (`load()` in
-js-yaml, `yaml.safe_load` in Python, `yaml.Unmarshal` into one value in Go)
-either raises an error or silently returns only the first document.
+written.
 
-If you need to detect the layout rather than always taking the last document, a
+If you would rather detect the layout than always take the last document, a
 file whose first line is `---` has an env document. pnpm writes that leading
 marker only when it writes two documents.
+
+### Everything the lockfile installs
+
+Read every document and union what you find in each:
+
+```js
+const documents = loadAll(await readFile('pnpm-lock.yaml', 'utf8'))
+const installed = documents.flatMap((doc) => Object.keys(doc.packages ?? {}))
+```
+
+Take each document as an inventory of its own rather than merging the documents
+into a single object first. Both use the `.` importer key, and each carries its
+own `packages` and `snapshots` maps, so merging them overwrites one side's
+importer and loses whichever graph it held.
 
 ## Why the env document comes first
 
@@ -116,10 +145,9 @@ built on it passes.
 
 If you scan pnpm projects:
 
-- **Read both documents and union them.** Config dependencies are real npm
-  packages, installed into `node_modules/.pnpm-config`. A tool that reads only
-  the project document misses them; a tool that reads only the env document
-  misses everything else.
+- **Read every document**, as described above. A tool that reads only the
+  project document misses the config dependencies; a tool that reads only the
+  env document misses everything else.
 - **Verify your scanner against a two-document lockfile before you trust its
   output.** "It reported something" is not a sufficient check here: the env
   document does contain packages, so a broken reader emits a plausible-looking

--- a/docs/lockfile.md
+++ b/docs/lockfile.md
@@ -1,0 +1,133 @@
+---
+id: lockfile
+title: Reading `pnpm-lock.yaml`
+---
+
+`pnpm-lock.yaml` is a YAML file, but it is not always a **single** YAML
+document. Depending on what the project uses, pnpm writes either one document
+or two:
+
+| Document | Contents |
+| --- | --- |
+| The **env lockfile** (first, when present) | [Config dependencies] and the pnpm version resolved for the project, under `configDependencies` and `packageManagerDependencies`, with the `packages` and `snapshots` entries those need |
+| The **project lockfile** (last, always present) | The project's own dependency graph: `importers` with their `dependencies`, and the matching `packages` and `snapshots` |
+
+Both documents declare the same `lockfileVersion`. That field describes the
+schema of the entries inside a document, not how many documents the file
+contains, so it does not change when the env document appears.
+
+This page is for tools that read `pnpm-lock.yaml` — vulnerability scanners,
+SBOM generators, dependency graph builders, and dependency update bots. If you
+only use pnpm, you don't need to care about any of this.
+
+A two-document lockfile looks like this:
+
+```yaml title="pnpm-lock.yaml"
+---
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    configDependencies: {}
+    packageManagerDependencies:
+      pnpm:
+        specifier: 12.0.0-rc.7
+        version: 12.0.0-rc.7
+
+packages:
+  # pnpm and its platform binaries
+snapshots:
+  # ...
+---
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+
+importers:
+
+  .:
+    dependencies:
+      react:
+        specifier: ^19.0.0
+        version: 19.0.0
+
+packages:
+  # every package in the project's dependency graph
+snapshots:
+  # ...
+```
+
+## Take the last document
+
+Read all documents and use the last one:
+
+```js
+import { loadAll } from 'js-yaml'
+
+const lockfile = loadAll(await readFile('pnpm-lock.yaml', 'utf8')).at(-1)
+```
+
+This is correct for both shapes, and for every `pnpm-lock.yaml` pnpm has ever
+written. Loading the file with a single-document API instead (`load()` in
+js-yaml, `yaml.safe_load` in Python, `yaml.Unmarshal` into one value in Go)
+either raises an error or silently returns only the first document.
+
+If you need to detect the layout rather than always taking the last document, a
+file whose first line is `---` has an env document. pnpm writes that leading
+marker only when it writes two documents.
+
+## Why the env document comes first
+
+pnpm has to know which pnpm version to switch to, and which plugins to load,
+before it can do anything else — including before it has any reason to parse a
+dependency graph that may be several megabytes. Keeping that information in a
+small leading document means every command reads a few kilobytes rather than
+the whole file.
+
+## When a lockfile has two documents
+
+The env document is written when either of these applies:
+
+- The project has [config dependencies]. Their integrity checksums are project
+  content and are always recorded.
+- pnpm records the pnpm version it resolved for the project, under
+  `packageManagerDependencies`. This happens when the project declares
+  [`devEngines.packageManager`], or pins pnpm 12 or newer through the legacy
+  `packageManager` field. Setting [`pmOnFail`] to `ignore` turns it off — pnpm
+  then doesn't enforce the pinned version, so it has nothing to record.
+
+Two-document lockfiles have existed since config dependencies were introduced.
+They became common in pnpm 12, which records the resolved package manager
+version by default.
+
+## Scanning for vulnerabilities
+
+:::caution
+
+A tool that reads only the first document of a two-document lockfile does not
+fail loudly. The env document is a structurally valid lockfile — it just
+describes an importer with no `dependencies`. Such a tool reports that the
+project has no dependencies, and therefore no vulnerabilities, and a CI gate
+built on it passes.
+
+:::
+
+If you scan pnpm projects:
+
+- **Read both documents and union them.** Config dependencies are real npm
+  packages, installed into `node_modules/.pnpm-config`. A tool that reads only
+  the project document misses them; a tool that reads only the env document
+  misses everything else.
+- **Verify your scanner against a two-document lockfile before you trust its
+  output.** "It reported something" is not a sufficient check here: the env
+  document does contain packages, so a broken reader emits a plausible-looking
+  result listing pnpm's own binaries.
+- [`pnpm audit`] reads the lockfile correctly in both shapes and needs no
+  configuration.
+
+[Config dependencies]: config-dependencies.md
+[`devEngines.packageManager`]: package_json.md#devenginespackagemanager
+[`pmOnFail`]: settings/cli.md#pmonfail
+[`pnpm audit`]: cli/audit.md

--- a/docs/package_json.md
+++ b/docs/package_json.md
@@ -136,7 +136,7 @@ Allows specifying the pnpm version via `devEngines.packageManager` in `package.j
 
 :::note
 
-When pnpm is declared via the legacy `packageManager` field (not `devEngines.packageManager`), its resolution info is **not** written to `pnpm-lock.yaml` — unless the pinned pnpm version is v12 or newer. This keeps the lockfile stable when upgrading from pnpm v10 to v11 without forcing projects off the legacy field.
+When pnpm is declared via the legacy `packageManager` field (not `devEngines.packageManager`), its resolution info is **not** written to `pnpm-lock.yaml` — unless the pinned pnpm version is v12 or newer. This keeps the lockfile stable when upgrading from pnpm v10 to v11 without forcing projects off the legacy field. When the resolution is recorded, `pnpm-lock.yaml` gains a leading [env lockfile document](./lockfile.md).
 
 :::
 

--- a/docs/package_json.md
+++ b/docs/package_json.md
@@ -136,7 +136,7 @@ Allows specifying the pnpm version via `devEngines.packageManager` in `package.j
 
 :::note
 
-When pnpm is declared via the legacy `packageManager` field (not `devEngines.packageManager`), its resolution info is **not** written to `pnpm-lock.yaml` — unless the pinned pnpm version is v12 or newer. This keeps the lockfile stable when upgrading from pnpm v10 to v11 without forcing projects off the legacy field. When the resolution is recorded, `pnpm-lock.yaml` gains a leading [env lockfile document](./lockfile.md).
+When pnpm is declared via the legacy `packageManager` field (not `devEngines.packageManager`), its resolution info is **not** written to `pnpm-lock.yaml` — unless the pinned pnpm version is v12 or newer and [`pmOnFail`](./settings/cli.md#pmonfail) is not set to `ignore`. This keeps the lockfile stable when upgrading from pnpm v10 to v11 without forcing projects off the legacy field. When the resolution is recorded, `pnpm-lock.yaml` gains a leading [env lockfile document](./lockfile.md).
 
 :::
 

--- a/docs/supply-chain-security.md
+++ b/docs/supply-chain-security.md
@@ -29,6 +29,8 @@ Additionally, the [trustPolicyIgnoreAfter] setting allows you to ignore trust ch
 
 It goes without saying that you should always lock your dependencies with a lockfile. Commit your lockfile to your repository to avoid unexpected updates.
 
+If you scan `pnpm-lock.yaml` with a vulnerability scanner or an SBOM generator, check that it handles the [two-document lockfile](lockfile.md): a tool that reads only the first document reports that the project has no dependencies, and no vulnerabilities, without failing.
+
 ### Pin dependencies to the registry they come from
 
 If you install from more than one registry, use [namedRegistries] aliases for the packages that must come from a specific one. Since v11.20.0, pnpm records those packages in the lockfile under registry-qualified keys (`<name>@<registryName>:<version>`), so a package cannot be quietly substituted by another registry that publishes the same name and version. See [Named registries in the lockfile]. Packages installed without an alias are resolved through the default [registries] configuration as before.

--- a/sidebars.json
+++ b/sidebars.json
@@ -211,6 +211,7 @@
       "limitations",
       "symlinked-node-modules-structure",
       "how-peers-are-resolved",
+      "lockfile",
       "uninstall",
       "pnpm-vs-npm"
     ]

--- a/versioned_sidebars/version-11.x-sidebars.json
+++ b/versioned_sidebars/version-11.x-sidebars.json
@@ -633,6 +633,10 @@
         },
         {
           "type": "doc",
+          "id": "lockfile"
+        },
+        {
+          "type": "doc",
           "id": "uninstall"
         },
         {


### PR DESCRIPTION
## Summary

`pnpm-lock.yaml` carries a leading env lockfile document whenever the project has config dependencies, or whenever pnpm records the version it resolved for the project — the common case in pnpm 12. Both documents declare the same `lockfileVersion`, so a consumer that loads the file with a single-document YAML API either throws, or silently reads the env document and concludes the project has no dependencies. That failure returns a populated result rather than an error, so a CI gate built on it passes: it has closed open vulnerability alerts on real repositories ([pnpm/pnpm#13805](https://github.com/pnpm/pnpm/issues/13805)), and osv-scalibr and Dependabot are still affected today.

The rule that works for every lockfile pnpm has ever written — read all documents, take the last, and union both when building an SBOM or scanning for vulnerabilities — was only ever stated in issue threads. This gives it a page of its own so upstream bug reports have something stable to point at.

Adds `docs/lockfile.md` (Advanced → *Reading `pnpm-lock.yaml`*), covering:

- the two document shapes, with an abridged example
- `loadAll(...).at(-1)`, and the leading `---` as the layout signal
- why the env document comes first (pnpm must know which version to switch to and which plugins to load before it parses a graph that may be megabytes)
- what triggers a second document, and that `pmOnFail: ignore` turns off the package-manager half of it
- what a scanner must do, and that "it reported something" is not a passing check — the env document does contain packages

Links to it from the three places where a reader learns their lockfile gained a document: `config-dependencies.md`, `package_json.md`, and *Use a lockfile* in `supply-chain-security.md`.

---
Written by an agent (Claude Code, claude-opus-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance on pnpm lockfiles containing environment and project documents.
  * Documented how to read, inventory, detect, and create two-document lockfiles.
  * Added security guidance for vulnerability scanners and SBOM generators.
  * Clarified when pnpm resolution is recorded.
  * Added lockfile guidance to Advanced documentation navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->