### PR TITLE
refactor: render the benchmark page here, from published numbers

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,8 +1,10 @@
 name: Benchmark sync
 
 # The benchmarks are measured in https://github.com/pnpm/benchmarks, on its own
-# schedule. This job only copies the page and charts it publishes into the site,
-# and is run by hand when those numbers should be picked up.
+# schedule. That repository publishes the numbers and nothing else; this job
+# renders the page and its charts from them (`scripts/benchmarks/`), and is run
+# by hand when the latest numbers should be picked up. Editing what the page
+# says needs no run of this at all — it is a commit to this repository.
 
 on:
   workflow_dispatch:
@@ -23,8 +25,6 @@ jobs:
       # Node's built-ins are all the script needs, so the site's dependencies
       # are not installed here.
       - run: node scripts/update-benchmarks.mjs
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Commit & Push changes
         # Pinned: this step is handed a token that can write to the repo, so
         # what runs in it shouldn't be able to change without a commit here.

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "examples": "docusaurus-examples",
     "copy-docs": "shx rm -rf versioned_docs/version-11.x && shx cp -r docs versioned_docs/version-11.x",
     "update-benchmarks": "node ./scripts/update-benchmarks.mjs",
+    "test": "node --test scripts/benchmarks/*.test.mjs",
     "start": "pnpm copy-docs && docusaurus start",
     "build": "pnpm copy-docs && node scripts/build-with-fallback.mjs",
     "publish-gh-pages": "docusaurus-publish --skip-image-compression",

--- a/scripts/benchmarks/columns.mjs
+++ b/scripts/benchmarks/columns.mjs
@@ -200,6 +200,6 @@ export const nodeVersionScenarios = {
 export const fixtureHeadings = {
   'alotta-files': {
     title: 'Lots of Files',
-    intro: "The app's `package.json` [here](https://github.com/pnpm/benchmarks/blob/main/fixtures/alotta-files/package.json)",
+    intro: "The app's [`alotta-files` package.json](https://github.com/pnpm/benchmarks/blob/main/fixtures/alotta-files/package.json)",
   },
 }

--- a/scripts/benchmarks/columns.mjs
+++ b/scripts/benchmarks/columns.mjs
@@ -1,0 +1,205 @@
+// What the benchmark page shows, and what it calls things.
+//
+// https://github.com/pnpm/benchmarks measures every tool and publishes the
+// numbers in `benchmarks.json`; nothing there decides what a reader is shown.
+// This file does. Adding or dropping a column is an edit here — and no
+// benchmark has to be re-run to change what the page says.
+//
+// The manifest carries more than this page draws, on purpose: Yarn and Bun are
+// measured for comparisons of our own and deliberately left off the site, so
+// numbers for a tool that isn't listed here are expected rather than a column
+// someone forgot to add.
+//
+// `key` is the name the manifest files a tool's results under. `legend` labels
+// it in the charts, `mdLegend` (when it differs) in the tables, where it can be
+// a link. `color` is the bar; `displayVersion` overrides the measured version
+// under a chart legend, for a tool whose real version is an unhelpfully long
+// prerelease string.
+
+/** The columns of the install table, in the order they appear. */
+export const packageManagerColumns = [
+  {
+    key: 'npm',
+    legend: 'npm',
+    color: '#cd3731',
+  },
+  {
+    key: 'pnpm11',
+    legend: 'pnpm',
+    color: '#fbae00',
+  },
+  {
+    key: 'pnpm12',
+    legend: 'pnpm 🦀',
+    mdLegend: '[pnpm 🦀](https://github.com/pnpm/pacquet)',
+    color: '#fbae00',
+    displayVersion: '12',
+    mascot: '🦀',
+  },
+  {
+    // The same pnpm 12 as the column before it, resolving its dependency graph
+    // on the registry instead of walking it itself.
+    key: 'pnpm_pnpr',
+    legend: 'pnpm + pnpr',
+    mdLegend: '[pnpm + pnpr](/pnpr/install-acceleration)',
+    color: '#2fa84f',
+    displayVersion: '12',
+  },
+]
+
+/**
+ * The bars of the main chart.
+ *
+ * Not one per table column: pnpm 11 and pnpm 12 are merged into a single
+ * stacked bar so that pnpm 12's speedup over pnpm 11 is visible at a glance,
+ * and `pnpm_pnpr` is left out — it is the same pnpm as one of those bars, so a
+ * bar of its own would read as another package manager rather than as a
+ * setting. The table keeps it.
+ */
+export const mainChartBars = [
+  { key: 'npm' },
+  {
+    stacked: true,
+    primaryKey: 'pnpm12',
+    secondaryKey: 'pnpm11',
+    extraColor: '#cccccc',
+    extraLegend: 'pnpm 11 extra',
+  },
+]
+
+/** The columns of the Node.js version management table. */
+export const nodeVersionManagerColumns = [
+  {
+    key: 'pnpm12',
+    legend: 'pnpm',
+    mdLegend: 'pnpm 12',
+    color: '#fbae00',
+    displayVersion: '12',
+  },
+  {
+    key: 'fnm',
+    legend: 'fnm',
+    color: '#6f42c1',
+  },
+  {
+    key: 'nvm',
+    legend: 'nvm',
+    color: '#5fa04e',
+  },
+]
+
+/**
+ * The install scenarios, keyed by the name the manifest reports them under.
+ *
+ * `cache`, `lockfile` and `nodeModules` are the table's own columns: which of
+ * them are warm or present before install runs. `label` is what the chart
+ * writes next to the bar group, one array entry per line. `explanation` is the
+ * line under the table that maps the scenario onto something a reader does.
+ *
+ * The rows are ordered by the page, slowest first; the order here is only the
+ * order they are declared in.
+ */
+export const installScenarios = {
+  firstInstall: {
+    action: 'install',
+    cache: ' ',
+    lockfile: ' ',
+    nodeModules: ' ',
+    label: ['clean'],
+    explanation: '`clean`: a brand-new clone — nothing cached, no lockfile, no `node_modules`.',
+  },
+  withWarmModules: {
+    action: 'install',
+    cache: ' ',
+    lockfile: ' ',
+    nodeModules: '✔',
+    label: ['node_modules'],
+    explanation: '`node_modules`: the cache and lockfile are deleted and install is run again.',
+  },
+  withLockfile: {
+    action: 'install',
+    cache: ' ',
+    lockfile: '✔',
+    nodeModules: ' ',
+    label: ['trusted lockfile'],
+    explanation: '`trusted lockfile`: a CI server doing its first install.',
+  },
+  withWarmCacheAndModules: {
+    action: 'install',
+    cache: '✔',
+    lockfile: ' ',
+    nodeModules: '✔',
+    label: ['cache', 'node_modules'],
+    explanation: '`cache+node_modules`: the lockfile is deleted and install is run again.',
+  },
+  withWarmCache: {
+    action: 'install',
+    cache: '✔',
+    lockfile: ' ',
+    nodeModules: ' ',
+    label: ['cache'],
+    explanation: '`cache`: a developer reinstalling without a lockfile.',
+  },
+  withWarmCacheAndLockfile: {
+    action: 'install',
+    cache: '✔',
+    lockfile: '✔',
+    nodeModules: ' ',
+    label: ['cache', 'trusted lockfile'],
+    explanation: '`cache+trusted lockfile`: a developer reinstalling a known project.',
+  },
+  withWarmModulesAndLockfile: {
+    action: 'install',
+    cache: ' ',
+    lockfile: '✔',
+    nodeModules: '✔',
+    label: ['trusted lockfile', 'node_modules'],
+    explanation: '`trusted lockfile+node_modules`: the cache is deleted and install is run again.',
+  },
+  repeatInstall: {
+    action: 'install',
+    cache: '✔',
+    lockfile: '✔',
+    nodeModules: '✔',
+    label: ['cache', 'trusted lockfile', 'node_modules'],
+    explanation: '`cache+trusted lockfile+node_modules`: re-running install when nothing has changed.',
+  },
+  updatedDependencies: {
+    action: 'update',
+    cache: 'n/a',
+    lockfile: 'n/a',
+    nodeModules: 'n/a',
+    label: ['update'],
+    explanation: '`update`: dependency versions are bumped in `package.json` and install is run again, from a warm cache.',
+  },
+}
+
+/**
+ * The Node.js version management scenarios. `chartLabel` is absent for the one
+ * that isn't charted: running Node.js takes milliseconds, so it would render as
+ * an invisible bar. The table below the chart reports it.
+ *
+ * `describe` is given the Node.js versions the run pinned, so the table says
+ * which ones were installed without this file having to know.
+ */
+export const nodeVersionScenarios = {
+  cleanInstall: {
+    describe: ({ primary }) => `install Node.js ${primary} with nothing cached`,
+    chartLabel: ['install', 'clean'],
+  },
+  warmStoreInstall: {
+    describe: ({ primary }) => `install Node.js ${primary} that was installed before`,
+    chartLabel: ['install', 'warm store'],
+  },
+  runInProject: {
+    describe: ({ secondary }) => `run \`node\` in a project pinned to Node.js ${secondary}`,
+  },
+}
+
+/** The fixtures the page draws, and how it introduces each. */
+export const fixtureHeadings = {
+  'alotta-files': {
+    title: 'Lots of Files',
+    intro: "The app's `package.json` [here](https://github.com/pnpm/benchmarks/blob/main/fixtures/alotta-files/package.json)",
+  },
+}

--- a/scripts/benchmarks/generate-stacked-svg.mjs
+++ b/scripts/benchmarks/generate-stacked-svg.mjs
@@ -1,0 +1,110 @@
+// Renders a stacked bar per scenario: the orange segment is pnpm 12's time,
+// the gray extension is the additional time pnpm 11 takes. Total bar length
+// equals pnpm 11's time, so you can see at a glance how much faster v12 is.
+
+const getMax = (results) => Math.max(...results.map((r) => r.v11))
+
+// `nodeVersion`, `formattedNow`: see the note in `generate-svg.mjs`.
+export default (results, formattedNow, nodeVersion) => {
+  const v12Color = '#fbae00'
+  const extraColor = '#cccccc'
+
+  const offset = { left: 40, right: 10, top: 35, bottom: 10 }
+  const thickness = 10
+  const separation = 5
+
+  const graph = {
+    x: offset.left,
+    y: offset.top,
+    w: 250,
+    h: results.length * (thickness + separation),
+  }
+
+  const vb = {
+    x: 0,
+    y: 0,
+    w: graph.w + offset.left + offset.right,
+    h: graph.h + offset.top + offset.bottom,
+  }
+
+  const max = getMax(results)
+  const limit = Math.ceil(max / 5) * 5
+  const ratio = graph.w / limit
+
+  const styles = {
+    font: '.font { font-family: sans-serif; }',
+    s3: '.s3 { font-size: 3px; }',
+    s4: '.s4 { font-size: 4px; }',
+    s5: '.s5 { font-size: 5px; }',
+    line: '.line { stroke: #cacaca; }',
+    width: '.width { stroke-width: 0.5; }',
+    text: '.text { fill: #888; }',
+  }
+
+  let svgStr = ''
+  svgStr += '<svg version="1.1" xmlns="http://www.w3.org/2000/svg" '
+  svgStr += `viewBox="${vb.x} ${vb.y} ${vb.w} ${vb.h}">\n`
+
+  svgStr += '  <style>\n'
+  Object.values(styles).forEach((s) => { svgStr += `    ${s}\n` })
+  svgStr += '  </style>\n'
+
+  svgStr += `  <rect x="${vb.x}" y="${vb.y}" width="${vb.w}" height="${vb.h}" fill="#fff"></rect>\n`
+
+  // Legend: orange = pnpm 12, gray = additional time pnpm 11 takes.
+  const legends = [
+    { color: v12Color, label: 'pnpm 12' },
+    { color: extraColor, label: 'additional time pnpm 11 takes' },
+  ]
+  legends.forEach((leg, i) => {
+    const radius = 4
+    const x = graph.x + radius + i * 80
+    const y = vb.y + radius + 2
+    svgStr += `  <circle cx="${x}" cy="${y}" r="${radius}" fill="${leg.color}"></circle>\n`
+    svgStr += `  <text x="${x + radius + 2}" y="${y + 1}" class="font s4" dominant-baseline="middle" text-anchor="start">${leg.label}</text>\n`
+  })
+
+  const graphLines = [0, 0.2, 0.4, 0.6, 0.8, 1].map((f) => graph.x + limit * ratio * f)
+  let baseGraphLine = ''
+  graphLines.forEach((gl, i) => {
+    const isBase = i === 0
+    const compositeClass = isBase ? 'line' : 'line width'
+    const y1 = graph.y - separation
+    const y2 = y1 + graph.h
+    const line = `  <line x1="${gl}" y1="${y1}" x2="${gl}" y2="${y2}" class="${compositeClass}"></line>\n`
+    if (isBase) baseGraphLine = line
+    else svgStr += line
+
+    const num = limit * (i / (graphLines.length - 1))
+    svgStr += `  <text x="${gl}" y="${graph.y - 7}" class="font s5 text" text-anchor="middle">${num}</text>\n`
+    svgStr += `  <text x="${gl}" y="${y2 + 5}" class="font s5 text" text-anchor="middle">${num}</text>\n`
+  })
+
+  svgStr += `  <text x="${graph.x + graph.w}" y="${graph.y - 15}" class="font s4 text" font-style="italic" text-anchor="end">Installation time in seconds (lower is better)</text>\n`
+
+  // Stacked bars: full v11 length in gray, v12 portion overlaid in orange.
+  results.forEach((r, indexT) => {
+    const y = graph.y + (thickness + separation) * indexT
+    const v11Len = Math.max(1, Math.round(r.v11 * ratio))
+    const v12Len = Math.max(1, Math.round(r.v12 * ratio))
+    svgStr += `  <rect x="${graph.x}" y="${y}" width="${v11Len}" height="${thickness}" fill="${extraColor}" rx="1" ry="1"></rect>\n`
+    svgStr += `  <rect x="${graph.x}" y="${y}" width="${v12Len}" height="${thickness}" fill="${v12Color}" rx="1" ry="1"></rect>\n`
+  })
+
+  svgStr += baseGraphLine
+
+  // Labels on the left, centered vertically on each bar.
+  const labelSpacing = 4
+  results.forEach((r, indexT) => {
+    const labelBlockOffset = ((r.label.length - 1) * labelSpacing) / 2
+    r.label.forEach((line, indexP) => {
+      const y = graph.y + (thickness + separation) * indexT + thickness / 2 - labelBlockOffset + indexP * labelSpacing
+      svgStr += `  <text x="${graph.x - 2}" y="${y}" class="font s4" dominant-baseline="middle" text-anchor="end">${line}</text>\n`
+    })
+  })
+
+  svgStr += `  <text x="${graph.x + graph.w}" y="${vb.h - 2}" class="font s4 text" text-anchor="end">Tests were run using Node.js ${nodeVersion} at: ${formattedNow}</text>\n`
+
+  svgStr += '</svg>\n'
+  return svgStr
+}

--- a/scripts/benchmarks/generate-stacked-svg.mjs
+++ b/scripts/benchmarks/generate-stacked-svg.mjs
@@ -2,7 +2,10 @@
 // the gray extension is the additional time pnpm 11 takes. Total bar length
 // equals pnpm 11's time, so you can see at a glance how much faster v12 is.
 
-const getMax = (results) => Math.max(...results.map((r) => r.v11))
+// Both releases, not just pnpm 11: the gray bar is normally the longer of the
+// two, but nothing guarantees it. Scaling to v11 alone would send a scenario
+// where pnpm 12 came out slower straight off the right edge of the graph.
+const getMax = (results) => Math.max(...results.flatMap(({ v11, v12 }) => [v11, v12]))
 
 // `nodeVersion`, `formattedNow`: see the note in `generate-svg.mjs`.
 export default (results, formattedNow, nodeVersion) => {

--- a/scripts/benchmarks/generate-svg.mjs
+++ b/scripts/benchmarks/generate-svg.mjs
@@ -1,0 +1,237 @@
+// Draws the grouped bar chart the benchmark page carries. Moved here from
+// https://github.com/pnpm/benchmarks, which now publishes only the numbers:
+// what a bar is called and what colour it is drawn in is this site's business,
+// and it changes far more often than the measurement does.
+
+// Results are either a number (simple bar) or { primary, secondary } where
+// the secondary value is rendered behind the primary in a different color
+// (used for the pnpm 11/12 stacked bar).
+const getHighestNumber = (resultArrays) => {
+  let max = 0
+  for (const row of resultArrays) {
+    for (const val of row) {
+      if (typeof val === 'number') {
+        if (val > max) max = val
+      } else if (val) {
+        if (val.primary > max) max = val.primary
+        if (val.secondary > max) max = val.secondary
+      }
+    }
+  }
+  return max
+}
+
+// `nodeVersion` and `formattedNow` describe the run these numbers come from,
+// not this one: the chart is drawn on a machine that measured nothing, so
+// neither can be read off the process drawing it.
+export default (resultArrays, pms, tests, formattedNow, nodeVersion) => {
+  let svgStr = ''
+  // Expand stacked PM slots into two legend entries (primary + extra).
+  const legendEntries = pms.flatMap((pm) => pm.stacked
+    ? [
+        { color: pm.color, legend: pm.legend, version: pm.version, displayVersion: pm.displayVersion },
+        { color: pm.extraColor, legend: pm.extraLegend, noVersion: true },
+      ]
+    : [pm]
+  )
+  // empty areas next to the graph. The top has to hold the legend, the axis
+  // explanation and the scale, each on a line of its own: the explanation is
+  // anchored to the right edge and was drawn through the version under the
+  // last legend entry.
+  const offset = {
+    left: 40,
+    right: 10,
+    top: 43,
+    bottom: 10
+  }
+  // thickness of bars
+  const thickness = 6
+  // spacing between bars
+  const spacing = 0.5
+  // spacing between groups of bars
+  const separation = 4
+  // rectangle in which the graph will be drawn
+  const graph = {
+    x: offset.left,
+    y: offset.top,
+    w: 250,
+    h: tests.length * pms.length * (thickness + spacing) +
+      (tests.length - 1) * separation +
+      separation * 2 // extra white space above first bar and below last bar
+  }
+  // viewbox dimensions
+  const vb = {
+    x: 0,
+    y: 0,
+    w: graph.w +
+      offset.left +
+      offset.right,
+    h: graph.h + offset.top + offset.bottom
+  }
+  // get the highest number of the results so
+  // that the graph can be scaled accordingly
+  const max = getHighestNumber(resultArrays)
+  // upper limit of graph is the highest result rounded
+  // up to the nearest number divisible by 5
+  const limit = Math.ceil(max / 5) * 5
+  const ratio = graph.w / limit
+  const styles = {
+    font: '.font { font-family: sans-serif; }',
+    s3: '.s3 { font-size: 3px; }',
+    s4: '.s4 { font-size: 4px; }',
+    s5: '.s5 { font-size: 5px; }',
+    line: '.line { stroke: #cacaca; }',
+    width: '.width { stroke-width: 0.5; }',
+    text: '.text { fill: #888; }'
+  }
+
+  svgStr += '<svg version="1.1" xmlns="http://www.w3.org/2000/svg" '
+  svgStr += `viewBox="${vb.x} ${vb.y} ${vb.w} ${vb.h}">` + '\n'
+
+  // add styles
+  svgStr += '  <style>' + '\n'
+  Object.values(styles).forEach((style) => {
+    svgStr += `    ${style}` + '\n'
+  })
+  svgStr += '  </style>' + '\n'
+
+  // add white background
+  svgStr += `  <rect x="${vb.x}" y="${vb.y}" width="${vb.w}" height="${vb.h}" fill="${'#fff'}"></rect>` + '\n'
+
+  // uncomment to color the entire view box for debugging
+  // svgStr += `<rect x="${vb.x}" y="${vb.y}" width="${vb.w}" height="${vb.h}" fill="${'#eaeaea'}"></rect>` + '\n'
+
+  // draw legend
+  // Wider spacing when stacking adds long "extra" entries; default tight spacing for simple charts.
+  const legendStepX = legendEntries.length > pms.length ? 36 : 16
+  legendEntries.forEach((entry, index) => {
+    const radius = 4
+    const x = graph.x + radius + legendStepX * index
+    const y = vb.y + radius + 2
+    svgStr += `  <circle cx="${x}" cy="${y}" r="${radius}" fill="${entry.color}"></circle>` + '\n'
+
+    const anchor = 'middle'
+    let textY = y + radius + 4
+    svgStr += `  <text x="${x}" y="${textY}" class="font s4" text-anchor="${anchor}">${entry.legend}</text>` + '\n'
+
+    if (!entry.noVersion) {
+      const text = `v${entry.displayVersion ?? entry.version}`
+      textY += 4
+      svgStr += `  <text x="${x}" y="${textY}" class="font s3" text-anchor="${anchor}">${text}</text>` + '\n'
+    }
+  })
+
+  const graphLines = [
+    graph.x + limit * ratio * 0,
+    graph.x + limit * ratio * 0.2,
+    graph.x + limit * ratio * 0.4,
+    graph.x + limit * ratio * 0.6,
+    graph.x + limit * ratio * 0.8,
+    graph.x + limit * ratio * 1
+  ]
+  let baseGraphLine = ''
+
+  // draw graph lines
+  graphLines.forEach((graphLine, index) => {
+    const isBaseLine = index === 0
+    const compositeClass = isBaseLine
+      ? 'line'
+      : 'line width'
+    const y1 = graph.y - separation
+    const y2 = y1 + graph.h
+    const line = `  <line x1="${graphLine}" y1="${y1}" x2="${graphLine}" y2="${y2}" class="${compositeClass}"></line>` + '\n'
+    // add base graph line after the bars are drawn so that it is drawn over the bars
+    if (isBaseLine) {
+      baseGraphLine = line
+    } else {
+      svgStr += line
+    }
+
+    // add numbers above the graph lines
+    const anchor = 'middle'
+    const x = graphLine
+    let y = graph.y - 7
+    const number = limit * (index / (graphLines.length - 1))
+    svgStr += `  <text x="${x}" y="${y}" class="font s5 text" text-anchor="${anchor}">${number}</text>` + '\n'
+
+    // add numbers below the graph lines
+    y = y2 + 5
+    svgStr += `  <text x="${x}" y="${y}" class="font s5 text" text-anchor="${anchor}">${number}</text>` + '\n'
+  })
+
+  // add axis explanation
+  ;(() => {
+    const text = 'Installation time in seconds (lower is better)'
+    const anchor = 'end'
+    const fontStyle = 'italic'
+    const x = graph.x + graph.w
+    const y = graph.y - 15
+    svgStr += `  <text x="${x}" y="${y}" class="font s4 text" font-style="${fontStyle}" text-anchor="${anchor}">${text}</text>` + '\n'
+  })()
+
+  // draw results as bars
+  resultArrays.forEach((results, indexA) => {
+    results.forEach((result, indexR) => {
+      const pm = pms[indexR]
+      const roundedCorners = 1
+      const y = graph.y +
+        ((thickness + spacing) * indexR) +
+        (((thickness + spacing) * pms.length + separation) * indexA)
+      const x = graph.x
+
+      if (pm.stacked) {
+        const sLen = Math.round((result.secondary ?? 0) * ratio)
+        const pLen = Math.round((result.primary ?? 0) * ratio)
+        if (sLen > 0) {
+          svgStr += `  <rect x="${x}" y="${y}" width="${sLen}" height="${thickness}" fill="${pm.extraColor}" rx="${roundedCorners}" ry="${roundedCorners}"></rect>` + '\n'
+        }
+        if (pLen > 0) {
+          svgStr += `  <rect x="${x}" y="${y}" width="${pLen}" height="${thickness}" fill="${pm.color}" rx="${roundedCorners}" ry="${roundedCorners}"></rect>` + '\n'
+        }
+      } else {
+        const length = Math.round(result * ratio)
+        svgStr += `  <rect x="${x}" y="${y}" width="${length}" height="${thickness}" fill="${pm.color}" rx="${roundedCorners}" ry="${roundedCorners}"></rect>` + '\n'
+        if (pm.mascot && result > 0) {
+          const mascotX = x + length + 2
+          const mascotY = y + thickness / 2
+          svgStr += `  <text x="${mascotX}" y="${mascotY}" class="font" font-size="7" dominant-baseline="central">${pm.mascot}</text>` + '\n'
+        }
+      }
+    })
+  })
+
+  // draw base graph line over the bars
+  svgStr += baseGraphLine
+
+  // next to each bar group specify the properties of the test
+  const groupHeight = thickness * pms.length + spacing * (pms.length - 1)
+  const groupCenter = groupHeight / 2
+  const labelSpacing = 4
+  tests.forEach((properties, indexT) => {
+    const labelBlockOffset = ((properties.length - 1) * labelSpacing) / 2
+    properties.forEach((property, indexP) => {
+      const baseline = 'middle'
+      const anchor = 'end'
+      const x = graph.x - 2
+      const y = graph.y +
+        ((thickness + spacing) * pms.length + separation) * indexT +
+        groupCenter -
+        labelBlockOffset +
+        indexP * labelSpacing
+      svgStr += `  <text x="${x}" y="${y}" class="font s4" dominant-baseline="${baseline}" text-anchor="${anchor}">${property}</text>` + '\n'
+    })
+  })
+
+  // add node version
+  ;(() => {
+    const text = `Tests were run using Node.js ${nodeVersion} at: ${formattedNow}`
+    const anchor = 'end'
+    const x = graph.x + graph.w
+    const y = vb.h - 2
+    svgStr += `  <text x="${x}" y="${y}" class="font s4 text" text-anchor="${anchor}">${text}</text>` + '\n'
+  })()
+
+  svgStr += `</svg>` + '\n'
+
+  return svgStr
+}

--- a/scripts/benchmarks/page.mjs
+++ b/scripts/benchmarks/page.mjs
@@ -1,0 +1,293 @@
+// Turns the numbers https://github.com/pnpm/benchmarks publishes into the page
+// at /benchmarks and the charts it carries. Everything a reader sees is decided
+// here or in `columns.mjs`; the manifest this reads is only measurements.
+
+import crypto from 'node:crypto'
+import generateSvg from './generate-svg.mjs'
+import generateStackedSvg from './generate-stacked-svg.mjs'
+import prettyMs from './pretty-ms.mjs'
+import {
+  packageManagerColumns,
+  mainChartBars,
+  nodeVersionManagerColumns,
+  installScenarios,
+  nodeVersionScenarios,
+  fixtureHeadings,
+} from './columns.mjs'
+
+/**
+ * Renders the page and its charts.
+ *
+ * Returns the markdown and every chart it refers to, rather than writing
+ * anything: what the files are called and where they go is the caller's.
+ */
+export default function renderBenchmarksPage (manifest) {
+  assertManifest(manifest)
+  const measuredAt = formatMeasuredAt(manifest.measuredAt)
+  const chart = chartWriter(measuredAt, manifest.node)
+
+  const sections = []
+  for (const fixture of manifest.fixtures) {
+    sections.push(...fixtureSections(fixture, chart))
+  }
+  sections.push(nodeVersionsSection(manifest.nodeVersions, chart))
+
+  const markdown = [
+    introduction(manifest, measuredAt),
+    scenarioKey(manifest.fixtures[0]),
+    ...sections,
+  ].join('\n\n') + '\n'
+
+  return { markdown, charts: chart.written }
+}
+
+/**
+ * Collects the charts as they are drawn and hands back the `?v=` URL for each.
+ *
+ * The hash is of the chart's own bytes, so a page and the chart it points at
+ * can never disagree: redraw the chart and the URL in the markdown moves with
+ * it, which is what stops a browser (or a CDN) serving last week's picture
+ * under this week's page.
+ */
+function chartWriter (measuredAt, nodeVersion) {
+  const written = []
+  return {
+    written,
+    measuredAt,
+    nodeVersion,
+    add (name, svg) {
+      written.push({ name, svg })
+      const hash = crypto.createHash('sha256').update(svg).digest('hex').slice(0, 8)
+      return `/img/benchmarks/${name}.svg?v=${hash}`
+    },
+  }
+}
+
+function introduction (manifest, measuredAt) {
+  const { roundTripMs, bandwidthMbps } = manifest.network
+  return `# Benchmarks of JavaScript Package Managers
+
+**Last benchmarked at**: _${measuredAt}_ (_weekly_ updated).
+
+This benchmark compares the performance of npm and pnpm. Every package manager installs through the same [pnpr](/pnpr) registry (v${manifest.pnpr}) across an emulated ${roundTripMs}ms round trip at ${bandwidthMbps} Mbit/s, so they all face one registry over one reproducible network instead of whatever link the benchmark machine happens to have. pnpm 12 is measured twice: once on its own, and once resolving its dependency graph [on the server](/pnpr/install-acceleration) instead of walking it itself. The page also compares how fast pnpm, fnm, and nvm install and switch Node.js versions.
+
+About the setup:
+
+- **Every manager crosses the same link.** The round trip is applied to all of them, and to pnpm's resolution requests as well, so no client gets a cheaper connection than another. The bandwidth cap is the link's, shared across all of a manager's connections — opening more connections in parallel spreads the latency, as on a real network, but cannot multiply the ${bandwidthMbps} Mbit/s.
+- **pnpr's cache is warmed before anything is timed** — with the fixture's dependency graph and with the one the update row installs — so no manager pays to pull either into the registry on behalf of the ones measured after it.
+- **Server-side resolution pays off when there is a graph to resolve.** Resolving one means walking it level by level, and each level costs a round trip, so the cost is roughly the depth of the graph times the latency. pnpr does that walk next to the registry — its own metadata access stays on loopback, the co-located shape the [pnpm monorepo's integrated benchmark](https://github.com/pnpm/pnpm) measures — and answers with the whole resolved lockfile at once, which is why the rows without a lockfile, and the row that changes dependencies, are the ones where it pulls ahead of plain pnpm.
+- **The lockfile is trusted, so both managers are asked for the same work.** pnpm verifies a lockfile against the registry before installing it — a supply-chain pass that costs a packument per package, and one npm doesn't perform. The rows with a lockfile run every pnpm column with [\`trustLockfile\`](/settings#trustlockfile), so what they compare is the install rather than a safety check only one participant was asked for. It is on by default outside this benchmark, and pnpm's own resolution still applies its release-age policy on the rows that resolve.
+- **With an up-to-date lockfile there is nothing to resolve.** pnpm doesn't ask the server then, so those rows measure the same install in both pnpm 12 columns.
+- **The update row starts from a warm cache.** The rows before it delete the cache twice, and how much of it a manager has rebuilt by the time update runs is an accident of row ordering — restoring a warm \`node_modules\` without touching the registry leaves the cache cold, while re-downloading the whole graph on the same row refills it. A developer who bumps versions has the cache their installs left, so before the update is timed, every manager re-fetches the base graph once, untimed.
+- Tarballs are still fetched by the client, in parallel and directly, on every row.`
+}
+
+/**
+ * The lines under the table that map each scenario onto something a reader
+ * does, in the order the table puts the rows in.
+ */
+function scenarioKey (fixture) {
+  const items = orderScenarios(fixture)
+    .map((test) => `- ${installScenarios[test].explanation}`)
+    .join('\n')
+  return `Each row's label lists which of \`cache\`, \`trusted lockfile\`, and \`node_modules\` are warm/present before install runs. Quick mapping to the real world (ordered from slowest to fastest scenario):
+
+${items}`
+}
+
+/**
+ * The scenarios slowest first, measured by the first column — the reference
+ * every other column is read against. `update` is a different kind of action,
+ * so it is pinned at the end rather than sorted among the installs.
+ */
+function orderScenarios (fixture, byKey = packageManagerColumns[0].key) {
+  const measured = fixture.packageManagers[byKey].results
+  const installs = Object.keys(installScenarios)
+    .filter((test) => test !== 'updatedDependencies')
+    .sort((a, b) => (measured[b] ?? 0) - (measured[a] ?? 0))
+  return [...installs, 'updatedDependencies']
+}
+
+function fixtureSections (fixture, chart) {
+  const heading = fixtureHeadings[fixture.name]
+  if (!heading) {
+    throw new Error(
+      `The manifest carries a fixture named ${fixture.name}, which \`columns.mjs\` has no heading for. ` +
+      'Add one there, or the page would introduce it with nothing.'
+    )
+  }
+  const tests = orderScenarios(fixture)
+  const measured = (key) => fixture.packageManagers[key]
+
+  const mainTable = installTable(packageManagerColumns, tests, measured)
+  const bars = mainChartBars.map((bar) => resolveBar(bar, measured))
+  const mainResults = tests.map((test) => bars.map((bar) => (bar.stacked
+    ? {
+        primary: toSeconds(measured(bar.primaryKey).results[test]),
+        secondary: toSeconds(measured(bar.secondaryKey).results[test]),
+      }
+    : toSeconds(measured(bar.key).results[test]))))
+  const mainSvg = generateSvg(
+    mainResults,
+    bars,
+    tests.map((test) => installScenarios[test].label),
+    chart.measuredAt,
+    chart.nodeVersion,
+  )
+  const mainSrc = chart.add(fixture.name, mainSvg)
+
+  // pnpm against pnpm. Only the two releases belong here: `pnpm_pnpr` is the
+  // same pnpm as one of them, and putting it in this table would compare a
+  // registry feature against a release.
+  const pnpmColumns = packageManagerColumns.filter(({ key }) => key === 'pnpm11' || key === 'pnpm12')
+  const pnpmTests = orderScenarios(fixture, 'pnpm11')
+  const pnpmTable = installTable(pnpmColumns, pnpmTests, measured)
+  const pnpmSvg = generateStackedSvg(
+    pnpmTests.map((test) => ({
+      label: installScenarios[test].label,
+      v11: toSeconds(measured('pnpm11').results[test]),
+      v12: toSeconds(measured('pnpm12').results[test]),
+    })),
+    chart.measuredAt,
+    chart.nodeVersion,
+  )
+  const pnpmSrc = chart.add(`${fixture.name}-pnpm`, pnpmSvg)
+
+  return [
+    `## ${heading.title}
+
+${heading.intro}
+
+${mainTable}
+
+<img alt="Graph of the ${fixture.name} results" src="${mainSrc}" />`,
+    `### ${pnpmColumns.map((column) => column.legend).join(' vs ')}
+
+pnpm v12 will use a new installation engine for fetching and linking written in Rust. See [pacquet](https://github.com/pnpm/pacquet).
+
+${pnpmTable}
+
+<img alt="Graph comparing pnpm versions on the ${fixture.name} fixture" src="${pnpmSrc}" />`,
+  ]
+}
+
+function installTable (columns, tests, measured) {
+  const legends = columns.map((column) => column.mdLegend ?? column.legend).join(' | ')
+  const separator = columns.map(() => '---').join(' | ')
+  const rows = tests.map((test) => {
+    const { action, cache, lockfile, nodeModules } = installScenarios[test]
+    const values = columns.map((column) => prettyMs(measured(column.key).results[test])).join(' | ')
+    return `| ${action} | ${cache} | ${lockfile} | ${nodeModules} | ${values} |`
+  }).join('\n')
+  return `| action  | cache | trusted lockfile | node_modules| ${legends} |
+| ---     | ---   | ---      | ---         | ${separator} |
+${rows}`
+}
+
+/** Fills a chart bar in with the colours and the version it is drawn with. */
+function resolveBar (bar, measured) {
+  const column = (key) => {
+    const found = packageManagerColumns.find((candidate) => candidate.key === key)
+    if (!found) {
+      throw new Error(`The main chart draws ${key}, which is not one of the columns in \`columns.mjs\`.`)
+    }
+    return found
+  }
+  if (!bar.stacked) {
+    return { ...column(bar.key), key: bar.key, version: measured(bar.key).version }
+  }
+  const primary = column(bar.primaryKey)
+  return {
+    ...bar,
+    color: primary.color,
+    legend: primary.legend,
+    displayVersion: primary.displayVersion,
+    version: measured(bar.primaryKey).version,
+  }
+}
+
+function nodeVersionsSection (nodeVersions, chart) {
+  const { managers } = nodeVersions
+  const columns = nodeVersionManagerColumns
+  const legends = columns.map((column) => column.mdLegend ?? column.legend).join(' | ')
+  const separator = columns.map(() => '---').join(' | ')
+  const rows = Object.entries(nodeVersionScenarios).map(([test, scenario]) => {
+    const values = columns.map((column) => prettyMs(managers[column.key].results[test])).join(' | ')
+    return `| ${scenario.describe(nodeVersions)} | ${values} |`
+  }).join('\n')
+
+  const charted = Object.entries(nodeVersionScenarios).filter(([, scenario]) => scenario.chartLabel)
+  const bars = columns.map((column) => ({ ...column, version: managers[column.key].version }))
+  const svg = generateSvg(
+    charted.map(([test]) => bars.map((bar) => toSeconds(managers[bar.key].results[test]))),
+    bars,
+    charted.map(([, scenario]) => scenario.chartLabel),
+    chart.measuredAt,
+    chart.nodeVersion,
+  )
+  const src = chart.add('node-versions', svg)
+
+  return `## Node.js Version Management
+
+pnpm installs and switches Node.js versions itself, so a separate version manager is not needed. This section compares [\`pnpm runtime set node\`](/cli/runtime) with fnm and nvm.
+
+| scenario | ${legends} |
+| ---      | ${separator} |
+${rows}
+
+<img alt="Graph comparing Node.js version managers on installing Node.js" src="${src}" />
+
+A few things to keep in mind when reading these numbers:
+
+- pnpm keeps Node.js in its content-addressable store and nvm keeps the downloaded tarballs in \`$NVM_DIR/.cache\`, so for both of them installing a version that was installed before needs no download. fnm has no download cache and fetches Node.js again.
+- pnpm doesn't extract the \`npm\`, \`npx\`, and \`corepack\` binaries bundled with Node.js, so on a clean install it downloads and writes fewer files than the other two.
+- Per-project switching costs no command at all in pnpm: the \`node\` on your PATH is a shim that reads the [\`devEngines.runtime\`](/package_json#devenginesruntime) of the project and runs the matching version. fnm and nvm read a \`.node-version\` or \`.nvmrc\` file through a shell hook that fires on \`cd\`, which is what \`fnm exec\` and \`nvm use\` measure in that row. Loading nvm into the shell in the first place is not counted at all here, and it costs more than everything in that row.
+- All three have to materialize the pinned version the first time a project asks for it: pnpm links it from its store, fnm downloads it, nvm unpacks it. The row measures the repeated runs after that.`
+}
+
+/** Charts are drawn in seconds, to one decimal. */
+function toSeconds (milliseconds) {
+  return Math.round(milliseconds / 100) / 10
+}
+
+/**
+ * Formatted in UTC rather than in whatever zone the machine rendering the page
+ * happens to sit in, so re-rendering the same manifest twice produces the same
+ * page.
+ */
+function formatMeasuredAt (iso) {
+  return new Intl.DateTimeFormat('en-US', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+    timeZone: 'UTC',
+  }).format(new Date(iso))
+}
+
+/**
+ * The manifest crosses a repository boundary, so what it is missing is worth
+ * saying plainly. A column with no numbers behind it would otherwise surface as
+ * `undefined` somewhere in the middle of a table.
+ */
+function assertManifest (manifest) {
+  for (const field of ['measuredAt', 'node', 'pnpr', 'network', 'fixtures', 'nodeVersions']) {
+    if (manifest?.[field] == null) {
+      throw new Error(`The benchmark manifest carries no \`${field}\`.`)
+    }
+  }
+  for (const fixture of manifest.fixtures) {
+    for (const { key } of packageManagerColumns) {
+      if (!fixture.packageManagers?.[key]?.results) {
+        throw new Error(
+          `The benchmark manifest has no results for ${key} on the ${fixture.name} fixture. ` +
+          'Either the benchmark stopped measuring it, or the column outlived the measurement — ' +
+          'drop it from `columns.mjs`.'
+        )
+      }
+    }
+  }
+  for (const { key } of nodeVersionManagerColumns) {
+    if (!manifest.nodeVersions.managers?.[key]?.results) {
+      throw new Error(`The benchmark manifest has no Node.js version management results for ${key}.`)
+    }
+  }
+}

--- a/scripts/benchmarks/page.mjs
+++ b/scripts/benchmarks/page.mjs
@@ -265,8 +265,14 @@ function formatMeasuredAt (iso) {
 
 /**
  * The manifest crosses a repository boundary, so what it is missing is worth
- * saying plainly. A column with no numbers behind it would otherwise surface as
- * `undefined` somewhere in the middle of a table.
+ * saying plainly — and worth catching before anything is written rather than
+ * after.
+ *
+ * Every scenario is checked down to the number, not just to the object holding
+ * it. A missing or unmeasurable timing is not an error anywhere downstream: it
+ * formats as `NaN` in a table cell and renders as a `NaN`-wide bar, which is an
+ * SVG that draws nothing and a page that publishes a hole. Failing the render
+ * is the only way that becomes visible.
  */
 function assertManifest (manifest) {
   for (const field of ['measuredAt', 'node', 'pnpr', 'network', 'fixtures', 'nodeVersions']) {
@@ -276,18 +282,35 @@ function assertManifest (manifest) {
   }
   for (const fixture of manifest.fixtures) {
     for (const { key } of packageManagerColumns) {
-      if (!fixture.packageManagers?.[key]?.results) {
+      const results = fixture.packageManagers?.[key]?.results
+      if (!results) {
         throw new Error(
           `The benchmark manifest has no results for ${key} on the ${fixture.name} fixture. ` +
           'Either the benchmark stopped measuring it, or the column outlived the measurement — ' +
           'drop it from `columns.mjs`.'
         )
       }
+      assertTimings(results, Object.keys(installScenarios), `${key} on the ${fixture.name} fixture`)
     }
   }
   for (const { key } of nodeVersionManagerColumns) {
-    if (!manifest.nodeVersions.managers?.[key]?.results) {
+    const results = manifest.nodeVersions.managers?.[key]?.results
+    if (!results) {
       throw new Error(`The benchmark manifest has no Node.js version management results for ${key}.`)
+    }
+    assertTimings(results, Object.keys(nodeVersionScenarios), `${key} in the Node.js section`)
+  }
+}
+
+/** Every scenario the page draws has to be a duration, and durations are finite and not negative. */
+function assertTimings (results, scenarios, subject) {
+  for (const scenario of scenarios) {
+    const value = results[scenario]
+    if (!Number.isFinite(value) || value < 0) {
+      throw new Error(
+        `The benchmark manifest reports \`${scenario}\` for ${subject} as ${JSON.stringify(value)}, ` +
+        'which is not a duration the page can draw.'
+      )
     }
   }
 }

--- a/scripts/benchmarks/page.test.mjs
+++ b/scripts/benchmarks/page.test.mjs
@@ -1,0 +1,129 @@
+// The contracts the renderer has to hold that reading it doesn't reveal.
+//
+// Run with `pnpm test`. Node's own test runner, no dependencies — the sync runs
+// on a bare Node.js in CI, and a test that needed an install would be testing a
+// setup the real thing never has.
+
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import crypto from 'node:crypto'
+import renderBenchmarksPage from './page.mjs'
+import prettyMs from './pretty-ms.mjs'
+import {
+  packageManagerColumns,
+  nodeVersionManagerColumns,
+  installScenarios,
+  nodeVersionScenarios,
+  fixtureHeadings,
+} from './columns.mjs'
+
+/**
+ * A manifest shaped like the one pnpm/benchmarks publishes, built from the
+ * columns actually configured — so adding a column can't leave the tests
+ * exercising a shape the renderer no longer sees.
+ */
+function manifest () {
+  const timings = (scenarios) => Object.fromEntries(
+    Object.keys(scenarios).map((scenario, i) => [scenario, (i + 1) * 1000]),
+  )
+  return {
+    measuredAt: '2026-08-23T03:38:00.000Z',
+    node: 'v24.19.0',
+    pnpr: '0.1.0-alpha.7',
+    network: { roundTripMs: 50, bandwidthMbps: 200 },
+    fixtures: [{
+      name: Object.keys(fixtureHeadings)[0],
+      packageManagers: Object.fromEntries(packageManagerColumns.map(({ key }, i) => [
+        key,
+        { version: `1.2.${i}`, results: timings(installScenarios) },
+      ])),
+    }],
+    nodeVersions: {
+      primary: '24',
+      secondary: '22',
+      managers: Object.fromEntries(nodeVersionManagerColumns.map(({ key }, i) => [
+        key,
+        { version: `3.4.${i}`, results: timings(nodeVersionScenarios) },
+      ])),
+    },
+  }
+}
+
+test('rendering the same manifest twice produces the same bytes', () => {
+  // The sync commits what it renders. Anything non-deterministic in here — a
+  // date read from the clock, a set iterated in hash order — would show up as a
+  // diff every week that no measurement is behind.
+  const first = renderBenchmarksPage(manifest())
+  const second = renderBenchmarksPage(manifest())
+  assert.equal(first.markdown, second.markdown)
+  assert.deepEqual(first.charts, second.charts)
+})
+
+test('the page is dated from the manifest, not from the clock', () => {
+  const { markdown } = renderBenchmarksPage(manifest())
+  assert.match(markdown, /\*\*Last benchmarked at\*\*: _Aug 23, 2026/)
+})
+
+test("each chart's ?v= hash is the hash of that chart", () => {
+  // What keeps a page from pointing at a cached copy of a chart it no longer
+  // matches.
+  const { markdown, charts } = renderBenchmarksPage(manifest())
+  assert.ok(charts.length > 0)
+  for (const { name, svg } of charts) {
+    const hash = crypto.createHash('sha256').update(svg).digest('hex').slice(0, 8)
+    assert.ok(
+      markdown.includes(`/img/benchmarks/${name}.svg?v=${hash}`),
+      `${name}.svg is not referenced at its own hash`,
+    )
+  }
+})
+
+test('every configured column reaches the page', () => {
+  const { markdown } = renderBenchmarksPage(manifest())
+  for (const column of packageManagerColumns) {
+    assert.ok(markdown.includes(column.mdLegend ?? column.legend), `${column.key} is missing`)
+  }
+})
+
+test('a manifest missing a column is refused', () => {
+  const broken = manifest()
+  delete broken.fixtures[0].packageManagers[packageManagerColumns.at(-1).key]
+  assert.throws(() => renderBenchmarksPage(broken), /has no results for/)
+})
+
+test('a scenario that is not a duration is refused', () => {
+  // The failure this exists for is silent: an absent timing formats as `NaN` in
+  // a table cell and draws a `NaN`-wide bar, publishing a hole rather than an
+  // error.
+  for (const value of [undefined, null, NaN, -1, 'fast']) {
+    const broken = manifest()
+    broken.fixtures[0].packageManagers[packageManagerColumns[0].key]
+      .results[Object.keys(installScenarios)[0]] = value
+    assert.throws(
+      () => renderBenchmarksPage(broken),
+      /is not a duration the page can draw/,
+      `${JSON.stringify(value)} was accepted as a timing`,
+    )
+  }
+})
+
+test('a Node.js version manager missing a scenario is refused', () => {
+  const broken = manifest()
+  delete broken.nodeVersions.managers[nodeVersionManagerColumns[0].key]
+    .results[Object.keys(nodeVersionScenarios)[0]]
+  assert.throws(() => renderBenchmarksPage(broken), /is not a duration the page can draw/)
+})
+
+test('durations format the way pretty-ms formatted them', () => {
+  // `pretty-ms.mjs` stands in for the dependency the page used to carry, and
+  // the numbers it prints are the published result. Truncation is the part
+  // worth pinning: 1051ms is a second, not 1.1 seconds.
+  assert.equal(prettyMs(15), '15ms')
+  assert.equal(prettyMs(964), '964ms')
+  assert.equal(prettyMs(1051), '1s')
+  assert.equal(prettyMs(2400), '2.4s')
+  assert.equal(prettyMs(11547), '11.5s')
+  assert.equal(prettyMs(45939), '45.9s')
+  assert.equal(prettyMs(60000), '1m')
+  assert.equal(prettyMs(62400), '1m 2.4s')
+})

--- a/scripts/benchmarks/pretty-ms.mjs
+++ b/scripts/benchmarks/pretty-ms.mjs
@@ -6,6 +6,14 @@
 // Sub-second durations are reported whole, in milliseconds; anything longer is
 // reported in seconds with one decimal, truncated rather than rounded, and a
 // trailing `.0` dropped — so 1051ms reads as `1s`, not `1.1s`.
+//
+// The seconds are taken from the integer remainder rather than from
+// `ms / 1000 % 60`, which is where `pretty-ms` itself gets them. That
+// expression is inexact above a minute — 62400 comes back as 2.3999999999999986
+// — and truncating it publishes `1m 2.3s` for a duration of 62.4 seconds. No
+// number on the page crosses a minute today, so this changes nothing that is
+// currently published; it is simply not worth reproducing a rounding bug in
+// order to match a dependency we no longer have.
 export default function prettyMs (milliseconds) {
   if (milliseconds < 1000) {
     return `${Math.trunc(milliseconds)}ms`
@@ -15,7 +23,7 @@ export default function prettyMs (milliseconds) {
   const minutes = Math.trunc(milliseconds / 60000)
   if (minutes > 0) parts.push(`${minutes}m`)
 
-  const seconds = (milliseconds / 1000) % 60
+  const seconds = (milliseconds % 60000) / 1000
   // Truncated to one decimal: a number the benchmark measured should never be
   // rounded up into a faster-looking neighbour's territory.
   const truncated = (Math.floor(seconds * 10 + Number.EPSILON) / 10).toFixed(1)

--- a/scripts/benchmarks/pretty-ms.mjs
+++ b/scripts/benchmarks/pretty-ms.mjs
@@ -1,0 +1,26 @@
+// The `pretty-ms` formatting the benchmark page has always used, as much of it
+// as a duration under an hour needs. It lives here rather than in
+// `package.json` because the sync script runs on a bare Node.js in CI, with
+// the site's dependencies deliberately not installed.
+//
+// Sub-second durations are reported whole, in milliseconds; anything longer is
+// reported in seconds with one decimal, truncated rather than rounded, and a
+// trailing `.0` dropped — so 1051ms reads as `1s`, not `1.1s`.
+export default function prettyMs (milliseconds) {
+  if (milliseconds < 1000) {
+    return `${Math.trunc(milliseconds)}ms`
+  }
+
+  const parts = []
+  const minutes = Math.trunc(milliseconds / 60000)
+  if (minutes > 0) parts.push(`${minutes}m`)
+
+  const seconds = (milliseconds / 1000) % 60
+  // Truncated to one decimal: a number the benchmark measured should never be
+  // rounded up into a faster-looking neighbour's territory.
+  const truncated = (Math.floor(seconds * 10 + Number.EPSILON) / 10).toFixed(1)
+  const secondsString = truncated.replace(/\.0+$/, '')
+  if (secondsString !== '0') parts.push(`${secondsString}s`)
+
+  return parts.length > 0 ? parts.join(' ') : '0ms'
+}

--- a/scripts/update-benchmarks.mjs
+++ b/scripts/update-benchmarks.mjs
@@ -1,107 +1,70 @@
-// Pulls the benchmark page and the charts it refers to from the repo that
-// measures them, https://github.com/pnpm/benchmarks, and writes them into this
-// site. Nothing is measured here: running the benchmarks takes hours and needs
-// a machine that is not doing anything else, which a site build is not.
+// Rebuilds the benchmark page from the numbers the repo that measures them
+// publishes, https://github.com/pnpm/benchmarks. Nothing is measured here:
+// running the benchmarks takes hours and needs a machine that is not doing
+// anything else, which a site build is not.
+//
+// That repo publishes one file — `benchmarks.json`, the numbers together with
+// the versions and the conditions they were measured under. What the page says
+// about them, which columns it carries and what the charts look like are all
+// decided in `scripts/benchmarks/`, so changing the wording of the page is an
+// edit in this repository rather than a benchmark run in the other one.
 
 import fs from 'node:fs';
 import path from 'node:path';
+import renderBenchmarksPage from './benchmarks/page.mjs';
 
 const REPO = process.env.BENCHMARKS_REPO ?? 'pnpm/benchmarks';
 const REF = process.env.BENCHMARKS_REF ?? 'main';
+// A local checkout to read instead of the published one, for trying out a
+// change to the page against numbers that aren't merged yet.
+const LOCAL_MANIFEST = process.env.BENCHMARKS_MANIFEST;
 
 const SCRIPT_DIR = path.dirname(new URL(import.meta.url).pathname);
 const PROJECT_ROOT = path.resolve(SCRIPT_DIR, '..');
 const PAGE_FILE = path.join(PROJECT_ROOT, 'src', 'pages', 'benchmarks.md');
 const IMGS_DIR = path.join(PROJECT_ROOT, 'static', 'img', 'benchmarks');
 
-// Where the charts sit in the source repo. It publishes them under the path the
-// page points at, so the two need no reconciling.
-const SOURCE_PAGE = 'benchmarks.md';
-const sourceImage = (name) => `img/benchmarks/${name}`;
+const MANIFEST_FILE = 'benchmarks.json';
 
-const headers = {
-  accept: 'application/vnd.github+json',
-  // Unauthenticated GitHub requests are rate limited per IP, which a CI runner
-  // shares with everyone else on it.
-  ...(process.env.GITHUB_TOKEN ? { authorization: `Bearer ${process.env.GITHUB_TOKEN}` } : {}),
-};
-
-/**
- * Resolves the ref to the commit behind it, so every file below is read from
- * one snapshot. Reading them from a moving ref one at a time can pick up a page
- * from before a benchmark run and a chart from after it.
- */
-async function resolveCommit() {
-  const res = await fetch(`https://api.github.com/repos/${REPO}/commits/${REF}`, { headers });
-  if (!res.ok) {
-    throw new Error(`Couldn't resolve ${REPO}@${REF}: ${res.status} ${res.statusText}`);
+async function readManifest() {
+  if (LOCAL_MANIFEST) {
+    console.log(`Reading ${LOCAL_MANIFEST}`);
+    return JSON.parse(fs.readFileSync(LOCAL_MANIFEST, 'utf8'));
   }
-  return (await res.json()).sha;
-}
-
-async function fetchFile(file, commit) {
-  const url = `https://raw.githubusercontent.com/${REPO}/${commit}/${file}`;
+  const url = `https://raw.githubusercontent.com/${REPO}/${REF}/${MANIFEST_FILE}`;
+  console.log(`Reading ${REPO}@${REF}`);
   const res = await fetch(url);
-  if (res.status === 404) return null;
-  if (!res.ok) throw new Error(`Couldn't fetch ${url}: ${res.status} ${res.statusText}`);
-  return Buffer.from(await res.arrayBuffer());
-}
-
-/**
- * The page stands on its own where it is published, so its links into this
- * site's docs are absolute. Left that way here they would send a reader on a
- * full page load out of the site and back into it.
- */
-function localizeLinks(md) {
-  return md.replaceAll('https://pnpm.io/', '/');
-}
-
-/** The charts the page asks for, in the order it asks for them. */
-function referencedImages(md) {
-  const names = [...md.matchAll(/\/img\/benchmarks\/([\w.-]+\.svg)/g)].map((m) => m[1]);
-  return [...new Set(names)];
+  if (!res.ok) {
+    throw new Error(`Couldn't fetch ${url}: ${res.status} ${res.statusText}`);
+  }
+  return res.json();
 }
 
 function writeIfChanged(file, content) {
-  if (fs.existsSync(file) && Buffer.compare(fs.readFileSync(file), Buffer.from(content)) === 0) {
+  if (fs.existsSync(file) && fs.readFileSync(file, 'utf8') === content) {
     return false;
   }
-  fs.writeFileSync(file, content);
+  fs.writeFileSync(file, content, 'utf8');
   return true;
 }
 
 async function update() {
-  const commit = await resolveCommit();
-  console.log(`Reading ${REPO}@${commit.slice(0, 7)}`);
-
-  const page = await fetchFile(SOURCE_PAGE, commit);
-  if (!page) throw new Error(`${REPO} has no ${SOURCE_PAGE} to publish`);
-  const md = localizeLinks(page.toString('utf8'));
+  const manifest = await readManifest();
+  const { markdown, charts } = renderBenchmarksPage(manifest);
 
   fs.mkdirSync(IMGS_DIR, { recursive: true });
-  const wanted = referencedImages(md);
-  const missing = [];
   const written = [];
-  for (const name of wanted) {
-    const svg = await fetchFile(sourceImage(name), commit);
-    if (!svg) {
-      missing.push(name);
-      continue;
-    }
-    if (writeIfChanged(path.join(IMGS_DIR, name), svg)) written.push(name);
+  for (const { name, svg } of charts) {
+    if (writeIfChanged(path.join(IMGS_DIR, `${name}.svg`), svg)) written.push(name);
   }
 
   // A chart the page stopped drawing would otherwise be served forever.
-  const stale = fs.readdirSync(IMGS_DIR).filter((name) => !wanted.includes(name));
+  const drawn = new Set(charts.map(({ name }) => `${name}.svg`));
+  const stale = fs.readdirSync(IMGS_DIR).filter((name) => !drawn.has(name));
   for (const name of stale) fs.rmSync(path.join(IMGS_DIR, name));
 
-  const pageChanged = writeIfChanged(PAGE_FILE, md);
+  const pageChanged = writeIfChanged(PAGE_FILE, markdown);
 
-  if (missing.length) {
-    // Not fatal: the page is worth publishing with the charts that do exist,
-    // and this is what a reference left behind by an older run looks like.
-    console.warn(`No chart published for: ${missing.join(', ')} — the page references them anyway`);
-  }
   if (stale.length) console.log(`Removed unreferenced: ${stale.join(', ')}`);
   if (written.length) console.log(`Updated charts: ${written.join(', ')}`);
   console.log(pageChanged ? `Updated ${path.relative(PROJECT_ROOT, PAGE_FILE)}` : 'Page already up to date');

--- a/src/pages/benchmarks.md
+++ b/src/pages/benchmarks.md
@@ -1,64 +1,66 @@
 # Benchmarks of JavaScript Package Managers
 
-**Last benchmarked at**: _Aug 14, 2026, 8:47 AM_ (_daily_ updated).
+**Last benchmarked at**: _Aug 28, 2026, 2:16 PM_ (_weekly_ updated).
 
-This benchmark compares the performance of npm, pnpm, Yarn, Yarn PnP, and Bun (check [Yarn's benchmarks](https://yarnpkg.com/benchmarks) for any other Yarn modes that are not included here). Every package manager installs through the same [pnpr](/pnpr) registry (v0.1.0-alpha.6) across an emulated 50ms round trip at 200 Mbit/s, so they all face one registry over one reproducible network instead of whatever link the benchmark machine happens to have. pnpm is measured twice: once on its own, and once resolving its dependency graph [on the server](/pnpr/install-acceleration) instead of walking it itself. The page also compares how fast pnpm, fnm, and nvm install and switch Node.js versions.
+This benchmark compares the performance of npm and pnpm. Every package manager installs through the same [pnpr](/pnpr) registry (v0.1.0-alpha.7) across an emulated 50ms round trip at 200 Mbit/s, so they all face one registry over one reproducible network instead of whatever link the benchmark machine happens to have. pnpm 12 is measured twice: once on its own, and once resolving its dependency graph [on the server](/pnpr/install-acceleration) instead of walking it itself. The page also compares how fast pnpm, fnm, and nvm install and switch Node.js versions.
 
 About the setup:
 
-- **Every manager crosses the same link.** The round trip is applied to all of them, and to pnpm's resolution requests as well, so no client gets a cheaper connection than another.
-- **pnpr's cache is warmed before anything is timed**, so no manager pays to pull the fixture into the registry on behalf of the ones measured after it.
-- **Server-side resolution pays off when there is a graph to resolve.** Resolving one means walking it level by level, and each level costs a round trip, so the cost is roughly the depth of the graph times the latency. pnpr does that walk next to the registry and answers with the whole resolved lockfile at once, which is why the rows without a lockfile — and the row that changes dependencies — are the ones where it pulls ahead of plain pnpm.
-- **It costs a round trip when there is not.** pnpm asks the server on every install, including the ones where the lockfile is already up to date and there is nothing to work out. The server answers a question it has been asked before from its cache, in a few milliseconds — what the client pays for is the round trip and having the resolved lockfile streamed back, which plain pnpm never pays because it never asks. That is why the rows with a lockfile come out slightly behind plain pnpm instead of level with it.
+- **Every manager crosses the same link.** The round trip is applied to all of them, and to pnpm's resolution requests as well, so no client gets a cheaper connection than another. The bandwidth cap is the link's, shared across all of a manager's connections — opening more connections in parallel spreads the latency, as on a real network, but cannot multiply the 200 Mbit/s.
+- **pnpr's cache is warmed before anything is timed** — with the fixture's dependency graph and with the one the update row installs — so no manager pays to pull either into the registry on behalf of the ones measured after it.
+- **Server-side resolution pays off when there is a graph to resolve.** Resolving one means walking it level by level, and each level costs a round trip, so the cost is roughly the depth of the graph times the latency. pnpr does that walk next to the registry — its own metadata access stays on loopback, the co-located shape the [pnpm monorepo's integrated benchmark](https://github.com/pnpm/pnpm) measures — and answers with the whole resolved lockfile at once, which is why the rows without a lockfile, and the row that changes dependencies, are the ones where it pulls ahead of plain pnpm.
+- **The lockfile is trusted, so both managers are asked for the same work.** pnpm verifies a lockfile against the registry before installing it — a supply-chain pass that costs a packument per package, and one npm doesn't perform. The rows with a lockfile run every pnpm column with [`trustLockfile`](/settings#trustlockfile), so what they compare is the install rather than a safety check only one participant was asked for. It is on by default outside this benchmark, and pnpm's own resolution still applies its release-age policy on the rows that resolve.
+- **With an up-to-date lockfile there is nothing to resolve.** pnpm doesn't ask the server then, so those rows measure the same install in both pnpm 12 columns.
+- **The update row starts from a warm cache.** The rows before it delete the cache twice, and how much of it a manager has rebuilt by the time update runs is an accident of row ordering — restoring a warm `node_modules` without touching the registry leaves the cache cold, while re-downloading the whole graph on the same row refills it. A developer who bumps versions has the cache their installs left, so before the update is timed, every manager re-fetches the base graph once, untimed.
 - Tarballs are still fetched by the client, in parallel and directly, on every row.
 
-Each row's label lists which of `cache`, `lockfile`, and `node_modules` are warm/present before install runs. Quick mapping to the real world (ordered from slowest to fastest scenario):
+Each row's label lists which of `cache`, `trusted lockfile`, and `node_modules` are warm/present before install runs. Quick mapping to the real world (ordered from slowest to fastest scenario):
 
 - `clean`: a brand-new clone — nothing cached, no lockfile, no `node_modules`.
+- `trusted lockfile`: a CI server doing its first install.
 - `cache`: a developer reinstalling without a lockfile.
-- `lockfile`: a CI server doing its first install.
-- `cache+lockfile`: a developer reinstalling a known project.
+- `cache+trusted lockfile`: a developer reinstalling a known project.
 - `cache+node_modules`: the lockfile is deleted and install is run again.
 - `node_modules`: the cache and lockfile are deleted and install is run again.
-- `cache+lockfile+node_modules`: re-running install when nothing has changed.
-- `lockfile+node_modules`: the cache is deleted and install is run again.
-- `update`: dependency versions are bumped in `package.json` and install is run again.
+- `cache+trusted lockfile+node_modules`: re-running install when nothing has changed.
+- `trusted lockfile+node_modules`: the cache is deleted and install is run again.
+- `update`: dependency versions are bumped in `package.json` and install is run again, from a warm cache.
 
 ## Lots of Files
 
 The app's `package.json` [here](https://github.com/pnpm/benchmarks/blob/main/fixtures/alotta-files/package.json)
 
-| action  | cache | lockfile | node_modules| npm | pnpm | [pnpm 🦀](https://github.com/pnpm/pacquet) | [pnpm + pnpr](/pnpr/install-acceleration) | Yarn | Yarn PnP | Bun |
-| ---     | ---   | ---      | ---         | --- | --- | --- | --- | --- | --- | --- |
-| install |   |   |   | 58.4s | 8s | 2s | 5s | 7s | 3.6s | 4.1s |
-| install | ✔ |   |   | 55.4s | 4.6s | 1.2s | 2.7s | 5.5s | 3.6s | 767ms |
-| install |   | ✔ |   | 13.4s | 7s | 2.2s | 5.2s | 4.4s | 1.1s | 1.7s |
-| install | ✔ | ✔ |   | 10.4s | 2.4s | 711ms | 2.7s | 2s | 142ms | 743ms |
-| install | ✔ |   | ✔ | 1.9s | 580ms | 58ms | 602ms | 3.7s | n/a | 1.9s |
-| install |   |   | ✔ | 1.9s | 594ms | 65ms | 604ms | 7.4s | n/a | 3.4s |
-| install | ✔ | ✔ | ✔ | 1.4s | 517ms | 18ms | 456ms | 1.3s | n/a | 45ms |
-| install |   | ✔ | ✔ | 1.4s | 533ms | 73ms | 1.7s | 4.9s | n/a | 46ms |
-| update | n/a | n/a | n/a | 10s | 8.3s | 1.2s | 2.9s | 2.6s | 2.5s | 584ms |
+| action  | cache | trusted lockfile | node_modules| npm | pnpm | [pnpm 🦀](https://github.com/pnpm/pacquet) | [pnpm + pnpr](/pnpr/install-acceleration) |
+| ---     | ---   | ---      | ---         | --- | --- | --- | --- |
+| install |   |   |   | 45.9s | 8.2s | 5s | 3.3s |
+| install |   | ✔ |   | 11.5s | 4.7s | 3.2s | 3.2s |
+| install | ✔ |   |   | 10.9s | 4s | 964ms | 741ms |
+| install | ✔ | ✔ |   | 7.2s | 2.1s | 635ms | 682ms |
+| install | ✔ |   | ✔ | 1.4s | 598ms | 48ms | 53ms |
+| install |   |   | ✔ | 1.4s | 580ms | 67ms | 71ms |
+| install | ✔ | ✔ | ✔ | 1s | 472ms | 15ms | 17ms |
+| install |   | ✔ | ✔ | 1s | 610ms | 63ms | 67ms |
+| update | n/a | n/a | n/a | 3.8s | 3.5s | 949ms | 1s |
 
-<img alt="Graph of the alotta-files results" src="/img/benchmarks/alotta-files.svg?v=ff1f5301" />
+<img alt="Graph of the alotta-files results" src="/img/benchmarks/alotta-files.svg?v=6c57ee02" />
 
 ### pnpm vs pnpm 🦀
 
 pnpm v12 will use a new installation engine for fetching and linking written in Rust. See [pacquet](https://github.com/pnpm/pacquet).
 
-| action  | cache | lockfile | node_modules| pnpm | [pnpm 🦀](https://github.com/pnpm/pacquet) |
+| action  | cache | trusted lockfile | node_modules| pnpm | [pnpm 🦀](https://github.com/pnpm/pacquet) |
 | ---     | ---   | ---      | ---         | --- | --- |
-| install |   |   |   | 8s | 2s |
-| install |   | ✔ |   | 7s | 2.2s |
-| install | ✔ |   |   | 4.6s | 1.2s |
-| install | ✔ | ✔ |   | 2.4s | 711ms |
-| install |   |   | ✔ | 594ms | 65ms |
-| install | ✔ |   | ✔ | 580ms | 58ms |
-| install |   | ✔ | ✔ | 533ms | 73ms |
-| install | ✔ | ✔ | ✔ | 517ms | 18ms |
-| update | n/a | n/a | n/a | 8.3s | 1.2s |
+| install |   |   |   | 8.2s | 5s |
+| install |   | ✔ |   | 4.7s | 3.2s |
+| install | ✔ |   |   | 4s | 964ms |
+| install | ✔ | ✔ |   | 2.1s | 635ms |
+| install |   | ✔ | ✔ | 610ms | 63ms |
+| install | ✔ |   | ✔ | 598ms | 48ms |
+| install |   |   | ✔ | 580ms | 67ms |
+| install | ✔ | ✔ | ✔ | 472ms | 15ms |
+| update | n/a | n/a | n/a | 3.5s | 949ms |
 
-<img alt="Graph comparing pnpm versions on the alotta-files fixture" src="/img/benchmarks/alotta-files-pnpm.svg?v=c8e5f8f8" />
+<img alt="Graph comparing pnpm versions on the alotta-files fixture" src="/img/benchmarks/alotta-files-pnpm.svg?v=547ccef5" />
 
 ## Node.js Version Management
 
@@ -66,11 +68,11 @@ pnpm installs and switches Node.js versions itself, so a separate version manage
 
 | scenario | pnpm 12 | fnm | nvm |
 | ---      | --- | --- | --- |
-| install Node.js 24 with nothing cached | 1s | 2.3s | 3s |
-| install Node.js 24 that was installed before | 189ms | 2.4s | 2.8s |
-| run `node` in a project pinned to Node.js 22 | 8ms | 5ms | 93ms |
+| install Node.js 24 with nothing cached | 1s | 2.3s | 2.7s |
+| install Node.js 24 that was installed before | 146ms | 2.4s | 2.3s |
+| run `node` in a project pinned to Node.js 22 | 8ms | 3ms | 81ms |
 
-<img alt="Graph comparing Node.js version managers on installing Node.js" src="/img/benchmarks/node-versions.svg?v=ce61b813" />
+<img alt="Graph comparing Node.js version managers on installing Node.js" src="/img/benchmarks/node-versions.svg?v=c1cc84f3" />
 
 A few things to keep in mind when reading these numbers:
 

--- a/src/pages/benchmarks.md
+++ b/src/pages/benchmarks.md
@@ -28,7 +28,7 @@ Each row's label lists which of `cache`, `trusted lockfile`, and `node_modules` 
 
 ## Lots of Files
 
-The app's `package.json` [here](https://github.com/pnpm/benchmarks/blob/main/fixtures/alotta-files/package.json)
+The app's [`alotta-files` package.json](https://github.com/pnpm/benchmarks/blob/main/fixtures/alotta-files/package.json)
 
 | action  | cache | trusted lockfile | node_modules| npm | pnpm | [pnpm 🦀](https://github.com/pnpm/pacquet) | [pnpm + pnpr](/pnpr/install-acceleration) |
 | ---     | ---   | ---      | ---         | --- | --- | --- | --- |

--- a/static/img/benchmarks/alotta-files-pnpm.svg
+++ b/static/img/benchmarks/alotta-files-pnpm.svg
@@ -31,38 +31,38 @@
   <text x="290" y="28" class="font s5 text" text-anchor="middle">10</text>
   <text x="290" y="170" class="font s5 text" text-anchor="middle">10</text>
   <text x="290" y="20" class="font s4 text" font-style="italic" text-anchor="end">Installation time in seconds (lower is better)</text>
-  <rect x="40" y="35" width="203" height="10" fill="#cccccc" rx="1" ry="1"></rect>
-  <rect x="40" y="35" width="53" height="10" fill="#fbae00" rx="1" ry="1"></rect>
-  <rect x="40" y="50" width="175" height="10" fill="#cccccc" rx="1" ry="1"></rect>
-  <rect x="40" y="50" width="57" height="10" fill="#fbae00" rx="1" ry="1"></rect>
-  <rect x="40" y="65" width="115" height="10" fill="#cccccc" rx="1" ry="1"></rect>
-  <rect x="40" y="65" width="30" height="10" fill="#fbae00" rx="1" ry="1"></rect>
-  <rect x="40" y="80" width="63" height="10" fill="#cccccc" rx="1" ry="1"></rect>
-  <rect x="40" y="80" width="18" height="10" fill="#fbae00" rx="1" ry="1"></rect>
+  <rect x="40" y="35" width="205" height="10" fill="#cccccc" rx="1" ry="1"></rect>
+  <rect x="40" y="35" width="125" height="10" fill="#fbae00" rx="1" ry="1"></rect>
+  <rect x="40" y="50" width="118" height="10" fill="#cccccc" rx="1" ry="1"></rect>
+  <rect x="40" y="50" width="83" height="10" fill="#fbae00" rx="1" ry="1"></rect>
+  <rect x="40" y="65" width="100" height="10" fill="#cccccc" rx="1" ry="1"></rect>
+  <rect x="40" y="65" width="25" height="10" fill="#fbae00" rx="1" ry="1"></rect>
+  <rect x="40" y="80" width="55" height="10" fill="#cccccc" rx="1" ry="1"></rect>
+  <rect x="40" y="80" width="15" height="10" fill="#fbae00" rx="1" ry="1"></rect>
   <rect x="40" y="95" width="15" height="10" fill="#cccccc" rx="1" ry="1"></rect>
   <rect x="40" y="95" width="3" height="10" fill="#fbae00" rx="1" ry="1"></rect>
   <rect x="40" y="110" width="15" height="10" fill="#cccccc" rx="1" ry="1"></rect>
-  <rect x="40" y="110" width="3" height="10" fill="#fbae00" rx="1" ry="1"></rect>
-  <rect x="40" y="125" width="13" height="10" fill="#cccccc" rx="1" ry="1"></rect>
+  <rect x="40" y="110" width="1" height="10" fill="#fbae00" rx="1" ry="1"></rect>
+  <rect x="40" y="125" width="15" height="10" fill="#cccccc" rx="1" ry="1"></rect>
   <rect x="40" y="125" width="3" height="10" fill="#fbae00" rx="1" ry="1"></rect>
   <rect x="40" y="140" width="13" height="10" fill="#cccccc" rx="1" ry="1"></rect>
   <rect x="40" y="140" width="1" height="10" fill="#fbae00" rx="1" ry="1"></rect>
-  <rect x="40" y="155" width="210" height="10" fill="#cccccc" rx="1" ry="1"></rect>
-  <rect x="40" y="155" width="30" height="10" fill="#fbae00" rx="1" ry="1"></rect>
+  <rect x="40" y="155" width="88" height="10" fill="#cccccc" rx="1" ry="1"></rect>
+  <rect x="40" y="155" width="23" height="10" fill="#fbae00" rx="1" ry="1"></rect>
   <line x1="40" y1="30" x2="40" y2="165" class="line"></line>
   <text x="38" y="40" class="font s4" dominant-baseline="middle" text-anchor="end">clean</text>
-  <text x="38" y="55" class="font s4" dominant-baseline="middle" text-anchor="end">lockfile</text>
+  <text x="38" y="55" class="font s4" dominant-baseline="middle" text-anchor="end">trusted lockfile</text>
   <text x="38" y="70" class="font s4" dominant-baseline="middle" text-anchor="end">cache</text>
   <text x="38" y="83" class="font s4" dominant-baseline="middle" text-anchor="end">cache</text>
-  <text x="38" y="87" class="font s4" dominant-baseline="middle" text-anchor="end">lockfile</text>
-  <text x="38" y="100" class="font s4" dominant-baseline="middle" text-anchor="end">node_modules</text>
+  <text x="38" y="87" class="font s4" dominant-baseline="middle" text-anchor="end">trusted lockfile</text>
+  <text x="38" y="98" class="font s4" dominant-baseline="middle" text-anchor="end">trusted lockfile</text>
+  <text x="38" y="102" class="font s4" dominant-baseline="middle" text-anchor="end">node_modules</text>
   <text x="38" y="113" class="font s4" dominant-baseline="middle" text-anchor="end">cache</text>
   <text x="38" y="117" class="font s4" dominant-baseline="middle" text-anchor="end">node_modules</text>
-  <text x="38" y="128" class="font s4" dominant-baseline="middle" text-anchor="end">lockfile</text>
-  <text x="38" y="132" class="font s4" dominant-baseline="middle" text-anchor="end">node_modules</text>
+  <text x="38" y="130" class="font s4" dominant-baseline="middle" text-anchor="end">node_modules</text>
   <text x="38" y="141" class="font s4" dominant-baseline="middle" text-anchor="end">cache</text>
-  <text x="38" y="145" class="font s4" dominant-baseline="middle" text-anchor="end">lockfile</text>
+  <text x="38" y="145" class="font s4" dominant-baseline="middle" text-anchor="end">trusted lockfile</text>
   <text x="38" y="149" class="font s4" dominant-baseline="middle" text-anchor="end">node_modules</text>
   <text x="38" y="160" class="font s4" dominant-baseline="middle" text-anchor="end">update</text>
-  <text x="290" y="178" class="font s4 text" text-anchor="end">Tests were run using Node.js v24.19.0 at: Aug 14, 2026, 8:47 AM</text>
+  <text x="290" y="178" class="font s4 text" text-anchor="end">Tests were run using Node.js v24.19.0 at: Aug 28, 2026, 2:16 PM</text>
 </svg>

--- a/static/img/benchmarks/alotta-files.svg
+++ b/static/img/benchmarks/alotta-files.svg
@@ -1,4 +1,4 @@
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 385.5">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 210">
   <style>
     .font { font-family: sans-serif; }
     .s3 { font-size: 3px; }
@@ -8,7 +8,7 @@
     .width { stroke-width: 0.5; }
     .text { fill: #888; }
   </style>
-  <rect x="0" y="0" width="300" height="385.5" fill="#fff"></rect>
+  <rect x="0" y="0" width="300" height="210" fill="#fff"></rect>
   <circle cx="44" cy="6" r="4" fill="#cd3731"></circle>
   <text x="44" y="14" class="font s4" text-anchor="middle">npm</text>
   <text x="44" y="18" class="font s3" text-anchor="middle">v12.0.2</text>
@@ -17,97 +17,63 @@
   <text x="80" y="18" class="font s3" text-anchor="middle">v12</text>
   <circle cx="116" cy="6" r="4" fill="#cccccc"></circle>
   <text x="116" y="14" class="font s4" text-anchor="middle">pnpm 11 extra</text>
-  <circle cx="152" cy="6" r="4" fill="#248ebd"></circle>
-  <text x="152" y="14" class="font s4" text-anchor="middle">Yarn</text>
-  <text x="152" y="18" class="font s3" text-anchor="middle">v6.0.0-rc.19</text>
-  <circle cx="188" cy="6" r="4" fill="#40a9ff"></circle>
-  <text x="188" y="14" class="font s4" text-anchor="middle">Yarn PnP</text>
-  <text x="188" y="18" class="font s3" text-anchor="middle">v6.0.0-rc.19</text>
-  <circle cx="224" cy="6" r="4" fill="#e0709a"></circle>
-  <text x="224" y="14" class="font s4" text-anchor="middle">Bun</text>
-  <text x="224" y="18" class="font s3" text-anchor="middle">v1.3.14</text>
   <text x="40" y="36" class="font s5 text" text-anchor="middle">0</text>
-  <text x="40" y="376.5" class="font s5 text" text-anchor="middle">0</text>
-  <line x1="90" y1="39" x2="90" y2="371.5" class="line width"></line>
-  <text x="90" y="36" class="font s5 text" text-anchor="middle">12</text>
-  <text x="90" y="376.5" class="font s5 text" text-anchor="middle">12</text>
-  <line x1="140" y1="39" x2="140" y2="371.5" class="line width"></line>
-  <text x="140" y="36" class="font s5 text" text-anchor="middle">24</text>
-  <text x="140" y="376.5" class="font s5 text" text-anchor="middle">24</text>
-  <line x1="190" y1="39" x2="190" y2="371.5" class="line width"></line>
-  <text x="190" y="36" class="font s5 text" text-anchor="middle">36</text>
-  <text x="190" y="376.5" class="font s5 text" text-anchor="middle">36</text>
-  <line x1="240.00000000000003" y1="39" x2="240.00000000000003" y2="371.5" class="line width"></line>
-  <text x="240.00000000000003" y="36" class="font s5 text" text-anchor="middle">48</text>
-  <text x="240.00000000000003" y="376.5" class="font s5 text" text-anchor="middle">48</text>
-  <line x1="290" y1="39" x2="290" y2="371.5" class="line width"></line>
-  <text x="290" y="36" class="font s5 text" text-anchor="middle">60</text>
-  <text x="290" y="376.5" class="font s5 text" text-anchor="middle">60</text>
+  <text x="40" y="201" class="font s5 text" text-anchor="middle">0</text>
+  <line x1="90" y1="39" x2="90" y2="196" class="line width"></line>
+  <text x="90" y="36" class="font s5 text" text-anchor="middle">10</text>
+  <text x="90" y="201" class="font s5 text" text-anchor="middle">10</text>
+  <line x1="140" y1="39" x2="140" y2="196" class="line width"></line>
+  <text x="140" y="36" class="font s5 text" text-anchor="middle">20</text>
+  <text x="140" y="201" class="font s5 text" text-anchor="middle">20</text>
+  <line x1="190" y1="39" x2="190" y2="196" class="line width"></line>
+  <text x="190" y="36" class="font s5 text" text-anchor="middle">30</text>
+  <text x="190" y="201" class="font s5 text" text-anchor="middle">30</text>
+  <line x1="240" y1="39" x2="240" y2="196" class="line width"></line>
+  <text x="240" y="36" class="font s5 text" text-anchor="middle">40</text>
+  <text x="240" y="201" class="font s5 text" text-anchor="middle">40</text>
+  <line x1="290" y1="39" x2="290" y2="196" class="line width"></line>
+  <text x="290" y="36" class="font s5 text" text-anchor="middle">50</text>
+  <text x="290" y="201" class="font s5 text" text-anchor="middle">50</text>
   <text x="290" y="28" class="font s4 text" font-style="italic" text-anchor="end">Installation time in seconds (lower is better)</text>
-  <rect x="40" y="43" width="244" height="6" fill="#cd3731" rx="1" ry="1"></rect>
-  <rect x="40" y="49.5" width="34" height="6" fill="#cccccc" rx="1" ry="1"></rect>
-  <rect x="40" y="49.5" width="9" height="6" fill="#fbae00" rx="1" ry="1"></rect>
-  <rect x="40" y="56" width="29" height="6" fill="#248ebd" rx="1" ry="1"></rect>
-  <rect x="40" y="62.5" width="15" height="6" fill="#40a9ff" rx="1" ry="1"></rect>
-  <rect x="40" y="69" width="18" height="6" fill="#e0709a" rx="1" ry="1"></rect>
-  <rect x="40" y="79.5" width="231" height="6" fill="#cd3731" rx="1" ry="1"></rect>
-  <rect x="40" y="86" width="19" height="6" fill="#cccccc" rx="1" ry="1"></rect>
-  <rect x="40" y="86" width="5" height="6" fill="#fbae00" rx="1" ry="1"></rect>
-  <rect x="40" y="92.5" width="23" height="6" fill="#248ebd" rx="1" ry="1"></rect>
-  <rect x="40" y="99" width="15" height="6" fill="#40a9ff" rx="1" ry="1"></rect>
-  <rect x="40" y="105.5" width="3" height="6" fill="#e0709a" rx="1" ry="1"></rect>
-  <rect x="40" y="116" width="56" height="6" fill="#cd3731" rx="1" ry="1"></rect>
-  <rect x="40" y="122.5" width="29" height="6" fill="#cccccc" rx="1" ry="1"></rect>
-  <rect x="40" y="122.5" width="10" height="6" fill="#fbae00" rx="1" ry="1"></rect>
-  <rect x="40" y="129" width="19" height="6" fill="#248ebd" rx="1" ry="1"></rect>
-  <rect x="40" y="135.5" width="5" height="6" fill="#40a9ff" rx="1" ry="1"></rect>
-  <rect x="40" y="142" width="8" height="6" fill="#e0709a" rx="1" ry="1"></rect>
-  <rect x="40" y="152.5" width="43" height="6" fill="#cd3731" rx="1" ry="1"></rect>
-  <rect x="40" y="159" width="10" height="6" fill="#cccccc" rx="1" ry="1"></rect>
-  <rect x="40" y="159" width="3" height="6" fill="#fbae00" rx="1" ry="1"></rect>
-  <rect x="40" y="165.5" width="9" height="6" fill="#248ebd" rx="1" ry="1"></rect>
-  <rect x="40" y="172" width="0" height="6" fill="#40a9ff" rx="1" ry="1"></rect>
-  <rect x="40" y="178.5" width="3" height="6" fill="#e0709a" rx="1" ry="1"></rect>
-  <rect x="40" y="189" width="8" height="6" fill="#cd3731" rx="1" ry="1"></rect>
-  <rect x="40" y="195.5" width="3" height="6" fill="#cccccc" rx="1" ry="1"></rect>
-  <rect x="40" y="202" width="16" height="6" fill="#248ebd" rx="1" ry="1"></rect>
-  <rect x="40" y="208.5" width="0" height="6" fill="#40a9ff" rx="1" ry="1"></rect>
-  <rect x="40" y="215" width="8" height="6" fill="#e0709a" rx="1" ry="1"></rect>
-  <rect x="40" y="225.5" width="8" height="6" fill="#cd3731" rx="1" ry="1"></rect>
-  <rect x="40" y="232" width="3" height="6" fill="#cccccc" rx="1" ry="1"></rect>
-  <rect x="40" y="238.5" width="31" height="6" fill="#248ebd" rx="1" ry="1"></rect>
-  <rect x="40" y="245" width="0" height="6" fill="#40a9ff" rx="1" ry="1"></rect>
-  <rect x="40" y="251.5" width="15" height="6" fill="#e0709a" rx="1" ry="1"></rect>
-  <rect x="40" y="262" width="6" height="6" fill="#cd3731" rx="1" ry="1"></rect>
-  <rect x="40" y="268.5" width="2" height="6" fill="#cccccc" rx="1" ry="1"></rect>
-  <rect x="40" y="275" width="5" height="6" fill="#248ebd" rx="1" ry="1"></rect>
-  <rect x="40" y="281.5" width="0" height="6" fill="#40a9ff" rx="1" ry="1"></rect>
-  <rect x="40" y="288" width="0" height="6" fill="#e0709a" rx="1" ry="1"></rect>
-  <rect x="40" y="298.5" width="6" height="6" fill="#cd3731" rx="1" ry="1"></rect>
-  <rect x="40" y="305" width="2" height="6" fill="#cccccc" rx="1" ry="1"></rect>
-  <rect x="40" y="311.5" width="21" height="6" fill="#248ebd" rx="1" ry="1"></rect>
-  <rect x="40" y="318" width="0" height="6" fill="#40a9ff" rx="1" ry="1"></rect>
-  <rect x="40" y="324.5" width="0" height="6" fill="#e0709a" rx="1" ry="1"></rect>
-  <rect x="40" y="335" width="42" height="6" fill="#cd3731" rx="1" ry="1"></rect>
-  <rect x="40" y="341.5" width="35" height="6" fill="#cccccc" rx="1" ry="1"></rect>
-  <rect x="40" y="341.5" width="5" height="6" fill="#fbae00" rx="1" ry="1"></rect>
-  <rect x="40" y="348" width="11" height="6" fill="#248ebd" rx="1" ry="1"></rect>
-  <rect x="40" y="354.5" width="11" height="6" fill="#40a9ff" rx="1" ry="1"></rect>
-  <rect x="40" y="361" width="3" height="6" fill="#e0709a" rx="1" ry="1"></rect>
-  <line x1="40" y1="39" x2="40" y2="371.5" class="line"></line>
-  <text x="38" y="59" class="font s4" dominant-baseline="middle" text-anchor="end">clean</text>
-  <text x="38" y="95.5" class="font s4" dominant-baseline="middle" text-anchor="end">cache</text>
-  <text x="38" y="132" class="font s4" dominant-baseline="middle" text-anchor="end">lockfile</text>
-  <text x="38" y="166.5" class="font s4" dominant-baseline="middle" text-anchor="end">cache</text>
-  <text x="38" y="170.5" class="font s4" dominant-baseline="middle" text-anchor="end">lockfile</text>
-  <text x="38" y="203" class="font s4" dominant-baseline="middle" text-anchor="end">cache</text>
-  <text x="38" y="207" class="font s4" dominant-baseline="middle" text-anchor="end">node_modules</text>
-  <text x="38" y="241.5" class="font s4" dominant-baseline="middle" text-anchor="end">node_modules</text>
-  <text x="38" y="274" class="font s4" dominant-baseline="middle" text-anchor="end">cache</text>
-  <text x="38" y="278" class="font s4" dominant-baseline="middle" text-anchor="end">lockfile</text>
-  <text x="38" y="282" class="font s4" dominant-baseline="middle" text-anchor="end">node_modules</text>
-  <text x="38" y="312.5" class="font s4" dominant-baseline="middle" text-anchor="end">lockfile</text>
-  <text x="38" y="316.5" class="font s4" dominant-baseline="middle" text-anchor="end">node_modules</text>
-  <text x="38" y="351" class="font s4" dominant-baseline="middle" text-anchor="end">update</text>
-  <text x="290" y="383.5" class="font s4 text" text-anchor="end">Tests were run using Node.js v24.19.0 at: Aug 14, 2026, 8:47 AM</text>
+  <rect x="40" y="43" width="230" height="6" fill="#cd3731" rx="1" ry="1"></rect>
+  <rect x="40" y="49.5" width="41" height="6" fill="#cccccc" rx="1" ry="1"></rect>
+  <rect x="40" y="49.5" width="25" height="6" fill="#fbae00" rx="1" ry="1"></rect>
+  <rect x="40" y="60" width="58" height="6" fill="#cd3731" rx="1" ry="1"></rect>
+  <rect x="40" y="66.5" width="24" height="6" fill="#cccccc" rx="1" ry="1"></rect>
+  <rect x="40" y="66.5" width="17" height="6" fill="#fbae00" rx="1" ry="1"></rect>
+  <rect x="40" y="77" width="55" height="6" fill="#cd3731" rx="1" ry="1"></rect>
+  <rect x="40" y="83.5" width="20" height="6" fill="#cccccc" rx="1" ry="1"></rect>
+  <rect x="40" y="83.5" width="5" height="6" fill="#fbae00" rx="1" ry="1"></rect>
+  <rect x="40" y="94" width="36" height="6" fill="#cd3731" rx="1" ry="1"></rect>
+  <rect x="40" y="100.5" width="11" height="6" fill="#cccccc" rx="1" ry="1"></rect>
+  <rect x="40" y="100.5" width="3" height="6" fill="#fbae00" rx="1" ry="1"></rect>
+  <rect x="40" y="111" width="8" height="6" fill="#cd3731" rx="1" ry="1"></rect>
+  <rect x="40" y="117.5" width="3" height="6" fill="#cccccc" rx="1" ry="1"></rect>
+  <rect x="40" y="128" width="8" height="6" fill="#cd3731" rx="1" ry="1"></rect>
+  <rect x="40" y="134.5" width="3" height="6" fill="#cccccc" rx="1" ry="1"></rect>
+  <rect x="40" y="134.5" width="1" height="6" fill="#fbae00" rx="1" ry="1"></rect>
+  <rect x="40" y="145" width="6" height="6" fill="#cd3731" rx="1" ry="1"></rect>
+  <rect x="40" y="151.5" width="3" height="6" fill="#cccccc" rx="1" ry="1"></rect>
+  <rect x="40" y="162" width="5" height="6" fill="#cd3731" rx="1" ry="1"></rect>
+  <rect x="40" y="168.5" width="3" height="6" fill="#cccccc" rx="1" ry="1"></rect>
+  <rect x="40" y="168.5" width="1" height="6" fill="#fbae00" rx="1" ry="1"></rect>
+  <rect x="40" y="179" width="20" height="6" fill="#cd3731" rx="1" ry="1"></rect>
+  <rect x="40" y="185.5" width="18" height="6" fill="#cccccc" rx="1" ry="1"></rect>
+  <rect x="40" y="185.5" width="5" height="6" fill="#fbae00" rx="1" ry="1"></rect>
+  <line x1="40" y1="39" x2="40" y2="196" class="line"></line>
+  <text x="38" y="49.25" class="font s4" dominant-baseline="middle" text-anchor="end">clean</text>
+  <text x="38" y="66.25" class="font s4" dominant-baseline="middle" text-anchor="end">trusted lockfile</text>
+  <text x="38" y="83.25" class="font s4" dominant-baseline="middle" text-anchor="end">cache</text>
+  <text x="38" y="98.25" class="font s4" dominant-baseline="middle" text-anchor="end">cache</text>
+  <text x="38" y="102.25" class="font s4" dominant-baseline="middle" text-anchor="end">trusted lockfile</text>
+  <text x="38" y="115.25" class="font s4" dominant-baseline="middle" text-anchor="end">cache</text>
+  <text x="38" y="119.25" class="font s4" dominant-baseline="middle" text-anchor="end">node_modules</text>
+  <text x="38" y="134.25" class="font s4" dominant-baseline="middle" text-anchor="end">node_modules</text>
+  <text x="38" y="147.25" class="font s4" dominant-baseline="middle" text-anchor="end">cache</text>
+  <text x="38" y="151.25" class="font s4" dominant-baseline="middle" text-anchor="end">trusted lockfile</text>
+  <text x="38" y="155.25" class="font s4" dominant-baseline="middle" text-anchor="end">node_modules</text>
+  <text x="38" y="166.25" class="font s4" dominant-baseline="middle" text-anchor="end">trusted lockfile</text>
+  <text x="38" y="170.25" class="font s4" dominant-baseline="middle" text-anchor="end">node_modules</text>
+  <text x="38" y="185.25" class="font s4" dominant-baseline="middle" text-anchor="end">update</text>
+  <text x="290" y="208" class="font s4 text" text-anchor="end">Tests were run using Node.js v24.19.0 at: Aug 28, 2026, 2:16 PM</text>
 </svg>

--- a/static/img/benchmarks/node-versions.svg
+++ b/static/img/benchmarks/node-versions.svg
@@ -17,7 +17,7 @@
   <text x="60" y="18" class="font s3" text-anchor="middle">v1.39.0</text>
   <circle cx="76" cy="6" r="4" fill="#5fa04e"></circle>
   <text x="76" y="14" class="font s4" text-anchor="middle">nvm</text>
-  <text x="76" y="18" class="font s3" text-anchor="middle">v0.40.6</text>
+  <text x="76" y="18" class="font s3" text-anchor="middle">v0.40.7</text>
   <text x="40" y="36" class="font s5 text" text-anchor="middle">0</text>
   <text x="40" y="95" class="font s5 text" text-anchor="middle">0</text>
   <line x1="90" y1="39" x2="90" y2="90" class="line width"></line>
@@ -38,14 +38,14 @@
   <text x="290" y="28" class="font s4 text" font-style="italic" text-anchor="end">Installation time in seconds (lower is better)</text>
   <rect x="40" y="43" width="50" height="6" fill="#fbae00" rx="1" ry="1"></rect>
   <rect x="40" y="49.5" width="120" height="6" fill="#6f42c1" rx="1" ry="1"></rect>
-  <rect x="40" y="56" width="150" height="6" fill="#5fa04e" rx="1" ry="1"></rect>
-  <rect x="40" y="66.5" width="10" height="6" fill="#fbae00" rx="1" ry="1"></rect>
+  <rect x="40" y="56" width="135" height="6" fill="#5fa04e" rx="1" ry="1"></rect>
+  <rect x="40" y="66.5" width="5" height="6" fill="#fbae00" rx="1" ry="1"></rect>
   <rect x="40" y="73" width="125" height="6" fill="#6f42c1" rx="1" ry="1"></rect>
-  <rect x="40" y="79.5" width="140" height="6" fill="#5fa04e" rx="1" ry="1"></rect>
+  <rect x="40" y="79.5" width="115" height="6" fill="#5fa04e" rx="1" ry="1"></rect>
   <line x1="40" y1="39" x2="40" y2="90" class="line"></line>
   <text x="38" y="50.5" class="font s4" dominant-baseline="middle" text-anchor="end">install</text>
   <text x="38" y="54.5" class="font s4" dominant-baseline="middle" text-anchor="end">clean</text>
   <text x="38" y="74" class="font s4" dominant-baseline="middle" text-anchor="end">install</text>
   <text x="38" y="78" class="font s4" dominant-baseline="middle" text-anchor="end">warm store</text>
-  <text x="290" y="102" class="font s4 text" text-anchor="end">Tests were run using Node.js v24.19.0 at: Aug 14, 2026, 8:47 AM</text>
+  <text x="290" y="102" class="font s4 text" text-anchor="end">Tests were run using Node.js v24.19.0 at: Aug 28, 2026, 2:16 PM</text>
 </svg>


### PR DESCRIPTION
Depends on **pnpm/benchmarks#67** — merge that first, since this reads `benchmarks.json` from its `main`.

pnpm/benchmarks used to write the benchmark page and its charts, and `scripts/update-benchmarks.mjs` copied both across. Every wording change went through a benchmark run in a repository whose job is measurement, and what the page said about the numbers lived nowhere near the site that served it.

That repository now publishes only `benchmarks.json` — the numbers, the versions they were measured with, and the conditions they were measured under. This PR renders the page and its charts here from it:

- **`scripts/benchmarks/columns.mjs`** — which columns the page carries, their legends, colors, row labels and explanations. This is where a package manager is added to or dropped from the comparison.
- **`scripts/benchmarks/page.mjs`** — the prose and the table assembly.
- **`scripts/benchmarks/generate-svg.mjs`**, **`generate-stacked-svg.mjs`** — moved across unchanged, but for their `process.version` defaults: a machine that measured nothing has no business reading its own Node.js version onto a chart.
- **`scripts/benchmarks/pretty-ms.mjs`** — the sliver of `pretty-ms` the tables need. The sync workflow runs on a bare Node.js with the site's dependencies deliberately not installed, so it can't be a dependency.

`update-benchmarks.mjs` now fetches one JSON file and renders, rather than resolving a commit and copying a page plus every chart it references. The `GITHUB_TOKEN` it needed for the API goes away with it.

### Yarn and Bun

Off the page; npm and the pnpm columns stay. They are still measured upstream and still in the manifest — the split means dropping them from the site costs nothing upstream, and picking them back up is an edit to `columns.mjs`.

The manifest deliberately carries more than the page draws, so `columns.mjs` says so: a tool with numbers but no column is expected, not an oversight. The reverse is checked and fails loudly — a column can't outlive its measurement.

### Verification

Rendered against the results currently recorded in pnpm/benchmarks: the npm and pnpm numbers come out identical to the last published page, the charts render with the two bar groups, a second run writes nothing, and the output is byte-identical whether or not the manifest carries Yarn and Bun.

### One thing to look at

The page claimed to be updated **daily**. The benchmark's cron is weekly, so it now says weekly. This sync workflow is still `workflow_dispatch` only — if the page should update on its own, that workflow needs a schedule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SKeHCgKWBLVERXWMdVHQFJ