### PR TITLE
docs: render three platinum sponsors per row

### DIFF
--- a/scripts/generate-sponsors.mjs
+++ b/scripts/generate-sponsors.mjs
@@ -9,14 +9,9 @@ const SPONSORS_FILE = path.join(PROJECT_ROOT, 'sponsors.json');
 const BASE_URL = 'https://pnpm.io/img/users';
 
 const TIER_CONFIG = {
-  platinum: { columns: 1, heading: 'Platinum Sponsors' },
+  platinum: { columns: 3, heading: 'Platinum Sponsors' },
   gold: { columns: 3, heading: 'Gold Sponsors' },
   silver: { columns: 3, heading: 'Silver Sponsors' },
-};
-
-const README_TIER_CONFIG = {
-  ...TIER_CONFIG,
-  platinum: { ...TIER_CONFIG.platinum, columns: 2 },
 };
 
 const ALT_EXTENSIONS = ['.svg', '.png', '.jpg', '.jpeg'];
@@ -197,7 +192,7 @@ function generate() {
   const absPnpmRoot = path.resolve(pnpmRoot);
 
   // READMEs — all tiers
-  const readmeMarkdown = generateMarkdown(sponsors, { tierConfig: README_TIER_CONFIG });
+  const readmeMarkdown = generateMarkdown(sponsors);
   updateFileMarkers(path.join(absPnpmRoot, 'README.md'), readmeMarkdown);
   updateFileMarkers(path.join(absPnpmRoot, 'pnpm/README.md'), readmeMarkdown);
 


### PR DESCRIPTION
The platinum tier was capped at one column in release notes and two in the READMEs, while gold and silver used three everywhere. With Notion joining as a third platinum sponsor that stacked them into a tall column, and the logos are narrow enough (80 + 160 + 80) that all three fit comfortably on one line in both places.

Both configs now agree, so `README_TIER_CONFIG` is gone. The `tierConfig` parameter stays as the extension point if the two ever need to diverge again.

Generated output for this is in pnpm/pnpm#14117.

🤖 Generated with [Claude Code](https://claude.com/claude-code)