### PR TITLE
docs: document pnpm 11.25 and 12.1

### DIFF
--- a/blog/releases/11.25.md
+++ b/blog/releases/11.25.md
@@ -1,0 +1,217 @@
+---
+title: pnpm 11.25
+authors: zkochan
+tags: [release]
+date: 2026-08-29
+---
+
+pnpm 11.25 replaces topological batches with a task scheduler, adds configurable
+workspace task dependencies and per-task concurrency, and makes interrupted
+recursive runs resumable from the work that actually passed. It also introduces
+registry revisions, signed build artifacts shared through pnpr, batch approval
+for staged packages, automatic pruning of stale audit exceptions, and a
+`pnpm init` pin that follows the latest released pnpm.
+
+<!-- truncate -->
+
+## Minor Changes
+
+### Workspace task orchestration
+
+`pnpm -r run` now schedules individual project/script tasks as soon as their
+dependencies finish. Declare relationships under `tasks` in
+`pnpm-workspace.yaml`:
+
+```yaml title="pnpm-workspace.yaml"
+tasks:
+  build:
+    dependsOn: ['^build']
+    concurrency: 2
+  test:
+    dependsOn: ['build']
+  lint: {}
+```
+
+`^build` means `build` in each workspace dependency; bare `build` means the
+task in the same project. A configured task with no `dependsOn` has no
+dependencies, while an unconfigured task retains the old default of depending
+on the same task in workspace dependencies. Missing scripts pass their edges
+through rather than cutting the graph.
+
+Cycles now fail with `ERR_PNPM_TASK_CYCLE` unless
+[`ignoreWorkspaceCycles`](/workspaces#ignoreworkspacecycles) is set. `--no-bail`
+skips dependents of a failed task while independent work continues; the default
+`--bail` stops dispatch and cancels work already running. Use
+`pnpm -r run --dry-run <script>` to inspect the graph, and add `--json` for its
+machine-readable nodes and edges. See [Workspace task
+orchestration](/workspace-task-orchestration).
+
+The scheduler also replaces topological batches in workspace install, rebuild,
+pack, publish, stage, and lifecycle work: a project starts as soon as its
+dependencies finish instead of waiting for unrelated projects in the same
+group.
+
+### Resuming the work that passed
+
+Recursive `run` and `exec` persist each successfully completed task. On a
+matching retry, [`--resume-from`](/workspace-task-orchestration#--resume-from-package_name)
+uses that record and skips exactly the work that passed, wherever it appears in
+the graph. The record is accepted only for the same selected projects, command,
+arguments, scripts, and execution-affecting settings.
+
+Without a compatible record, pnpm falls back to the graph: it treats the named
+task's transitive dependencies as completed, while still running the named
+task, its dependents, and unrelated work.
+
+### Signed build artifacts shared through pnpr
+
+The [`sideEffectsCache`](/settings/build#sideeffectscache) can now restore a
+dependency's build output across machines from pnpr. The repository declares
+which organization and packages are eligible; signing keys and all other
+publisher trust material are accepted only from the global config or the
+environment:
+
+```yaml title="pnpm-workspace.yaml"
+pnprServer: https://packages.example.com
+allowBuilds:
+  native-addon: true
+sideEffectsCache:
+  remote:
+    org: acme
+    packages: [native-addon]
+```
+
+Artifacts are P-256 signed and bound to the package, source integrity, build
+input, and platform. Linux/glibc, macOS, and Windows are supported on x64 and
+arm64. A restored artifact is persisted in the shared store with its signed
+origin and reverified under the current keys, policy, source, and platform
+before later reuse; a bad variant is quarantined for that server. A cache miss
+or any verification, network, compatibility, or blob failure falls back to the
+ordinary local build.
+
+The experimental protocol now gives every candidate and signed payload a
+discriminated subject: dependency builds carry package and source-integrity
+identity, while the protocol's workspace-task subject carries project and task
+identity. This changes request bodies and signed envelopes, so the pnpm client
+and pnpr server must be on matching releases.
+
+The new object form also unites the local cache controls:
+
+```yaml title="pnpm-workspace.yaml"
+sideEffectsCache:
+  read: true
+  write: true
+```
+
+It supports read-only and write-only caches. The older boolean
+`sideEffectsCache`, `sideEffectsCacheReadonly`, `remoteSideEffectsCache`, and
+`organization` spellings continue to work. See [Shared side-effects
+cache](/pnpr/shared-side-effects-cache).
+
+### Registry revisions
+
+A revision-aware registry can replace the artifact of an already-published
+version without rewriting the canonical `name@version` URL. pnpm records a
+selected replacement beside its integrity:
+
+```yaml title="pnpm-lock.yaml"
+packages:
+  lodash@4.17.21:
+    resolution:
+      integrity: sha512-<replacement-digest>
+      revision: 1
+```
+
+No `revision` means revision 0, the immutable original, so lockfiles that use no
+replacements retain their existing shape. A dependency or override can select
+one explicitly with `<version>+rN`; `+r0` pins the original. Run
+[`pnpm update --patches`](/cli/update#--patches) to refresh the selected
+artifacts without changing any package version or declared range. The refresh
+may run through the configured pnpr server. See [Registry
+revisions](/registry-revisions).
+
+### Batch approval for staged publishing
+
+[`pnpm stage approve`](/cli/stage#approve) accepts several stage ids, or opens
+an interactive picker when none are passed. One OTP approves the whole batch
+until the registry stops accepting it. Workspace packages are approved in
+dependency order, and a dependent is skipped when its workspace dependency
+could not be approved.
+
+### `pnpm init` follows `latest`
+
+[`pnpm init`](/cli/init#--init-package-manager) now looks up the pnpm version
+behind the `latest` tag and pins it when it is newer than the running pnpm. An
+offline, unreachable, slow, policy-rejected, or older result falls back to the
+running version and never fails or delays the scaffold indefinitely
+([#7490](https://github.com/pnpm/pnpm/issues/7490)).
+
+### Pruning stale audit exceptions
+
+Set [`audit.ignorePrune: true`](/cli/audit#auditignoreprune) to make
+`pnpm audit --fix` remove ignored GHSA entries that no longer occur in the audit
+report. An exception for an advisory still present in the report is kept.
+
+### A project cannot choose the login scope
+
+A `scope` key in a project's `pnpm-workspace.yaml` is now ignored with a
+warning. `pnpm login` turns its scope into a machine-wide registry route, so a
+repository must not be able to choose it. Pass `--scope`, set
+`PNPM_CONFIG_SCOPE`, or set `scope` in the global config instead
+([#13557](https://github.com/pnpm/pnpm/issues/13557)).
+
+## Patch Changes
+
+### Registry and update correctness
+
+- A `registry` or `registries` declaration now wins over a route inferred from
+  global `_auth`; the `pnpm_config__auth` environment setting deliberately
+  remains higher priority for CI-controlled routing.
+- `pnpm update` preserves a dependency's declared range or `catalog:` reference
+  when an override also matches it, including when the override repeats the
+  range verbatim ([#12115](https://github.com/pnpm/pnpm/issues/12115),
+  [#14224](https://github.com/pnpm/pnpm/issues/14224)).
+- `pnpm update -g` no longer downgrades a package whose installed version is
+  newer than `latest`, and it leaves pnpm itself to `pnpm self-update`
+  ([#14270](https://github.com/pnpm/pnpm/issues/14270)).
+- `--production` is accepted again as the alias of `--prod` on install, fetch,
+  prune, update, list, why, and sbom
+  ([#14147](https://github.com/pnpm/pnpm/issues/14147)).
+
+### Installation and build fixes
+
+- An install reached through a symlinked `node_modules` no longer rewrites the
+  target checkout, and `pnpm add --lockfile-only` no longer links dependencies
+  ([#14286](https://github.com/pnpm/pnpm/issues/14286)).
+- Incremental installs validate unused patches correctly, and `deploy --prod`
+  works when an omitted dev dependency is also an optional peer
+  ([#13692](https://github.com/pnpm/pnpm/issues/13692),
+  [#14302](https://github.com/pnpm/pnpm/issues/14302)).
+- Reusing a prepared git dependency from the shared store now enforces
+  `allowBuilds`, and approval suggestions use its canonical git resolution id.
+- Hoisted copies of a built package no longer replace a destination directory
+  and delete dependencies nested under its `node_modules`
+  ([#12880](https://github.com/pnpm/pnpm/issues/12880)).
+- The remote cache avoids downloading blobs already present in the store, uses
+  environment names under `PNPM_SIDE_EFFECTS_CACHE_REMOTE_*` (the old names
+  remain aliases), and pnpr resolution now receives patch hashes and package
+  extensions.
+
+### Workspace and package-manager fixes
+
+- Workspace project sorting is now linear-time, fixing long stalls on deep
+  workspaces with thousands of projects
+  ([#14149](https://github.com/pnpm/pnpm/issues/14149),
+  [#14151](https://github.com/pnpm/pnpm/issues/14151)).
+- Recursive-run cleanup terminates sibling process trees correctly on Windows.
+- A satisfied `devEngines.packageManager` range is now recorded in the
+  lockfile's `packageManagerDependencies` with the running version as its shared
+  resolution.
+- Automatic pnpm switching no longer forces descendant pnpm processes to use
+  the parent's version ([#14309](https://github.com/pnpm/pnpm/issues/14309)).
+- Update guidance now points to `pnpm self-update` only when `PNPM_HOME` manages
+  pnpm; Corepack and other package-manager installs point to the standalone
+  installer.
+
+For the complete list, see the [v11.25.0 release
+notes](https://github.com/pnpm/pnpm/releases/tag/v11.25.0).

--- a/blog/releases/12.0.md
+++ b/blog/releases/12.0.md
@@ -116,7 +116,7 @@ Set [`audit.ignorePrune: true`](/cli/audit#auditignoreprune) and `pnpm audit --f
 
 An opt-in proof of concept lets installs reuse a dependency's build output across machines, by publishing and restoring **signed**, organization-scoped artifacts through [pnpr](/pnpr) instead of running the lifecycle scripts locally.
 
-A repository names only the eligible [`remoteSideEffectsCache.organization` and `packages`](/settings/build#remotesideeffectscache); everything describing the act of signing is refused in `pnpm-workspace.yaml` and read from the global config file or the environment instead, so a cloned repository cannot turn the machine's key into a signing oracle. Every cache failure falls back to the ordinary local build. It restores on Linux/glibc x64 and arm64 only for now — see [Shared side-effects cache](/pnpr/shared-side-effects-cache).
+A repository names only the eligible [`remoteSideEffectsCache.organization` and `packages`](/settings/build#sideeffectscacheremote); everything describing the act of signing is refused in `pnpm-workspace.yaml` and read from the global config file or the environment instead, so a cloned repository cannot turn the machine's key into a signing oracle. Every cache failure falls back to the ordinary local build. It restores on Linux/glibc x64 and arm64 only for now — see [Shared side-effects cache](/pnpr/shared-side-effects-cache).
 
 ## Fixes worth knowing about
 

--- a/blog/releases/12.1.md
+++ b/blog/releases/12.1.md
@@ -1,0 +1,172 @@
+---
+title: pnpm 12.1
+authors: zkochan
+tags: [release]
+date: 2026-08-29
+---
+
+pnpm 12.1 brings the new workspace task scheduler to the Rust CLI, persists
+successful recursive tasks for precise retries, expands shared build artifacts
+to macOS and Windows, and moves login credentials into pnpm's structured global
+configuration. pnpr 0.1.0-alpha.9, released with it, makes the artifact tier
+independent and horizontally scalable through S3-compatible storage.
+
+<!-- truncate -->
+
+## Minor Changes
+
+### Workspace task orchestration
+
+`pnpm -r run` and `pnpm -r exec` now dispatch a project as soon as its
+dependencies finish instead of waiting for an unrelated topological group.
+Recursive scripts can declare cross-task relationships and per-task concurrency
+under `tasks`:
+
+```yaml title="pnpm-workspace.yaml"
+tasks:
+  build:
+    dependsOn: ['^build']
+    concurrency: 2
+  test:
+    dependsOn: ['build']
+```
+
+The scheduler detects task cycles, passes dependencies through projects that do
+not define a script, skips failed dependents under `--no-bail`, cancels in-flight
+work under the default `--bail`, and supports `--dry-run --json` graph output.
+Workspace install, rebuild, pack, publish, stage, and lifecycle work uses the
+same start-as-soon-as-ready scheduling. See [Workspace task
+orchestration](/workspace-task-orchestration).
+
+Successful recursive `run` and `exec` tasks are persisted. A matching
+[`--resume-from`](/workspace-task-orchestration#--resume-from-package_name)
+retry skips exactly what passed; an incompatible or missing record falls back
+to omitting the named task's transitive dependencies from the graph.
+
+### Login writes structured global configuration
+
+[`pnpm login`](/cli/login) and `pnpm adduser` now write the granted token to the
+global `config.yaml` under [`_auth`](/npmrc#_auth). With `--scope`, they also add
+the scope to that registry's global [`registries`](/registries) declaration, so
+the credential and the route that reaches it are recorded together.
+
+[`pnpm logout`](/cli/logout) removes credentials from `config.yaml` and still
+cleans an `auth.ini` written by an older pnpm. Existing `auth.ini` tokens remain
+readable. A `scope` in project `pnpm-workspace.yaml` is ignored with a warning;
+use `--scope`, `PNPM_CONFIG_SCOPE`, or the global config because a login route is
+machine-wide ([#13557](https://github.com/pnpm/pnpm/issues/13557)).
+
+### Shared build artifacts on Linux, macOS, and Windows
+
+[`sideEffectsCache`](/settings/build#sideeffectscache) now provides one object
+for local read/write behavior and the remote pnpr tier:
+
+```yaml title="pnpm-workspace.yaml"
+sideEffectsCache:
+  read: true
+  write: true
+  remote:
+    org: acme
+    packages: [native-addon]
+```
+
+Read-only and write-only caches are supported. The legacy boolean,
+`sideEffectsCacheReadonly`, `remoteSideEffectsCache`, and `organization`
+spellings keep working and are merged with the new shape.
+
+Remote artifacts now support Linux/glibc, macOS, and Windows on x64 and arm64.
+Verified artifacts are persisted in the shared store with their signed origin,
+reverified against the current trust, policy, platform, source, and stored files
+before reuse, and quarantined per pnpr server when invalid. The protocol now
+uses discriminated subjects, so dependency side effects and future workspace
+task artifacts cannot collide. The protocol changed; clients and pnpr servers
+must use matching releases. See [Shared side-effects
+cache](/pnpr/shared-side-effects-cache).
+
+## Patch Changes
+
+### Configuration and authentication
+
+- Explicit `registry` and `registries` settings now beat routes inferred from
+  global `_auth`; environment `_auth` remains the CI-controlled override.
+- The command-line forms of package import, hoisting, global and virtual store
+  paths, modules paths, child concurrency, lockfile, peer, side-effects cache,
+  trust-policy, and optimistic-repeat-install settings are accepted again
+  ([#14281](https://github.com/pnpm/pnpm/issues/14281)).
+- Basic `_auth` tolerates omitted or extra base64 padding and embedded
+  whitespace, while malformed base64 and a missing `username:password`
+  separator receive explicit errors
+  ([#14257](https://github.com/pnpm/pnpm/issues/14257)).
+
+### Command correctness
+
+- `pnpm clean` and `pnpm purge` from a workspace subdirectory remove each
+  project's own `node_modules`, and `pnpm pm clean` / `pnpm pm purge` force the
+  built-in command even when a package script shadows it
+  ([#14239](https://github.com/pnpm/pnpm/issues/14239),
+  [#14226](https://github.com/pnpm/pnpm/issues/14226)).
+- `pnpm dlx <pkg>@catalog:` resolves through the calling workspace's catalogs
+  ([#14294](https://github.com/pnpm/pnpm/issues/14294)).
+- `.mjs` pnpmfiles and config-dependency hooks load on Windows again
+  ([#14301](https://github.com/pnpm/pnpm/issues/14301)), and `pnpm pack` applies
+  `files` to root changelog, history, and notice files.
+- `pnpm update -g` neither downgrades a package installed from a newer tag nor
+  changes pnpm itself. `pnpm update` preserves catalog and range declarations
+  matched by overrides ([#14270](https://github.com/pnpm/pnpm/issues/14270),
+  [#12115](https://github.com/pnpm/pnpm/issues/12115),
+  [#14224](https://github.com/pnpm/pnpm/issues/14224)).
+- When several installed versions expose the same binary, the highest version
+  supplies the linked command ([#14249](https://github.com/pnpm/pnpm/issues/14249)).
+- `pnpm view --json` and its aliases print errors as JSON, and the OTP prompt no
+  longer contains a duplicate colon.
+- `pnpm add`, `update`, and `remove` save the requested manifest change before
+  reporting `ERR_PNPM_IGNORED_BUILDS`, since the dependency is already
+  materialized at that point.
+
+### Install behavior and performance
+
+- An artifact-only pnpr tier is accepted, and `pnpm install --fix-lockfile`
+  works through pnpr—including filtered installs—while preserving compatible
+  locked versions ([#14250](https://github.com/pnpm/pnpm/issues/14250)).
+- Git-hosted `patchedDependencies` match in fresh and frozen installs
+  ([#14273](https://github.com/pnpm/pnpm/issues/14273)); production deploys no
+  longer fail over excluded optional peers
+  ([#14302](https://github.com/pnpm/pnpm/issues/14302)).
+- Workspace project linking is concurrent, no-script installs skip unnecessary
+  build work, and hoisted workspaces no longer rescan every project to find bins.
+- Lockfile resolution and warm restoration overlap the Node.js version probe,
+  saving roughly 150–200 ms in the affected paths.
+- On macOS, the default isolated linker materializes each package once and uses
+  one copy-on-write directory clone per virtual-store copy, fixing the
+  many-core warm-install regression and reducing filesystem calls
+  ([#14231](https://github.com/pnpm/pnpm/issues/14231)).
+- Bailing from recursive `run` or `exec` now stops in-flight process trees.
+
+## pnpr 0.1.0-alpha.9
+
+The signed shared-artifact cache now uses its own top-level
+[`artifacts.enabled`](/pnpr/configuration#registry-resolver-and-artifact-surfaces)
+switch, independent of the registry and resolver surfaces. An artifact-only
+tier can therefore scale separately from compute-heavy resolution. With an
+[`s3:` block](/pnpr/storage), artifacts use the reserved
+`.pnpr-artifacts/v0/` namespace in S3, R2, MinIO, or another compatible object
+store; conditional quota updates make the tier safe to share across replicas.
+
+Publication slots are immutable across overlapping compatibility sets. A later
+universal, broader, or higher-floor artifact cannot replace the bytes a machine
+already receives; disjoint operating-system, architecture, and Node.js-major
+builds still coexist. Identical retries remain idempotent. After an ambiguous
+object-store write failure, pnpr waits for active publications to drain,
+reclaims blobs referenced by no envelope, and rebuilds quota without losing the
+fail-closed storage bounds.
+
+The v0 protocol now binds every candidate and signed payload to a discriminated
+subject: package plus source integrity for dependency side effects, or project
+plus task for workspace tasks. It also recognizes `fixLockfile` resolve
+requests. These request and envelope changes require matching pnpr and pnpm
+versions.
+
+For the complete client changes, see the [v12.1.0 release
+notes](https://github.com/pnpm/pnpm/releases/tag/v12.1.0). The server changes are
+in the [pnpr 0.1.0-alpha.9 release
+notes](https://github.com/pnpm/pnpm/releases/tag/pnpr%400.1.0-alpha.9).

--- a/docs/cli/config.md
+++ b/docs/cli/config.md
@@ -9,8 +9,12 @@ Manage the configuration files.
 
 pnpm settings are split across two kinds of configuration files:
 
-* **Registry and authentication settings** live in INI files — the global `rc` file and local `.npmrc` files.
-* **All other pnpm settings** live in YAML files — the global `config.yaml` and the per-project `pnpm-workspace.yaml`.
+* **Legacy and npm-compatible registry/authentication settings** live in INI
+  files — the global `rc` file, `auth.ini`, and local `.npmrc` files.
+* **pnpm settings** live in YAML files — the global `config.yaml` and the
+  per-project `pnpm-workspace.yaml`. The global file may also hold the
+  structured [`_auth`](../npmrc.md#_auth) and [`registries`](../registries.md)
+  values that pnpm 12.1 and newer writes during `pnpm login`.
 
 The local workspace configuration file is located at the root of the project and is named `pnpm-workspace.yaml`. The global YAML configuration file (`config.yaml`) is located at:
 
@@ -59,7 +63,7 @@ pnpm config set --location=project --json catalog '{ "react": "19" }'
 
 The `set` command does not accept a property path.
 
-Since v11.22.0, `pnpm config set` refuses to write a setting to a project's `pnpm-workspace.yaml` that pnpm does not read from there — `configDir`, `pnpmHomeDir`, `stateDir`, and the other settings that name machine-level state. The command fails with `ERR_PNPM_CONFIG_SET_NOT_A_PROJECT_SETTING`, naming where the setting belongs when it belongs somewhere. `pnpm config delete` still clears such a key from a file that already carries it.
+Since v11.22.0, `pnpm config set` refuses to write a setting to a project's `pnpm-workspace.yaml` that pnpm does not read from there — `configDir`, `pnpmHomeDir`, `stateDir`, and the other settings that name machine-level state. Since v11.25.0 and v12.1.0, this includes `scope`, which controls the machine-wide default for `pnpm login`. The command fails with `ERR_PNPM_CONFIG_SET_NOT_A_PROJECT_SETTING`, naming where the setting belongs when it belongs somewhere. `pnpm config delete` still clears such a key from a file that already carries it.
 
 ### get &lt;key>
 

--- a/docs/cli/exec.md
+++ b/docs/cli/exec.md
@@ -65,7 +65,12 @@ Do not hide prefix when running commands in parallel.
 
 ### --resume-from &lt;package_name\>
 
-Resume execution from a particular project. This can be useful if you are working with a large workspace and you want to restart a build at a particular project without running through all of the projects that precede it in the build order.
+Resume execution at a particular project. pnpm skips the projects a matching
+record of the previous recursive `exec` says already passed. Without such a
+record, it omits the named project's transitive dependencies, but still runs
+the named project, its dependents, and unrelated projects in the selected
+graph. See [Workspace task
+orchestration](../workspace-task-orchestration.md#--resume-from-package_name).
 
 ### --parallel
 

--- a/docs/cli/login.md
+++ b/docs/cli/login.md
@@ -17,7 +17,13 @@ Supports web-based login with QR code as well as classic username/password authe
 
 Since v11.19.0, web-based login no longer requires an interactive terminal: without a TTY, `pnpm login` prints the authentication URL (skipping the QR code and the prompt to open the URL in a browser) and polls the registry until the browser approval completes. Only the classic username/password login still fails with `ERR_PNPM_LOGIN_NON_INTERACTIVE` in a non-interactive terminal.
 
-Auth tokens are written to [`<pnpm config>/auth.ini`](../npmrc.md#auth-file-locations).
+In pnpm 12.1 and newer, the granted token is written to the global
+[`config.yaml`](./config.md), under the structured [`_auth`](../npmrc.md#_auth)
+setting. When `--scope` is present, the same write routes that scope to the
+registry under the global [`registries`](../registries.md) setting. pnpm 11.25
+writes the token and scoped route to
+[`<pnpm config>/auth.ini`](../npmrc.md#auth-file-locations); pnpm 12.1 continues
+to read tokens written there.
 
 ## Options
 
@@ -28,3 +34,12 @@ The registry to authenticate with. Defaults to the configured default registry.
 ### --scope &lt;scope\>
 
 Associate the credentials with the specified scope. The registry for that scope will be used.
+
+Since v11.25.0 and v12.1.0, a `scope` setting in a project's
+`pnpm-workspace.yaml` is ignored with a warning. A repository must not be able
+to choose the machine-wide route a later login writes. Pass `--scope`, set
+`PNPM_CONFIG_SCOPE`, or set the machine's default with:
+
+```sh
+pnpm config set --global scope @acme
+```

--- a/docs/cli/logout.md
+++ b/docs/cli/logout.md
@@ -13,7 +13,12 @@ pnpm logout [--registry <url>] [--scope <scope>]
 
 If a scope is provided, the registry associated with that scope is used.
 
-The token is removed from [`<pnpm config>/auth.ini`](../npmrc.md#auth-file-locations).
+pnpm 12.1 and newer removes a token written by `pnpm login` from the global
+[`config.yaml`](./config.md), and also checks
+[`<pnpm config>/auth.ini`](../npmrc.md#auth-file-locations) for a token written
+by an earlier version. A token supplied by `.npmrc`, another config file, or the
+environment is revoked at the registry but must be removed from that source
+manually.
 
 ## Options
 

--- a/docs/npmrc.md
+++ b/docs/npmrc.md
@@ -3,17 +3,25 @@ id: npmrc
 title: "Authentication Settings"
 ---
 
-The settings on this page contain sensitive credentials and are stored in INI-formatted files. Do not commit these files to your repository.
+The settings on this page contain sensitive credentials. Most use
+npm-compatible INI files; the structured [`_auth`](#_auth) setting lives in the
+global YAML config. Do not commit credential files to your repository.
 
 For non-sensitive settings (proxy, SSL, registries, etc.), see [Settings (pnpm-workspace.yaml)](./settings.md).
 
 ## Auth file locations
 
-pnpm reads authentication settings from the following files, in order of priority (highest first):
+pnpm reads npm-compatible INI authentication settings from the following
+files, in order of priority (highest first):
 
 1. **`<workspace root>/.npmrc`** — project-level auth. This file should be listed in `.gitignore`.
-2. **`<pnpm config>/auth.ini`** — the primary user-level auth file. `pnpm login` writes tokens here.
+2. **`<pnpm config>/auth.ini`** — the legacy user-level auth file. pnpm 11
+   writes login tokens here; pnpm 12.1 and newer writes structured `_auth` to
+   the global `config.yaml` instead, but continues to read this file.
 3. **`~/.npmrc`** — read as a fallback for easier migration from npm. Use the [`npmrcAuthFile`](./settings/other.md#npmrcauthfile) setting to point to a different file.
+
+The global `config.yaml` may additionally carry pnpm's structured
+[`_auth`](#_auth) setting. pnpm 12.1 and newer writes login tokens there.
 
 The `<pnpm config>` directory is:
 
@@ -113,7 +121,10 @@ pnpm can use different auth tokens for different package scopes, even when those
 
 When installing or publishing `@org-a/*`, pnpm uses `ORG_A_TOKEN`; for `@org-b/*`, it uses `ORG_B_TOKEN`. Optionally, packages without a matching scope fall back to the registry-wide token (`FALLBACK_TOKEN` above), when provided.
 
-`pnpm login --registry=https://npm.pkg.github.com --scope=@org-a` writes the token to the same scope-specific auth key.
+On pnpm 11, `pnpm login --registry=https://npm.pkg.github.com --scope=@org-a`
+writes the token to the same scope-specific auth key. pnpm 12.1 and newer writes
+the equivalent scoped entry under `_auth` in the global `config.yaml` and adds
+the scope to that registry's global `registries` declaration.
 
 This is useful for registries (such as GitHub Packages) that issue tokens per organization or per scope. Previously, auth was selected only by registry URL, so two scopes sharing a registry had to share a token.
 
@@ -171,12 +182,21 @@ Both `pnpm_config__auth` (lowercase) and `PNPM_CONFIG__AUTH` (all-caps, the conv
 
 Each entry also infers a trusted registry route: `@` routes the default registry (and `pnpm add <pkg>` resolves there), and `@org` routes that scope. Because the credential and its destination host arrive in one trusted value, repo-controlled config cannot redirect the token to a different host.
 
-Precedence, from highest to lowest:
+Since v12.1.0, `pnpm login` writes the token in this shape. An unscoped login
+adds an `@` credential without changing the machine's default registry. A
+scoped login adds that scope to the same URL under the global `registries`
+setting; logging the scope into another registry moves both its credential and
+its route. `pnpm logout` removes credentials pnpm wrote from `config.yaml` and
+from the legacy `auth.ini`, while leaving registry routes in place.
 
-1. CLI flags (`--registry`, `--@scope:registry`)
-2. `pnpm_config__auth` / `PNPM_CONFIG__AUTH`
-3. global `config.yaml` `_auth`
-4. `pnpm-workspace.yaml`
+The `pnpm_config__auth` / `PNPM_CONFIG__AUTH` environment value may deliberately
+route a scope or the default registry and overrides repository configuration,
+which lets CI mandate a proxy. A route inferred from `_auth` stored in the
+global `config.yaml` is only a fallback: an explicit `registry` or `registries`
+declaration in `pnpm-workspace.yaml` or the global config wins. The stored
+credential still authenticates requests to its URL; it simply does not redirect
+packages away from an explicitly selected registry. CLI registry flags remain
+the highest-priority route.
 
 Parsing is strict: a malformed value (bad JSON, wrong shape, an invalid registry URL or scope, or an unsupported credential field) fails fast with an error rather than being silently dropped.
 

--- a/docs/registries.md
+++ b/docs/registries.md
@@ -124,6 +124,11 @@ The setting belongs in `pnpm-workspace.yaml` rather than `.npmrc` or the global 
 
 The [global configuration file](./cli/config.md) (`config.yaml`) may declare the *routes* — `scopes` and `prefix` — so that a scope or an alias like `work:` applies to every project on the machine. The server descriptions (`serverType` and `supportsTimeField`) are read only from `pnpm-workspace.yaml`, for the reason above.
 
+Since v12.1.0, [`pnpm login --scope <scope>`](./cli/login.md#--scope-scope)
+adds that machine-wide scope route to the global `registries` setting while it
+records the credential under `_auth`. A later login for the same scope moves the
+route rather than declaring it at two registries.
+
 An entry that declares no routes describes a registry configured elsewhere — for example, the default registry set in `.npmrc`. Such an entry only takes effect when its URL is one the project actually resolves from; pnpm warns about entries that match no configured registry, since they would otherwise sit there inert (a stale URL, a scope that moved).
 
 Environment variables are **not** expanded in the URL keys of this setting, for the same reason they are not expanded in other [registry URLs in `pnpm-workspace.yaml`](./settings.md): the file is committed, and expanding env variables into a request destination could leak secrets to an attacker-controlled host. A key containing a `${...}` placeholder is ignored.

--- a/docs/settings/build.md
+++ b/docs/settings/build.md
@@ -85,8 +85,9 @@ Opt in to reusing a dependency's build output across machines, by restoring
 signed, organization-scoped artifacts through a [pnpr](/pnpr) server instead of
 running the package's lifecycle scripts locally. This is a proof of concept: it
 is off unless configured, it needs a pnpr server started with
-`resolver.artifacts: true`, and it only restores artifacts on Linux/glibc x64
-and arm64.
+`artifacts.enabled: true`, and it restores artifacts on Linux/glibc, macOS, and
+Windows, on x64 and arm64. Other operating systems and libc families build
+locally.
 
 A repository declares eligibility and nothing else:
 
@@ -125,6 +126,12 @@ Any cache failure — an unreachable server, an unverifiable signature, an
 incompatible platform, a bad blob — falls back to the ordinary local build. See
 [Shared side-effects cache](/pnpr/shared-side-effects-cache) for the full setup,
 including the server flag, the trust material, and how an artifact is published.
+
+Since v11.25.0 and v12.1.0, a restored artifact is saved in the shared store
+together with its signed origin. Before a later install reuses it, pnpm checks
+the signature again against the machine's current keys and revalidates its
+owner, package and source identity, platform, policy, and stored files. A bad
+remote variant is quarantined for that pnpr server and is not selected again.
 
 :::note
 

--- a/docs/workspace-task-orchestration.md
+++ b/docs/workspace-task-orchestration.md
@@ -148,12 +148,12 @@ the cycle's members, and may run them in any order relative to each other.
 
 The named package's requested task is the resume point.
 
-pnpm records which tasks pass as a recursive run proceeds. When that record
-belongs to the same invocation — the same selected projects, script bodies,
-command arguments, and script-affecting settings — `--resume-from` skips
-exactly the tasks the record says passed, wherever they sit in the graph, and
-runs everything else. A record left by a different invocation is ignored rather
-than trusted.
+pnpm records which tasks pass as a recursive `run` or `exec` proceeds. When that
+record belongs to the same invocation — the same selected projects, command,
+arguments, and execution-affecting settings (including script bodies for
+`run`) — `--resume-from` skips exactly the tasks the record says passed,
+wherever they sit in the graph, and runs everything else. A record left by a
+different invocation is ignored rather than trusted.
 
 Without a usable record — a first run, a run interrupted before any task
 passed, or a `node_modules` directory pnpm cannot write to — pnpm falls back to
@@ -194,8 +194,17 @@ print each task's output together after it finishes.
 
 The `tasks` declarations configure recursive `run`. Recursive `exec` follows
 workspace project dependencies but has no script task name, so it does not join
-declared `dependsOn` relationships.
+declared `dependsOn` relationships. It still uses the dependency-aware
+scheduler and the persisted `--resume-from` state described above.
 
 `--no-sort` removes graph ordering, and `--parallel` implies `--no-sort`.
 Consequently, both options ignore `tasks` declarations; `--reverse` and
 `--resume-from` also have no ordering edges to transform.
+
+## Other dependency-aware workspace commands
+
+Workspace install, rebuild, pack, publish, stage, and lifecycle work uses the
+same ready-queue scheduling principle: work for a project starts as soon as its
+workspace dependencies finish. These commands follow the workspace package
+graph, not the script relationships under `tasks`, and no longer wait for an
+unrelated topological group to finish first.

--- a/pnpr-docs/cli.md
+++ b/pnpr-docs/cli.md
@@ -14,13 +14,14 @@ pnpr [OPTIONS]
 | `-c, --config <path>` | Path to a [YAML config](configuration.md). When omitted, the global `config.yaml` in pnpr's config dir is used if it exists, otherwise the bundled default config. |
 | `--listen <addr>` | Address to bind to. Defaults to `127.0.0.1:7677`. |
 | `--storage <path>` | Override the [storage](configuration.md) directory from the loaded config — the source of truth for hosted packages. |
-| `--cache <path>` | Override the disposable proxy-cache directory (the mirror of upstream registries plus the resolver cache). Defaults to a `.pnpr-cache` subdirectory of the storage path. |
+| `--cache <path>` | Override the disposable cache directory (the mirror of upstream registries, resolver cache, and local shared-artifact store). Defaults to a `.pnpr-cache` subdirectory of the storage path. |
 | `--public-url <url>` | URL clients should use to reach the server, used when rewriting `dist.tarball` URLs in served packuments. Defaults to `http://<listen>`. |
 | `--packument-ttl-secs <n>` | Seconds before a cached packument is considered stale and refetched. When omitted, the loaded config's value wins. |
 | `--osv` | Enable local [OSV](https://osv.dev/) npm vulnerability checks. Requires a local OSV npm database zip at `--osv-db` or `<cache>/osv/npm/all.zip`. |
 | `--osv-db <path>` | Path to the local OSV npm database zip or extracted JSON directory. |
 | `--disable-registry` | Disable the npm registry surface (packument and tarball reads, publish, unpublish, dist-tags, and search) that is otherwise served whenever the config declares at least one registry. The health and login/token endpoints stay available. |
 | `--disable-resolver` | Disable the install-accelerator surface: `GET /-/pnpr`, `POST /-/pnpr/v0/resolve`, and `POST /-/pnpr/v0/verify-lockfile`. Overrides `resolver.enabled`. |
+| `--disable-artifacts` | Disable the signed shared-artifact surface. Overrides `artifacts.enabled` independently of the resolver. |
 | `-h, --help` | Print help. |
 | `-V, --version` | Print version. |
 

--- a/pnpr-docs/configuration.md
+++ b/pnpr-docs/configuration.md
@@ -48,7 +48,8 @@ pnpr keeps two kinds of data:
 - **`storage`** — the source of truth: packages published to this server plus
   anything served in static mode. Back this up and keep it on a durable volume.
 - **`cache`** — the disposable mirror of upstream registries plus the resolver
-  store, resolver cache, lockfile-verdict cache, and S3 upload staging scratch.
+  store, resolver cache, lockfile-verdict cache, local shared-artifact store,
+  and S3 upload staging scratch.
   Safe to wipe at any time. Defaults to a `.pnpr-cache` subdirectory of
   `storage`; point it at a separate, ephemeral volume to keep cached upstream
   content off the durable disk.
@@ -373,9 +374,9 @@ least 16 bytes. When omitted, a fresh random secret is generated per process,
 which means private cache entries only survive for that process's lifetime —
 set an explicit secret to keep private caches warm across restarts.
 
-## The registry surface and `resolver`
+## Registry, resolver, and artifact surfaces
 
-pnpr exposes two HTTP surfaces:
+pnpr exposes three independently deployable HTTP surfaces:
 
 - The **npm registry surface** — packument and tarball reads, publish,
   unpublish, dist-tags, and search, on the path-less base and on every
@@ -384,29 +385,36 @@ pnpr exposes two HTTP surfaces:
   `--disable-registry` turns it off for one process.
 - The **resolver surface** — the pnpr install-accelerator routes
   (`GET /-/pnpr`, `POST /-/pnpr/v0/resolve`, and
-  `POST /-/pnpr/v0/verify-lockfile`):
+  `POST /-/pnpr/v0/verify-lockfile`). It is enabled by default; the CLI flag
+  `--disable-resolver` overrides the setting:
 
 ```yaml
 resolver:
   enabled: true
-  artifacts: false
 ```
 
-The resolver is enabled by default; the CLI flag `--disable-resolver`
-overrides the setting.
+- The **shared-artifact surface** — the three organization-scoped endpoints of
+  the [shared side-effects cache](shared-side-effects-cache.md) proof of
+  concept. It is off by default and is a top-level peer of `resolver`, so an
+  I/O-bound artifact tier can scale independently of a compute-bound resolver:
 
-`artifacts` mounts the three organization-scoped endpoints of the
-[shared side-effects cache](shared-side-effects-cache.md) proof of concept. It
-is `false` by default, and `--disable-resolver` turns it off with the rest of
-the surface. With it off, those routes are not mounted at all and the handshake
-does not advertise them.
+```yaml
+artifacts:
+  enabled: true
+```
+
+The CLI flag `--disable-artifacts` overrides this setting. With artifacts off,
+its routes are not mounted and the `GET /-/pnpr` handshake advertises an empty
+artifact-version list. The handshake itself is served when either the resolver
+or artifact surface is enabled, so an artifact-only tier is discoverable.
 
 Something must be served: a config with no registries (or the registry
-surface disabled by flag) and the resolver disabled is a startup error.
+surface disabled by flag), the resolver disabled, and artifacts disabled is a
+startup error.
 
 The health endpoint (`/-/ping`) and the account endpoints (login, whoami, and
 token management) are always served, whichever surfaces are enabled — so
-`pnpm login` works even against a resolver-only server. See
+`pnpm login` works even against a resolver-only or artifact-only server. See
 [HTTP endpoints](endpoints.md).
 
 ## `routes`
@@ -463,6 +471,7 @@ parsing, so secrets can be kept out of the file:
 
 ```yaml
 s3:
+  bucket: my-pnpr-packages
   accessKeyId: ${PNPR_S3_ACCESS_KEY_ID}
   secretAccessKey: ${PNPR_S3_SECRET_ACCESS_KEY}
 ```

--- a/pnpr-docs/endpoints.md
+++ b/pnpr-docs/endpoints.md
@@ -4,7 +4,7 @@ title: HTTP endpoints
 ---
 
 pnpr exposes a set of always-on endpoints (health, user accounts, and tokens)
-plus two surfaces:
+plus three surfaces:
 
 - **Registry surface** - npm-compatible package, publish, staged-publish, and
   team endpoints. Served exactly when at least one registry is declared under
@@ -13,8 +13,10 @@ plus two surfaces:
   these routes aren't mounted at all — they answer `404`, not `403`.
 - **Resolver surface** (`resolver.enabled`) - pnpr install-accelerator
   endpoints under `/-/pnpr`.
+- **Shared-artifact surface** (`artifacts.enabled`) - signed artifact publish,
+  lookup, and blob endpoints under `/-/pnpr`. It may run without the resolver.
 
-See [Configuration](configuration.md#the-registry-surface-and-resolver) for
+See [Configuration](configuration.md#registry-resolver-and-artifact-surfaces) for
 the config keys and [CLI reference](cli.md) for the command-line overrides.
 
 ## Always available
@@ -62,14 +64,16 @@ Every request routes through the registry graph:
 The endpoint tables below show path-less shapes; each is equally available
 under a `/~<name>/` prefix.
 
-## Resolver endpoints
+## pnpr protocol endpoints
 
-The resolver endpoints are mounted when `resolver.enabled` is true. The
+The capability handshake is mounted when either `resolver.enabled` or
+`artifacts.enabled` is true. Each protocol advertises its versions
+independently, so resolver-only and artifact-only tiers are both valid. The
 `POST` endpoints require a valid pnpr `Authorization` header.
 
 | Method | Path | Description |
 | --- | --- | --- |
-| `GET` | `/-/pnpr` | Capability handshake. Returns supported protocol versions, currently `{"pnpr":{"versions":[0],"artifacts":[0]}}`. `artifacts` lists the shared-artifact protocol versions the server speaks, and is `[]` when [`resolver.artifacts`](configuration.md#the-registry-surface-and-resolver) is off. A 404 means the server has no compatible resolver surface. |
+| `GET` | `/-/pnpr` | Capability handshake. Returns `versions` for resolver protocols, `fixLockfile` for resolver versions that support lockfile repair, and `artifacts` for shared-artifact protocols. Each is currently `[0]` when its surface is enabled and `[]` otherwise. A 404 means both protocol surfaces are off. |
 | `POST` | `/-/pnpr/v0/resolve` | Resolves one project or workspace against the registries and policy sent by the client. Returns `application/x-ndjson` frames. |
 | `POST` | `/-/pnpr/v0/verify-lockfile` | Verifies an existing lockfile under the client's registry and policy settings without resolving again. Returns `application/x-ndjson` frames. |
 
@@ -78,7 +82,10 @@ The resolver endpoints are mounted when `resolver.enabled` is true. The
 `overrides`, `lockfile`, `frozenLockfile`, `preferFrozenLockfile`,
 `ignoreManifestCheck`, `trustLockfile`, `minimumReleaseAge`,
 `minimumReleaseAgeExclude`, `minimumReleaseAgeIgnoreMissingTime`,
-`trustPolicy`, `trustPolicyExclude`, and `trustPolicyIgnoreAfter`.
+`trustPolicy`, `trustPolicyExclude`, `trustPolicyIgnoreAfter`, and
+`fixLockfile`. Since v0.1.0-alpha.9, a repair request regenerates broken
+lockfile metadata while retaining compatible locked versions, including for a
+filtered install.
 
 Every registry the request would make pnpr fetch from — the `registry` and
 `namedRegistries` origins, plus any direct `http(s)`/`git` URL in a dependency
@@ -103,7 +110,8 @@ The `resolve` response is an NDJSON stream:
 
 Added in: v0.1.0-alpha.8
 
-These three are mounted only when `resolver.artifacts` is also true. They serve
+These three are mounted when top-level `artifacts.enabled` is true, independently
+of `resolver.enabled`. They serve
 the [shared side-effects cache](shared-side-effects-cache.md) proof of concept
 and, like the other `POST` resolver endpoints, require a pnpr `Authorization`
 header. Artifacts are owner-scoped, and in this proof of concept an
@@ -111,7 +119,7 @@ organization's name must equal the authenticated username.
 
 | Method | Path | Description |
 | --- | --- | --- |
-| `PUT` | `/-/pnpr/v0/artifacts` | Stores one opaque signed envelope and its inline content-addressed blobs in the authenticated organization's namespace. At most eight variants per input key. |
+| `PUT` | `/-/pnpr/v0/artifacts` | Stores one immutable opaque signed envelope and its inline content-addressed blobs in the authenticated organization's namespace. At most eight variants per input key; a different artifact whose compatible consumers overlap an existing variant gets `409 Conflict`. |
 | `POST` | `/-/pnpr/v0/artifacts/resolve` | One batched lookup for candidate input keys. Returns at most eight signed variants per key; scanned envelope bytes plus the serialized response share one 16 MiB budget. |
 | `POST` | `/-/pnpr/v0/artifacts/blob` | Reads one owner-scoped blob by its SHA-512 integrity. |
 

--- a/pnpr-docs/install-acceleration.md
+++ b/pnpr-docs/install-acceleration.md
@@ -62,6 +62,12 @@ For frozen restores with an already-fresh lockfile, pnpm can use
 `POST /-/pnpr/v0/verify-lockfile` to get only the server-side trust verdict
 instead of resolving again.
 
+Since pnpr v0.1.0-alpha.9, `pnpm install --fix-lockfile` is forwarded as a
+repair request, including during filtered installs. The server regenerates
+broken lockfile metadata while retaining locked versions that remain
+compatible. The `fixLockfile` list in `GET /-/pnpr` tells the client which
+resolver protocol versions support that request.
+
 ## What a configured server does not cost
 
 Since pnpm v12.0.0-rc.6, an install skips the exchanges it doesn't need, so a

--- a/pnpr-docs/shared-side-effects-cache.md
+++ b/pnpr-docs/shared-side-effects-cache.md
@@ -9,8 +9,8 @@ Added in: pnpr v0.1.0-alpha.8, pnpm v11.25.0 and v12.0.0
 
 This is a proof of concept for
 [pnpm/rfcs#20](https://github.com/pnpm/rfcs/pull/20). It is off on both sides
-unless you turn it on, it restores artifacts on Linux/glibc only, and its
-protocol may change without notice. Lockfile pinning, persistent quarantine,
+unless you turn it on, and its protocol may change without notice. It supports
+Linux/glibc, macOS, and Windows on x64 and arm64. Lockfile pinning,
 publisher-owned artifacts, and key lifecycle policy are deliberately left out.
 
 :::
@@ -38,8 +38,17 @@ tarball, and which platform it belongs to.
 4. It downloads that variant's blobs with `POST /-/pnpr/v0/artifacts/blob`, one
    request per unique SHA-512, recomputing the digest before accepting the
    bytes, and hydrates them into the store.
-5. The restored side-effects map is selected before lifecycle scripts run, so
-   the package's scripts are not executed.
+5. The restored side-effects map and its signed origin are persisted in the
+   shared store, then selected before lifecycle scripts run, so the package's
+   scripts are not executed.
+
+On a later install, pnpm does not trust the persisted mapping merely because it
+is local. It verifies the envelope again against the current public key and
+checks its channel, owner, package and source identity, builder profile,
+platform, manifest, policy, and stored files. An invalid remote envelope is
+removed from consideration and quarantined for that pnpr server. The quarantine
+is persisted in the store, so the same bad variant is not retried on every
+install; another server remains an independent channel.
 
 Any failure along that path — an unreachable server, an unverifiable signature,
 an incompatible platform, a digest mismatch — falls back to the ordinary local
@@ -47,26 +56,34 @@ build. The feature can make an install faster; it can never make it fail.
 
 ## Enabling it on the server
 
-The artifact endpoints are part of the resolver surface and are off by default:
+The artifact surface is off by default and is independent of the resolver:
 
 ```yaml title="config.yaml"
-resolver:
+artifacts:
   enabled: true
-  artifacts: true
 ```
 
-With `artifacts: false` (the default) the three routes are not mounted at all,
-and the handshake at `GET /-/pnpr` does not advertise them.
+With `artifacts.enabled: false` (the default) the three routes are not mounted
+at all, and the handshake at `GET /-/pnpr` does not advertise them. Since pnpr
+v0.1.0-alpha.9, an artifact-only tier may set `resolver.enabled: false`, declare
+no registries, and enable only `artifacts`; pnpm 12.1 can connect to that tier.
+
+By default artifacts live at `<cache>/shared-artifacts/v0`. When the pnpr config
+has an [`s3:` block](storage.md), they live under the reserved
+`.pnpr-artifacts/v0/` namespace in that bucket instead. The S3 layout and
+conditional quota updates let several stateless pnpr replicas share one
+artifact tier.
 
 Artifacts are stored per owner. In this proof of concept an `organization`
 owner's name must equal the authenticated pnpr username, so the login name a
 client uses is the organization it may read and write. Publisher-owned artifacts
 are rejected until publisher discovery is defined.
 
-pnpr enforces its own storage bounds: at most eight variants per input key
-(serialized with a cross-process lock, so replicas sharing one cache agree),
-1 GiB per owner, and 10 GiB across the server's artifact cache. A lookup's
-scanned envelope bytes plus its serialized response share one 16 MiB budget.
+pnpr enforces its own storage bounds: at most eight variants per input key,
+1 GiB per owner, and 10 GiB across the server's artifact cache. Local storage
+serializes updates with an advisory lock; S3 replicas coordinate the quota
+counter with conditional object writes. A lookup's scanned envelope bytes plus
+its serialized response share one 16 MiB budget.
 
 ## Configuring a consumer
 
@@ -155,6 +172,14 @@ artifact once is therefore never handed different bytes for it later, and no
 publishing credential can replace one — releasing a claimed slot is an operator
 action against the server's storage.
 
+Immutability covers every consumer a variant can reach, not only an exactly
+equal compatibility tag. pnpr rejects a new variant when its compatibility set
+overlaps an existing variant for the same input key. A later `universal` build,
+a broader build, or a higher-floor build therefore cannot take precedence for a
+machine already served by an earlier artifact. Disjoint platform builds still
+coexist: different operating systems, architectures, or Node.js majors have no
+consumer in common.
+
 Publication does not switch restoring off: a builder still looks the artifact up
 first, and a hit skips the build the same way it does anywhere else — which
 leaves nothing new to sign, since only an actual local build produces a diff to
@@ -178,19 +203,26 @@ every machine that installs, under the same key id.
 An artifact says which platforms it is valid for, and the proof of concept
 defines one narrow vocabulary rather than interpreting claims it does not
 understand. `universal` is the positive claim for platform-independent output.
-The only tagged form is:
+The tagged forms are:
 
 ```text
 pnpm:v1:linux-<architecture>-node<major>-glibc<major>.<minor>
+pnpm:v1:darwin-<architecture>-node<major>-macos<major>.<minor>
+pnpm:v1:win32-<architecture>-node<major>-windows<major>.<minor>.<build>
 ```
 
 `architecture` is `x64` or `arm64`, and every numeric component is a canonical
 unsigned decimal. A consumer generates the tags for its own glibc version down
 to minor zero, most recent floor first — glibc 2.3 advertises `glibc2.3`,
 `glibc2.2`, `glibc2.1`, `glibc2.0` — and matching is exact against that ordered
-set, so an artifact built against a 2.1 floor serves a 2.3 consumer. A tagged
-match beats `universal`, and equal-rank variants are ordered by ascending signed
-envelope digest.
+set, so an artifact built against a 2.1 floor serves a 2.3 consumer.
+
+A macOS consumer advertises its product-version major and minor, and a Windows
+consumer advertises its NT kernel major, minor, and build. For both, the
+operating system, architecture, and Node.js major must match exactly, while the
+consumer's OS version must be at least the artifact's declared floor. The
+greatest compatible floor wins. A tagged match beats `universal`, and equal-rank
+variants are ordered by ascending signed-envelope digest.
 
 An unknown schema, platform, or dimension, and any malformed tag, is a miss. No
 other platform or libc family is treated as compatible by guessing.
@@ -215,8 +247,18 @@ decoded payload\0
 decoded DER signature
 ```
 
-Input keys begin with `dependency-side-effects:v1:` and carry no host platform
-identity; compatibility tags live in the signed payload instead. The signed
-package name and version, the source tarball integrity, and the owner must all
-match the candidate being installed, and organization eligibility is supplied by
-the caller and checked before lookup.
+Since pnpr v0.1.0-alpha.9, every candidate and signed payload carries a
+discriminated subject. Dependency side effects use
+`{ kind: 'dependency-side-effects', package, sourceIntegrity }` and an input key
+beginning with `dependency-side-effects:v1:`. The protocol also defines
+`{ kind: 'workspace-task', project, task }` with a `workspace-task:v1:` input
+key, so workspace-task artifacts cannot be confused with dependency builds.
+The current pnpm integration publishes and restores dependency side effects;
+the workspace-task subject reserves the protocol identity for task artifacts.
+
+Input keys carry no host platform identity; compatibility tags live in the
+signed payload instead. The artifact kind and input-key prefix must match the
+subject, and its input key, subject, and owner must match the candidate. For a
+dependency, that binds the signed package name and version and source tarball
+integrity to the package being installed. Organization eligibility is supplied
+independently by the caller and checked before lookup.

--- a/pnpr-docs/storage.md
+++ b/pnpr-docs/storage.md
@@ -10,13 +10,20 @@ pnpr keeps two kinds of data:
   approval through [staged publishing](endpoints.md#staged-publishing-endpoints)
   are held here too, under a reserved `.staged/` namespace.
 - **Cache** — the disposable mirror of upstream registries plus the resolver
-  cache, lockfile-verdict cache, and S3 upload staging scratch. Lives under
-  `cache` (defaults to `<storage>/.pnpr-cache`).
+  cache, lockfile-verdict cache, local shared-artifact store, and S3 upload
+  staging scratch. Lives under `cache` (defaults to
+  `<storage>/.pnpr-cache`).
 
-By default both are local directories. Adding an `s3:` block moves the **hosted**
-store into an S3-compatible object store, so the durable data is replicated by
-the provider and can be shared by several stateless pnpr replicas. The cache
-always stays on local disk — only the hosted package store is pluggable.
+By default both are local directories. Adding an `s3:` block moves the
+**hosted** store and the enabled **shared-artifact** store into an S3-compatible
+object store, so they can be shared by several stateless pnpr replicas. The
+ordinary upstream and resolver cache stays on local disk.
+
+Shared artifacts use a reserved `.pnpr-artifacts/v0/` namespace under the
+configured prefix; hosted package objects keep their normal namespace. Without
+S3, artifacts live under `<cache>/shared-artifacts/v0`. They are rebuildable
+cache data rather than authoritative packages, but publication slots are
+immutable while they exist.
 
 Because any S3-compatible endpoint works, this also covers **Cloudflare R2**,
 **MinIO**, **Backblaze B2**, **Wasabi**, etc. — point `endpoint` at the right
@@ -43,7 +50,7 @@ s3:
 
 | Key | Required | Description |
 | --- | --- | --- |
-| `bucket` | yes | Bucket the hosted packages are stored in. |
+| `bucket` | yes | Bucket the hosted packages and enabled shared artifacts are stored in. |
 | `region` | no | AWS S3 needs a real region (e.g. `us-east-1`); Cloudflare R2 uses `auto`. |
 | `endpoint` | no | Custom endpoint for S3-compatible providers. Omit for AWS S3; for R2 it's `https://<account-id>.r2.cloudflarestorage.com`; for MinIO it's e.g. `http://127.0.0.1:9000`. |
 | `prefix` | no | Key prefix every object is stored under. |
@@ -70,6 +77,12 @@ locking:
   object is tolerated, but an object with different bytes left by a concurrent
   publisher of the same `name@version` is never overwritten; the losing publish
   gets a `409` before it writes any packument.
+- **Shared artifacts** — immutable artifact objects use create-only writes, and
+  the quota counter uses conditional updates across replicas. A publication
+  whose compatibility set overlaps an existing artifact for the same input key
+  gets a `409`; a byte-identical retry succeeds. After an ambiguous object-store
+  write failure, pnpr reclaims blobs referenced by no stored envelope and
+  rebuilds quota once active publications drain.
 
 This applies to the S3 backend. The local filesystem backend keeps its
 single-process behavior, since the shared-store race is specific to replicas
@@ -103,6 +116,9 @@ registries:
     sources: [local, npmjs]
 
 defaultRegistry: main
+
+artifacts:
+  enabled: true
 ```
 
 ```sh


### PR DESCRIPTION
## Summary

- add release posts for pnpm 11.25 and 12.1
- document pnpr alpha.9 shared-artifact storage and lockfile-repair features
- correct authentication, shared-artifact, and task-resume reference documentation

## Validation

- `pnpm test`
- `pnpm exec docusaurus build`
- `pnpm exec docusaurus build --locale en`

## Release sources

- https://github.com/pnpm/pnpm/releases/tag/v11.25.0
- https://github.com/pnpm/pnpm/releases/tag/v12.1.0
- https://github.com/pnpm/pnpm/releases/tag/pnpr%400.1.0-alpha.9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Faster workspace task execution with dependency-aware scheduling and per-task concurrency.
  - Resume recursive commands with `--resume-from`, skipping completed tasks.
  - Cross-platform signed shared build artifacts for Linux, macOS, and Windows.
  - Improved authentication storage and scoped registry login handling.
  - Batch approval for staged publishing and registry revision support.
  - `pnpm init` now pins package manager versions to the `latest` tag.

- **Bug Fixes**
  - Improved installation, lockfile repair, updates, builds, and workspace command reliability.

- **Documentation**
  - Updated CLI, authentication, registry, workspace orchestration, and shared-artifact guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->