### PR TITLE
docs: document confirmModulesPurge

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -157,6 +157,7 @@ Every setting is listed below, grouped by topic. Follow a setting to read its do
 * [nodePackageMapType](./settings/node-modules.md#nodepackagemaptype)
 * [symlink](./settings/node-modules.md#symlink)
 * [enableModulesDir](./settings/node-modules.md#enablemodulesdir)
+* [confirmModulesPurge](./settings/node-modules.md#confirmmodulespurge)
 * [virtualStoreDir](./settings/node-modules.md#virtualstoredir)
 * [virtualStoreDirMaxLength](./settings/node-modules.md#virtualstoredirmaxlength)
 * [virtualStoreOnly](./settings/node-modules.md#virtualstoreonly)

--- a/docs/settings/node-modules.md
+++ b/docs/settings/node-modules.md
@@ -89,6 +89,27 @@ mount a modules directory with FUSE: [@pnpm/mount-modules].
 
 [@pnpm/mount-modules]: https://www.npmjs.com/package/@pnpm/mount-modules
 
+### confirmModulesPurge
+
+* Default: **true** (confirmation is disabled in CI)
+* Type: **Boolean**
+
+When pnpm has to recreate a `node_modules` directory because its existing
+layout is incompatible with the current install settings, this setting controls
+whether pnpm asks for confirmation first. Set it to `false` to let pnpm remove
+and reinstall the directory without prompting.
+
+```yaml title="pnpm-workspace.yaml"
+confirmModulesPurge: false
+```
+
+:::note
+
+This setting is supported by pnpm v11. pnpm v12 does not implement it and warns
+that it belongs to pnpm v11.
+
+:::
+
 ### virtualStoreDir
 
 * Default: **node_modules/.pnpm**

--- a/docs/settings/node-modules.md
+++ b/docs/settings/node-modules.md
@@ -97,7 +97,8 @@ mount a modules directory with FUSE: [@pnpm/mount-modules].
 When pnpm has to recreate a `node_modules` directory because its existing
 layout is incompatible with the current install settings, this setting controls
 whether pnpm asks for confirmation first. Set it to `false` to let pnpm remove
-and reinstall the directory without prompting.
+and reinstall the directory without prompting. When confirmation is enabled
+but no TTY is available and CI is not detected, pnpm aborts the install instead.
 
 ```yaml title="pnpm-workspace.yaml"
 confirmModulesPurge: false


### PR DESCRIPTION
## Summary

- document how `confirmModulesPurge` controls confirmation before recreating incompatible `node_modules` directories
- note that confirmation is disabled in CI
- clarify that the setting is supported by pnpm v11 but not pnpm v12

## Testing

- `pnpm test`
- English Docusaurus production build

Refs pnpm/pnpm#14316.

---
Written by an agent (Codex, GPT-5).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added documentation for the `confirmModulesPurge` Node-Modules setting and linked to it from the settings overview.
  * Explained its default value, Boolean type, confirmation behavior, and CI behavior.
  * Documented that installs abort when confirmation is enabled, no TTY is available, and CI is not detected.
  * Documented automatic removal and reinstallation when disabled.
  * Noted pnpm v11 support and pnpm v12 limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->