### PR TITLE
fix: replace links to the archived pacquet repo

### DIFF
--- a/blog/releases/11.7.md
+++ b/blog/releases/11.7.md
@@ -51,7 +51,7 @@ When installing or publishing `@org-a/*`, pnpm uses `ORG_A_TOKEN`; for `@org-b/*
 
 ### Full resolving installs delegated to pacquet
 
-When [`pacquet`](https://github.com/pnpm/pnpm/tree/main/pacquet) (the Rust port of pnpm) is declared in `configDependencies`, pnpm now delegates dependency **resolution** to it too — not just materialization — provided the installed pacquet is new enough (>= 0.11.7).
+When [`pacquet`](/blog/releases/12.0) (the Rust port of pnpm) is declared in `configDependencies`, pnpm now delegates dependency **resolution** to it too — not just materialization — provided the installed pacquet is new enough (>= 0.11.7).
 
 Previously pacquet only ran in frozen-install mode: pnpm always resolved the graph itself and handed pacquet a finished lockfile to fetch / import / link. Now a non-frozen `pnpm install` (default isolated `nodeLinker`, plain install) is delegated to pacquet end-to-end in a single pass — it resolves the manifests, writes the lockfile, and materializes `node_modules`. Older pacquet releases keep the resolve-then-materialize split, and `add` / `update` / `remove` still resolve in pnpm. This remains an opt-in preview of the Rust install engine ([#11723](https://github.com/pnpm/pnpm/issues/11723)).
 

--- a/docs/pnpmfile.md
+++ b/docs/pnpmfile.md
@@ -416,7 +416,7 @@ The delegated resolution must be a complete, fetchable shape (for example `{ tar
 
 :::tip Prefer the envelope for portability
 
-The `{ delegate }` envelope is the only delegation form that works in both pnpm and [pacquet](https://github.com/pnpm/pnpm/tree/main/pacquet) (the Rust port of pnpm). pacquet invokes pnpmfile fetchers over IPC, where `cafs` and `fetchers` cannot exist and both arrive as `null`. A fetcher that should run on either stack must return the envelope rather than calling `fetchers.*`.
+The `{ delegate }` envelope is the only delegation form that works in both pnpm and [pacquet](/blog/releases/12.0) (the Rust port of pnpm). pacquet invokes pnpmfile fetchers over IPC, where `cafs` and `fetchers` cannot exist and both arrive as `null`. A fetcher that should run on either stack must return the envelope rather than calling `fetchers.*`.
 
 :::
 

--- a/scripts/benchmarks/columns.mjs
+++ b/scripts/benchmarks/columns.mjs
@@ -31,7 +31,7 @@ export const packageManagerColumns = [
   {
     key: 'pnpm12',
     legend: 'pnpm 🦀',
-    mdLegend: '[pnpm 🦀](https://github.com/pnpm/pacquet)',
+    mdLegend: '[pnpm 🦀](/blog/releases/12.0)',
     color: '#fbae00',
     displayVersion: '12',
     mascot: '🦀',

--- a/scripts/benchmarks/page.mjs
+++ b/scripts/benchmarks/page.mjs
@@ -163,7 +163,7 @@ ${mainTable}
 <img alt="Graph of the ${fixture.name} results" src="${mainSrc}" />`,
     `### ${pnpmColumns.map((column) => column.legend).join(' vs ')}
 
-pnpm v12 will use a new installation engine for fetching and linking written in Rust. See [pacquet](https://github.com/pnpm/pacquet).
+pnpm v12 will use a new installation engine for fetching and linking written in Rust. See [pacquet](/blog/releases/12.0).
 
 ${pnpmTable}
 

--- a/src/pages/benchmarks.md
+++ b/src/pages/benchmarks.md
@@ -30,7 +30,7 @@ Each row's label lists which of `cache`, `trusted lockfile`, and `node_modules` 
 
 The app's [`alotta-files` package.json](https://github.com/pnpm/benchmarks/blob/main/fixtures/alotta-files/package.json)
 
-| action  | cache | trusted lockfile | node_modules| npm | pnpm | [pnpm 🦀](https://github.com/pnpm/pacquet) | [pnpm + pnpr](/pnpr/install-acceleration) |
+| action  | cache | trusted lockfile | node_modules| npm | pnpm | [pnpm 🦀](/blog/releases/12.0) | [pnpm + pnpr](/pnpr/install-acceleration) |
 | ---     | ---   | ---      | ---         | --- | --- | --- | --- |
 | install |   |   |   | 45.9s | 8.2s | 5s | 3.3s |
 | install |   | ✔ |   | 11.5s | 4.7s | 3.2s | 3.2s |
@@ -46,9 +46,9 @@ The app's [`alotta-files` package.json](https://github.com/pnpm/benchmarks/blob/
 
 ### pnpm vs pnpm 🦀
 
-pnpm v12 will use a new installation engine for fetching and linking written in Rust. See [pacquet](https://github.com/pnpm/pacquet).
+pnpm v12 will use a new installation engine for fetching and linking written in Rust. See [pacquet](/blog/releases/12.0).
 
-| action  | cache | trusted lockfile | node_modules| pnpm | [pnpm 🦀](https://github.com/pnpm/pacquet) |
+| action  | cache | trusted lockfile | node_modules| pnpm | [pnpm 🦀](/blog/releases/12.0) |
 | ---     | ---   | ---      | ---         | --- | --- |
 | install |   |   |   | 8.2s | 5s |
 | install |   | ✔ |   | 4.7s | 3.2s |


### PR DESCRIPTION
The pacquet repo is archived, and the `pnpm/pnpm/tree/main/pacquet` paths 404 after the monorepo restructure. All of them now point at the pnpm 12 release post.

| File | Old URL |
|---|---|
| `docs/pnpmfile.md` | `github.com/pnpm/pnpm/tree/main/pacquet` (404) |
| `blog/releases/11.7.md` | `github.com/pnpm/pnpm/tree/main/pacquet` (404) |
| `src/pages/benchmarks.md` | `github.com/pnpm/pacquet` (archived) |
| `scripts/benchmarks/columns.mjs` | `github.com/pnpm/pacquet` (archived) |
| `scripts/benchmarks/page.mjs` | `github.com/pnpm/pacquet` (archived) |

Both the generated `src/pages/benchmarks.md` and its generator scripts are updated, so regenerating the benchmarks page won't reintroduce the old link.

The `npmx.dev/package/@pnpm/pacquet` links in `blog/releases/11.2.md` are left alone — they point at the npm package page, not the repo, and still resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NR8q2t6ADb3vjVFCMYnjah