### PR TITLE
docs: document workspace task orchestration

### DIFF
--- a/docs/cli/recursive.md
+++ b/docs/cli/recursive.md
@@ -84,8 +84,10 @@ pnpm -r --no-bail test
 * Default: **true**
 * Type: **Boolean**
 
-When `true`, packages are sorted topologically (dependencies before dependents).
-Pass `--no-sort` to disable.
+When `true`, commands follow the workspace dependency graph. Recursive `run`
+also applies relationships from the [`tasks` setting]. Pass `--no-sort` to
+remove graph ordering. This also makes `tasks`, `--reverse`, and `--resume-from`
+inapplicable.
 
 Example:
 ```sh
@@ -97,7 +99,8 @@ pnpm -r --no-sort test
 * Default: **false**
 * Type: **boolean**
 
-When `true`, the order of packages is reversed.
+When `true`, dependency edges are reversed. For recursive `run`, this reverses
+the resolved task graph, including relationships declared with `dependsOn`.
 
 ```
 pnpm -r --reverse run clean
@@ -108,3 +111,4 @@ pnpm -r --reverse run clean
 [Read more about filtering.](../filtering.md)
 
 [includeWorkspaceRoot]: ../workspaces.md#includeworkspaceroot
+[`tasks` setting]: ../workspace-task-orchestration.md

--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -104,6 +104,9 @@ This runs an arbitrary command from each package's "scripts" object.
 If a package doesn't have the command, it is skipped.
 If none of the packages have the command, the command fails.
 
+Recursive runs use a dependency-aware task graph. Configure relationships
+between scripts with the [`tasks` setting](../workspace-task-orchestration.md).
+
 ### --if-present
 
 You can use the `--if-present` flag to avoid exiting with a non-zero exit code
@@ -150,7 +153,28 @@ Aggregate output from child processes that are run in parallel, and only print o
 
 ### --resume-from &lt;package_name\>
 
-Resume execution from a particular project. This can be useful if you are working with a large workspace and you want to restart a build at a particular project without running through all of the projects that precede it in the build order.
+Resume at the named package's requested task. Pnpm omits that task's transitive
+dependencies, treating them as already completed, but still runs the task
+itself, its dependents, and unrelated tasks in the selected graph. See
+[Workspace task orchestration](../workspace-task-orchestration.md#--resume-from-package_name).
+
+### --dry-run
+
+Resolve a recursive run's task graph without running scripts. The plain output
+is one stable topological ordering, not a prediction of the order in which
+independent tasks will be dispatched.
+
+```sh
+pnpm -r run --dry-run build
+```
+
+`--dry-run` is only supported for recursive runs.
+
+### --json
+
+With `--dry-run`, print the resolved tasks and their dependency edges as JSON.
+See [Inspect the task graph](../workspace-task-orchestration.md#inspect-the-task-graph)
+for the schema and an example.
 
 ### --report-summary
 
@@ -183,6 +207,9 @@ Hide workspace prefix from output from child processes that are run in parallel,
 [Read more about filtering.](../filtering.md)
 
 ## pnpm-workspace.yaml settings
+
+The [`tasks` setting](../workspace-task-orchestration.md) configures dependency
+relationships and per-task concurrency limits for recursive runs.
 
 import EnablePrePostScripts from '../settings/_enablePrePostScripts.mdx'
 

--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -156,7 +156,7 @@ Aggregate output from child processes that are run in parallel, and only print o
 
 ### --resume-from &lt;package_name\>
 
-Resume at the named package's requested task. Pnpm skips the tasks a matching
+Resume at the named package's requested task. pnpm skips the tasks a matching
 record of the previous run says already passed; without such a record it omits
 the task's transitive dependencies instead, treating them as completed. Either
 way it still runs the task itself, its dependents, and unrelated tasks in the

--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -104,8 +104,11 @@ This runs an arbitrary command from each package's "scripts" object.
 If a package doesn't have the command, it is skipped.
 If none of the packages have the command, the command fails.
 
-Recursive runs use a dependency-aware task graph. Configure relationships
-between scripts with the [`tasks` setting](../workspace-task-orchestration.md).
+By default, recursive runs use a dependency-aware task graph. Configure
+relationships between scripts with the
+[`tasks` setting](../workspace-task-orchestration.md). `--no-sort`, and
+`--parallel` which implies it, remove that ordering and ignore the `tasks`
+declarations along with it.
 
 ### --if-present
 

--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -153,9 +153,11 @@ Aggregate output from child processes that are run in parallel, and only print o
 
 ### --resume-from &lt;package_name\>
 
-Resume at the named package's requested task. Pnpm omits that task's transitive
-dependencies, treating them as already completed, but still runs the task
-itself, its dependents, and unrelated tasks in the selected graph. See
+Resume at the named package's requested task. Pnpm skips the tasks a matching
+record of the previous run says already passed; without such a record it omits
+the task's transitive dependencies instead, treating them as completed. Either
+way it still runs the task itself, its dependents, and unrelated tasks in the
+selected graph. See
 [Workspace task orchestration](../workspace-task-orchestration.md#--resume-from-package_name).
 
 ### --dry-run

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -3,6 +3,17 @@ id: errors
 title: Error Codes
 ---
 
+## ERR_PNPM_TASK_CYCLE
+
+A recursive run's task graph contains a dependency cycle. The error lists the
+participating tasks as `<project>#<script>` identifiers.
+
+Remove or change the cycle under [`tasks`](./workspace-task-orchestration.md).
+If it is deliberate, set
+[`ignoreWorkspaceCycles`](./workspaces.md#ignoreworkspacecycles) to `true` to
+downgrade the error to a warning and run the cycle's tasks without a guaranteed
+order.
+
 ## ERR_PNPM_UNEXPECTED_STORE
 
 A modules directory is present and is linked to a different store directory.

--- a/docs/workspace-task-orchestration.md
+++ b/docs/workspace-task-orchestration.md
@@ -1,0 +1,183 @@
+---
+id: workspace-task-orchestration
+title: Workspace task orchestration
+---
+
+`pnpm -r run <script>` schedules a graph of workspace tasks. A task is a script
+in one workspace project, identified as `<project>#<script>`. It becomes ready
+after every task it depends on completes successfully, and ready tasks run under
+the [`--workspace-concurrency`](./cli/recursive.md#--workspace-concurrency)
+limit.
+
+Independent tasks do not wait for an unrelated project to finish. Their start
+and completion order is therefore not guaranteed.
+
+## Configure task dependencies
+
+Declare task relationships under `tasks` in `pnpm-workspace.yaml`:
+
+```yaml title="pnpm-workspace.yaml"
+packages:
+  - packages/*
+
+tasks:
+  build:
+    dependsOn:
+      - ^build
+  test:
+    dependsOn:
+      - build
+```
+
+Each `dependsOn` entry has one of these forms:
+
+| Entry | Meaning |
+| --- | --- |
+| `build` | The `build` task in the same project |
+| `^build` | The `build` task in each selected workspace dependency of the project |
+
+In this example, `pnpm -r run test` first runs `build` in each project. A
+project's `build` waits for `build` in its workspace dependencies.
+
+A task with no entry under `tasks` defaults to depending on the same task in
+its workspace dependencies. For example, an unconfigured `build` behaves as
+`dependsOn: ['^build']`, preserving the usual dependencies-before-dependents
+behavior.
+
+:::warning
+
+Once a task has an entry under `tasks`, an omitted `dependsOn` is the same as
+`dependsOn: []`. If you configure another field and still want the default
+topological relationship, declare it explicitly:
+
+```yaml title="pnpm-workspace.yaml"
+tasks:
+  build:
+    concurrency: 2
+    dependsOn:
+      - ^build
+```
+
+:::
+
+Task dependencies stay inside the projects selected by `--filter` and
+`includeWorkspaceRoot`. A `dependsOn` entry does not widen that selection.
+
+### Projects without a script
+
+If a selected project does not have a script named by the graph, pnpm treats
+that task as a pass-through. The task is reported as skipped after its own
+dependencies complete, so a package without `build` does not sever the build
+chain between its workspace dependencies and dependents.
+
+## Limit concurrency for one task
+
+Set `concurrency` to a positive integer to limit how many instances of a named
+task may run across workspace projects at once:
+
+```yaml title="pnpm-workspace.yaml"
+tasks:
+  build:
+    concurrency: 2
+    dependsOn:
+      - ^build
+```
+
+This limit is separate from the workspace-wide
+[`--workspace-concurrency`](./cli/recursive.md#--workspace-concurrency) limit.
+A `build` waiting for one of its two slots does not occupy a workspace slot, so
+an unrelated ready task can still run.
+
+## Inspect the task graph
+
+Use `--dry-run` to resolve the graph without running scripts:
+
+```sh
+pnpm -r run --dry-run build
+```
+
+The output is one stable topological ordering, with ties broken by project
+directory. It is not a prediction of dispatch order: independent tasks may run
+in any order.
+
+Add `--json` to receive graph nodes and edges:
+
+```sh
+pnpm -r run --dry-run --json test
+```
+
+```json
+{
+  "tasks": [
+    {
+      "project": "packages/app",
+      "script": "build",
+      "missingScript": false,
+      "dependsOn": [
+        { "project": "packages/lib", "script": "build" }
+      ]
+    },
+    {
+      "project": "packages/app",
+      "script": "test",
+      "missingScript": false,
+      "dependsOn": [
+        { "project": "packages/app", "script": "build" }
+      ]
+    }
+  ]
+}
+```
+
+`project` is relative to the workspace root. The `tasks` array and each
+`dependsOn` array are sorted by project and script so the output is stable.
+
+## Cycles
+
+Pnpm checks the graph after project selection and task expansion. A cycle fails
+before any script starts with `ERR_PNPM_TASK_CYCLE`, and the error names the
+participating tasks.
+
+Set [`ignoreWorkspaceCycles`](./workspaces.md#ignoreworkspacecycles) to `true`
+only when the cycle is deliberate. Pnpm then warns, removes the ordering among
+the cycle's members, and may run them in any order relative to each other.
+
+## Recursive run options
+
+### `--resume-from <package_name>`
+
+The named package's requested task is the resume point. Pnpm omits that task's
+transitive dependencies, treating them as already completed, but still runs the
+resume task, its dependents, and unrelated tasks in the selected graph.
+
+### `--reverse`
+
+Pnpm reverses every edge in the resolved task graph, including relationships
+declared with `dependsOn`. Tasks that normally depend on another task run before
+it.
+
+### `--no-bail`
+
+After a task fails, tasks that depend on it are skipped. With `--no-bail`,
+independent ready tasks continue to run and the command exits with a non-zero
+code after they settle. With the default `--bail`, pnpm stops dispatching new
+tasks after the first failure.
+
+### Output
+
+Pnpm inherits a script's output directly when at most one script can be running
+at any time, either because workspace concurrency is `1` or because the graph
+forms one serial chain. When scripts can overlap, pnpm pipes their output so it
+can prefix or aggregate it. Use [`--stream`](./cli/run.md#--stream) for immediate
+prefixed output or [`--aggregate-output`](./cli/run.md#--aggregate-output) to
+print each task's output together after it finishes.
+
+## Commands that do not use `tasks`
+
+The `tasks` declarations configure recursive `run`. Recursive `exec` follows
+workspace project dependencies but has no script task name, so it does not join
+declared `dependsOn` relationships.
+
+`--no-sort` removes graph ordering, and `--parallel` implies `--no-sort`.
+Consequently, both options ignore `tasks` declarations; `--reverse` and
+`--resume-from` also have no ordering edges to transform.

--- a/docs/workspace-task-orchestration.md
+++ b/docs/workspace-task-orchestration.md
@@ -146,9 +146,21 @@ the cycle's members, and may run them in any order relative to each other.
 
 ### `--resume-from <package_name>`
 
-The named package's requested task is the resume point. Pnpm omits that task's
-transitive dependencies, treating them as already completed, but still runs the
-resume task, its dependents, and unrelated tasks in the selected graph.
+The named package's requested task is the resume point.
+
+Pnpm records which tasks pass as a recursive run proceeds. When that record
+belongs to the same invocation — the same selected projects, script bodies,
+command arguments, and script-affecting settings — `--resume-from` skips
+exactly the tasks the record says passed, wherever they sit in the graph, and
+runs everything else. A record left by a different invocation is ignored rather
+than trusted.
+
+Without a usable record — a first run, a run interrupted before any task
+passed, or a `node_modules` directory pnpm cannot write to — pnpm falls back to
+graph position: it omits the resume point's transitive dependencies, treating
+them as already completed, but still runs the resume task, its dependents, and
+unrelated tasks in the selected graph. That assumption holds after a failed run
+and not after a cancelled one, where a dependency may never have started.
 
 ### `--reverse`
 
@@ -160,8 +172,14 @@ it.
 
 After a task fails, tasks that depend on it are skipped. With `--no-bail`,
 independent ready tasks continue to run and the command exits with a non-zero
-code after they settle. With the default `--bail`, pnpm stops dispatching new
-tasks after the first failure.
+code after they settle.
+
+With the default `--bail`, pnpm stops dispatching new tasks after the first
+failure and cancels the tasks already running, along with the processes they
+started. Otherwise a task that never exits on its own, such as a watcher or a
+dev server, would keep a failed run alive indefinitely. A cancelled task is not
+reported as a failure of its own; the failure that stopped the run is the one
+reported.
 
 ### Output
 

--- a/docs/workspace-task-orchestration.md
+++ b/docs/workspace-task-orchestration.md
@@ -134,12 +134,12 @@ pnpm -r run --dry-run --json test
 
 ## Cycles
 
-Pnpm checks the graph after project selection and task expansion. A cycle fails
+pnpm checks the graph after project selection and task expansion. A cycle fails
 before any script starts with `ERR_PNPM_TASK_CYCLE`, and the error names the
 participating tasks.
 
 Set [`ignoreWorkspaceCycles`](./workspaces.md#ignoreworkspacecycles) to `true`
-only when the cycle is deliberate. Pnpm then warns, removes the ordering among
+only when the cycle is deliberate. pnpm then warns, removes the ordering among
 the cycle's members, and may run them in any order relative to each other.
 
 ## Recursive run options
@@ -148,7 +148,7 @@ the cycle's members, and may run them in any order relative to each other.
 
 The named package's requested task is the resume point.
 
-Pnpm records which tasks pass as a recursive run proceeds. When that record
+pnpm records which tasks pass as a recursive run proceeds. When that record
 belongs to the same invocation — the same selected projects, script bodies,
 command arguments, and script-affecting settings — `--resume-from` skips
 exactly the tasks the record says passed, wherever they sit in the graph, and
@@ -164,7 +164,7 @@ and not after a cancelled one, where a dependency may never have started.
 
 ### `--reverse`
 
-Pnpm reverses every edge in the resolved task graph, including relationships
+pnpm reverses every edge in the resolved task graph, including relationships
 declared with `dependsOn`. Tasks that normally depend on another task run before
 it.
 
@@ -183,7 +183,7 @@ reported.
 
 ### Output
 
-Pnpm inherits a script's output directly when at most one script can be running
+pnpm inherits a script's output directly when at most one script can be running
 at any time, either because workspace concurrency is `1` or because the graph
 forms one serial chain. When scripts can overlap, pnpm pipes their output so it
 can prefix or aggregate it. Use [`--stream`](./cli/run.md#--stream) for immediate

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -287,7 +287,10 @@ When executing commands recursively in a workspace, execute them on the root wor
 * Default: **false**
 * Type: **Boolean**
 
-When set to `true`, no workspace cycle warnings will be printed.
+When set to `true`, no workspace dependency cycle warnings will be printed.
+It also downgrades an `ERR_PNPM_TASK_CYCLE` from a recursive run to a warning.
+The tasks in that cycle then have no guaranteed order relative to each other.
+See [Workspace task orchestration](./workspace-task-orchestration.md#cycles).
 
 ### disallowWorkspaceCycles
 

--- a/sidebars.json
+++ b/sidebars.json
@@ -184,6 +184,7 @@
       "registries",
       "registry-revisions",
       "workspaces",
+      "workspace-task-orchestration",
       "catalogs",
       "config-dependencies",
       "aliases",


### PR DESCRIPTION
## Summary

- add a workspace task orchestration guide covering `tasks`, `dependsOn`, the `^` convention, pass-through tasks, and per-task concurrency
- document task graph inspection with `--dry-run --json`, cycle handling, and the revised resume, reverse, bail, and output behavior
- link the guide from recursive run, recursive command, workspace, and error-code documentation
- state the current boundary that recursive `exec` follows project dependencies but does not join declared task relationships
- document `--resume-from`'s run-state record ([pnpm/pnpm#14258](https://github.com/pnpm/pnpm/pull/14258)): a record of the same invocation replaces the graph-position inference, which stays as the fallback and whose assumption only holds after a failure, not after a cancellation
- document that `--bail` cancels tasks already running ([pnpm/pnpm#14251](https://github.com/pnpm/pnpm/pull/14251)), not only the undispatched ones

Related to pnpm/pnpm#14211 (documentation item).

## Testing

- `pnpm build` (all 13 locales)

The build repeats the existing `/cli/pn` broken-link warning from the pnpm 11.0 release blog; no new broken links were reported.

---
Written by an agent (Codex, GPT-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a guide to workspace task orchestration, covering task ordering, concurrency limits, dry runs, cycle handling, resume behavior, and related command options.
  * Clarified recursive run sorting, reverse ordering, dependency graphs, and `--dry-run` / `--json` output.
  * Documented task-cycle errors and workspace cycle handling.
  * Added the new guide to the documentation navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
