### PR TITLE
docs: unite the side-effects cache settings

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -268,7 +268,7 @@ Every setting is listed below, grouped by topic. Follow a setting to read its do
 * [childConcurrency](./settings/build.md#childconcurrency)
 * [sideEffectsCache](./settings/build.md#sideeffectscache)
 * [sideEffectsCacheReadonly](./settings/build.md#sideeffectscachereadonly)
-* [remoteSideEffectsCache](./settings/build.md#remotesideeffectscache)
+* [sideEffectsCache.remote](./settings/build.md#sideeffectscacheremote)
 * [unsafePerm](./settings/build.md#unsafeperm)
 * [nodeOptions](./settings/build.md#nodeoptions)
 * [verifyDepsBeforeRun](./settings/build.md#verifydepsbeforerun)

--- a/docs/settings/build.md
+++ b/docs/settings/build.md
@@ -52,7 +52,7 @@ sideEffectsCache:
   read: true
   write: true
   remote:
-    organization: acme
+    org: acme
     packages:
       - native-addon
 ```
@@ -96,7 +96,7 @@ allowBuilds:
   native-addon: true
 sideEffectsCache:
   remote:
-    organization: acme
+    org: acme
     packages:
       - native-addon
 ```
@@ -128,7 +128,8 @@ including the server flag, the trust material, and how an artifact is published.
 
 :::note
 
-`remoteSideEffectsCache` is the older spelling of this setting and still works.
+`remoteSideEffectsCache` is the older spelling of this setting, and `organization`
+of its `org` field; both still work.
 Where both are set, `sideEffectsCache.remote` wins, and the two compose rather
 than replace — a repository may declare the organization under one while the
 machine supplies the signing key under the other.

--- a/docs/settings/build.md
+++ b/docs/settings/build.md
@@ -29,7 +29,7 @@ node_modules.
 ### sideEffectsCache
 
 * Default: **true**
-* Type: **Boolean**
+* Type: **Boolean or Object**
 
 Use and cache the results of (pre/post)install hooks.
 
@@ -44,14 +44,37 @@ You may want to disable this setting if:
 
 :::
 
+An object says the same thing in more detail, and is the only way to reach the
+remote tier:
+
+```yaml title="pnpm-workspace.yaml"
+sideEffectsCache:
+  read: true
+  write: true
+  remote:
+    organization: acme
+    packages:
+      - native-addon
+```
+
+* `read` — restore a build from the cache when one is present. Default **true**.
+* `write` — save a package's build output to the cache. Default **true**.
+* `remote` — reuse builds across machines; see below.
+
+`sideEffectsCache: true` is the shorthand for reading and writing, and is what
+the setting meant before it grew a remote tier. Writing without reading
+(`read: false, write: true`) populates a cache the run never consumes, which is
+what a job that warms one for others wants.
+
 ### sideEffectsCacheReadonly
 
 * Default: **false**
 * Type: **Boolean**
 
 Only use the side effects cache if present, do not create it for new packages.
+The older spelling of `sideEffectsCache: { read: true, write: false }`.
 
-### remoteSideEffectsCache
+### sideEffectsCache.remote
 
 Added in: v11.25.0 and v12.0.0
 
@@ -71,11 +94,15 @@ A repository declares eligibility and nothing else:
 pnprServer: http://127.0.0.1:7677
 allowBuilds:
   native-addon: true
-remoteSideEffectsCache:
-  organization: acme
-  packages:
-    - native-addon
+sideEffectsCache:
+  remote:
+    organization: acme
+    packages:
+      - native-addon
 ```
+
+Declaring only `remote` leaves `read` and `write` at their defaults, so the
+local cache keeps working as it did.
 
 `packages` is an eligibility list, not a permission: a package is only a
 candidate when it also passes [`allowBuilds`](#allowbuilds), has
@@ -98,6 +125,15 @@ Any cache failure — an unreachable server, an unverifiable signature, an
 incompatible platform, a bad blob — falls back to the ordinary local build. See
 [Shared side-effects cache](/pnpr/shared-side-effects-cache) for the full setup,
 including the server flag, the trust material, and how an artifact is published.
+
+:::note
+
+`remoteSideEffectsCache` is the older spelling of this setting and still works.
+Where both are set, `sideEffectsCache.remote` wins, and the two compose rather
+than replace — a repository may declare the organization under one while the
+machine supplies the signing key under the other.
+
+:::
 
 ### unsafePerm
 

--- a/docs/settings/build.md
+++ b/docs/settings/build.md
@@ -44,8 +44,8 @@ You may want to disable this setting if:
 
 :::
 
-An object says the same thing in more detail, and is the only way to reach the
-remote tier:
+An object says the same thing in more detail, and is the canonical way to
+declare the remote tier:
 
 ```yaml title="pnpm-workspace.yaml"
 sideEffectsCache:
@@ -128,11 +128,14 @@ including the server flag, the trust material, and how an artifact is published.
 
 :::note
 
-`remoteSideEffectsCache` is the older spelling of this setting, and `organization`
-of its `org` field; both still work.
-Where both are set, `sideEffectsCache.remote` wins, and the two compose rather
-than replace — a repository may declare the organization under one while the
-machine supplies the signing key under the other.
+`remoteSideEffectsCache` is the older spelling of this setting, and
+`organization` of its `org` field; both still work.
+
+The two spellings are merged, not chosen between: a field set under both takes
+its value from `sideEffectsCache.remote`, and a field set under only one is kept
+either way. That is what lets a repository declare the org in
+`pnpm-workspace.yaml` while the machine supplies the signing key from the global
+config under whichever spelling it already used.
 
 :::
 

--- a/pnpr-docs/shared-side-effects-cache.md
+++ b/pnpr-docs/shared-side-effects-cache.md
@@ -147,6 +147,14 @@ post-build diff, signs it, and stores it with
 are optional provenance recorded in the signed payload. Never commit the private
 key.
 
+A published artifact is immutable, the way a published `name@version` is. One
+input key and one set of compatibility constraints admit one artifact, so
+publishing a different build over an existing one answers `409 Conflict` while
+republishing the identical one succeeds unchanged. A consumer that resolved an
+artifact once is therefore never handed different bytes for it later, and no
+publishing credential can replace one — releasing a claimed slot is an operator
+action against the server's storage.
+
 Publication does not switch restoring off: a builder still looks the artifact up
 first, and a hit skips the build the same way it does anywhere else — which
 leaves nothing new to sign, since only an actual local build produces a diff to

--- a/pnpr-docs/shared-side-effects-cache.md
+++ b/pnpr-docs/shared-side-effects-cache.md
@@ -76,10 +76,11 @@ The repository declares eligibility, and nothing else:
 pnprServer: http://127.0.0.1:7677
 allowBuilds:
   native-addon: true
-remoteSideEffectsCache:
-  organization: acme
-  packages:
-    - native-addon
+sideEffectsCache:
+  remote:
+    organization: acme
+    packages:
+      - native-addon
 ```
 
 `packages` is an independent allowlist: a package is only a candidate when it is
@@ -95,10 +96,16 @@ turn the machine's key into a signing oracle. Those fields come from the [global
 configuration file](/cli/config) instead, which travels with the machine:
 
 ```yaml title="~/.config/pnpm/config.yaml"
-remoteSideEffectsCache:
-  trustedKeys:
-    acme-2026: '<base64 P-256 SubjectPublicKeyInfo DER public key>'
+sideEffectsCache:
+  remote:
+    trustedKeys:
+      acme-2026: '<base64 P-256 SubjectPublicKeyInfo DER public key>'
 ```
+
+The repository and the machine each declare one half of the same section, and
+they compose: neither file drops what the other set. `remoteSideEffectsCache` is
+the older spelling of `sideEffectsCache.remote` and still works, so a machine
+configured before the rename keeps its trust material.
 
 Every field of the section is also settable from the environment, which wins
 over both files — the shape a CI runner wants for material it must not commit:

--- a/pnpr-docs/shared-side-effects-cache.md
+++ b/pnpr-docs/shared-side-effects-cache.md
@@ -113,17 +113,20 @@ over both files — the shape a CI runner wants for material it must not commit:
 
 | Environment variable | Setting |
 | --- | --- |
-| `PNPM_REMOTE_SIDE_EFFECTS_CACHE_TRUSTED_KEYS` | `trustedKeys` (JSON object) |
-| `PNPM_REMOTE_SIDE_EFFECTS_CACHE_PRIVATE_KEY` | `privateKey` |
-| `PNPM_REMOTE_SIDE_EFFECTS_CACHE_PUBLISH` | `publish` |
-| `PNPM_REMOTE_SIDE_EFFECTS_CACHE_KEY_ID` | `keyId` |
-| `PNPM_REMOTE_SIDE_EFFECTS_CACHE_BUILDER_ID` | `builderId` |
-| `PNPM_REMOTE_SIDE_EFFECTS_CACHE_IMAGE_DIGEST` | `imageDigest` |
-| `PNPM_REMOTE_SIDE_EFFECTS_CACHE_ARCHITECTURE_BASELINE` | `architectureBaseline` |
-| `PNPM_REMOTE_SIDE_EFFECTS_CACHE_BUILD_ENV` | `buildEnv` (JSON object) |
+| `PNPM_SIDE_EFFECTS_CACHE_REMOTE_TRUSTED_KEYS` | `trustedKeys` (JSON object) |
+| `PNPM_SIDE_EFFECTS_CACHE_REMOTE_PRIVATE_KEY` | `privateKey` |
+| `PNPM_SIDE_EFFECTS_CACHE_REMOTE_PUBLISH` | `publish` |
+| `PNPM_SIDE_EFFECTS_CACHE_REMOTE_KEY_ID` | `keyId` |
+| `PNPM_SIDE_EFFECTS_CACHE_REMOTE_BUILDER_ID` | `builderId` |
+| `PNPM_SIDE_EFFECTS_CACHE_REMOTE_IMAGE_DIGEST` | `imageDigest` |
+| `PNPM_SIDE_EFFECTS_CACHE_REMOTE_ARCHITECTURE_BASELINE` | `architectureBaseline` |
+| `PNPM_SIDE_EFFECTS_CACHE_REMOTE_BUILD_ENV` | `buildEnv` (JSON object) |
+
+The `PNPM_REMOTE_SIDE_EFFECTS_CACHE_*` names still work, and the ones above win
+when both are set.
 
 The repository and the machine each contribute the half they own: a workspace
-naming `organization` and `packages` keeps whatever trust material the global
+naming `org` and `packages` keeps whatever trust material the global
 file or the environment supplied.
 
 ## Publishing from a builder
@@ -132,10 +135,10 @@ Publication is off unless a build explicitly turns it on, so only a trusted
 builder uploads the diff its own build produced:
 
 ```sh
-export PNPM_REMOTE_SIDE_EFFECTS_CACHE_PUBLISH=true
-export PNPM_REMOTE_SIDE_EFFECTS_CACHE_KEY_ID=acme-2026
-export PNPM_REMOTE_SIDE_EFFECTS_CACHE_PRIVATE_KEY='<base64 P-256 PKCS#8 DER private key>'
-export PNPM_REMOTE_SIDE_EFFECTS_CACHE_BUILDER_ID='ci/main/42'
+export PNPM_SIDE_EFFECTS_CACHE_REMOTE_PUBLISH=true
+export PNPM_SIDE_EFFECTS_CACHE_REMOTE_KEY_ID=acme-2026
+export PNPM_SIDE_EFFECTS_CACHE_REMOTE_PRIVATE_KEY='<base64 P-256 PKCS#8 DER private key>'
+export PNPM_SIDE_EFFECTS_CACHE_REMOTE_BUILDER_ID='ci/main/42'
 ```
 
 `pnpm install` then runs the lifecycle scripts as usual, captures the actual

--- a/pnpr-docs/shared-side-effects-cache.md
+++ b/pnpr-docs/shared-side-effects-cache.md
@@ -78,7 +78,7 @@ allowBuilds:
   native-addon: true
 sideEffectsCache:
   remote:
-    organization: acme
+    org: acme
     packages:
       - native-addon
 ```
@@ -104,8 +104,9 @@ sideEffectsCache:
 
 The repository and the machine each declare one half of the same section, and
 they compose: neither file drops what the other set. `remoteSideEffectsCache` is
-the older spelling of `sideEffectsCache.remote` and still works, so a machine
-configured before the rename keeps its trust material.
+the older spelling of `sideEffectsCache.remote`, and `organization` of `org`;
+both still work, so a machine configured before the rename keeps its trust
+material.
 
 Every field of the section is also settable from the environment, which wins
 over both files — the shape a CI runner wants for material it must not commit:


### PR DESCRIPTION
Documents the settings change in pnpm/pnpm#14285, where `sideEffectsCache` becomes the whole declaration of how a package's build output is reused.

- `sideEffectsCache` gains its object form — `read`, `write`, and `remote` — alongside the boolean it has always accepted.
- `sideEffectsCache.remote` replaces the `remoteSideEffectsCache` section, so the three settings now sit together on the page instead of the remote half sorting under "r" away from the two it extends.
- `sideEffectsCacheReadonly` is noted as the older spelling of `{ read: true, write: false }`.
- The pnpr guide's examples use the canonical spelling, and gained a line about the repository and the machine each declaring one half of the same section — they compose, so neither file drops what the other set.

`remoteSideEffectsCache` keeps working and is noted as the older spelling in both places. The 12.0 release note keeps the name it shipped with.

Depends on pnpm/pnpm#14285 — merge that first.

---
Written by an agent (Claude Code, claude-opus-5[1m]).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated build settings documentation to support Boolean or object-based `sideEffectsCache` configuration.
  - Documented local read/write controls and remote cache settings under `sideEffectsCache.remote`.
  - Added examples covering defaults, shorthand behavior, and configuration composition.
  - Updated remote cache configuration to use `org`, while documenting legacy spellings.
  - Documented updated environment variables and legacy configuration support.
  - Clarified that published artifacts are immutable: identical republishing succeeds, while conflicting replacements return `409 Conflict`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->