### PR TITLE
docs: make the pnpm 12 blog posts easier to read

### DIFF
--- a/.claude/skills/unslop/SKILL.md
+++ b/.claude/skills/unslop/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: unslop
+description: Cut AI tells from any writing. Must always apply.
+disable-model-invocation: true
+---
+
+# Unslop
+
+Edit text to remove AI patterns and add human voice.
+
+## Process
+
+1. Scan for the patterns below.
+2. Rewrite. Preserve meaning, match intended tone.
+3. Add soul (see next section).
+4. Self-audit: "What makes this obviously AI generated?" Fix remaining tells.
+
+## Adding soul
+
+Removing patterns is half the job. Sterile, voiceless writing is just as obvious.
+
+- **Have opinions.** React to facts instead of neutrally listing pros and cons.
+- **Vary rhythm.** Short sentences. Then longer ones that take their time. Mix it up.
+- **Acknowledge complexity.** "Impressive but also kind of unsettling" beats "impressive."
+- **Use "I" when it fits.** First person isn't unprofessional.
+- **Let some mess in.** Perfect structure looks machine-made.
+- **Be specific.** Not "this is concerning" but "there's something unsettling about agents churning away at 3am."
+
+## Patterns to detect and fix
+
+### Content
+
+1. **Puffery.** "pivotal moment", "testament to", "evolving landscape", "setting the stage for", "indelible mark", "deeply rooted". Cut puffery, state what happened.
+2. **Name-dropping.** Listing media outlets without context. Pick one, say what was said.
+3. **Superficial -ing phrases.** "highlighting...", "ensuring...", "reflecting...", "showcasing...", "fostering...". Delete or expand with real sources.
+4. **Promotional language.** "nestled", "vibrant", "breathtaking", "groundbreaking", "renowned", "stunning", "must-visit". Use neutral descriptions.
+5. **Vague attributions.** "Experts believe", "Industry reports suggest", "Some critics argue". Name the source or delete.
+6. **Formulaic challenges.** "Despite challenges... continues to thrive." Replace with specific facts.
+
+### Language
+
+7. **AI vocabulary.** Additionally, crucial, delve, enduring, enhance, fostering, garner, interplay, intricate, landscape (abstract), pivotal, showcase, tapestry (abstract), testament, underscore, vibrant. Replace with plain words.
+8. **Fancy ways to say "is".** "serves as", "stands as", "boasts", "features". Just say "is" or "has".
+9. **"Not just X, but Y."** State the point directly instead.
+10. **Rule of three.** Forcing ideas into groups of three. Use the natural number.
+11. **Synonym cycling.** Protagonist, main character, central figure, hero all in one paragraph. Pick one, repeat it.
+12. **False ranges.** "from X to Y" where X and Y aren't on a meaningful scale. List topics directly.
+
+### Style
+
+13. **Em dash overuse.** Avoid em dashes entirely. Use periods or commas only (no parentheses, no en dashes, no hyphen-as-dash substitutes). Em dashes are an AI tell, and reaching for parentheses instead just trades one tell for another. If a thought needs separation, end the sentence or use a comma.
+14. **Colon overuse.** Colons are fine before a list or example. Not as mid-sentence connectors. "If you're coming from traditional automation: instead of registering event handlers, you describe conditions" adds nothing with the colon. Rewrite to let the point stand on its own without comparison framing. "Describing when the scheduler should fire works best as plain English." Same meaning, no crutch punctuation.
+15. **Boldface overuse.** Don't bold every proper noun or acronym.
+16. **Inline-header lists.** The tell is a bold label and colon that restates the line: "**Performance:** Performance improved...". Convert those to prose. A bold lead-in that ends in a period, names the item, and is followed by genuinely new detail ("**Schema in TypeScript.** Tables live in one file.") is fine, not a tell.
+17. **Title case headings.** Use sentence case.
+18. **Decorative emojis.** Remove from headings and bullets.
+19. **Curly quotes.** Replace with straight quotes.
+
+### Communication artifacts
+
+20. **Chatbot phrases.** "I hope this helps!", "Let me know if...", "Of course!", "Certainly!", "Found the smoking gun!" Remove.
+21. **Cutoff disclaimers.** "While specific details are limited..." Find sources or remove.
+22. **Sycophantic tone.** "Great question! You're absolutely right!" Respond directly.
+
+### Filler
+
+23. **Filler phrases.** "In order to" becomes "To". "Due to the fact that" becomes "Because". "It is important to note that" gets deleted.
+24. **Excessive hedging.** "could potentially possibly be argued that it might" becomes "may".
+25. **Generic conclusions.** "The future looks bright." State specific plans or facts.
+
+### Jargon
+
+26. **Abstract metaphor nouns.** Substrate, wedge, vector, locus, vantage, nexus, primitive (as noun), harness (as metaphor), surface (as in "API surface"), bedrock, scaffolding (as metaphor), modality, paradigm, gold-plating, ratchet (as metaphor), evacuate (for moving code), endgame, north star, flywheel. These read as technical but usually have a plainer concrete word. "Substrate" becomes "base". "Wedge in" becomes "add". "Vector" becomes "way" or "method". "Gold-plating" becomes "more than the job needs". "Ratchet" becomes the mechanism's real name or "a limit that only tightens". "Evacuate" becomes "move out". "Endgame" becomes "the last phase". Pick the concrete word.
+
+### Plain speech
+
+27. **Say what it does, not how it feels.** "the database stays close at hand", "SQL you can read", "types that follow your schema" name a feeling. The fix names the mechanism or a number: "`.toSQL()` returns the exact string sent to the database", "a column rename fails the build". Ask what the sentence tells the reader to do or know, then write that. If you can't restate it as a concrete instruction, fact, or number, cut it. One more check: if the sentence could appear unchanged in another project's docs, it says nothing about this one. Cut it.
+28. **Shorten or split dense sentences.** If the reader has to backtrack to parse a sentence, break it in two or drop clauses. One idea per sentence.
+29. **Active voice.** Prefer it. Catch "is/are/was/were + past participle" and name the actor: "queries are validated" becomes "the compiler validates queries", "the file is parsed by the loader" becomes "the loader parses the file". Passive is fine only when the actor is unknown or genuinely doesn't matter.
+30. **Cut adverbs, or use a stronger verb.** "runs quickly" becomes "is fast" or the number. "significantly improves" becomes the measured delta. An adverb propping up a weak verb means the verb is wrong.
+31. **Prefer the plain word.** "utilize" becomes "use", "leverage" becomes "use", "facilitate" becomes "help", "numerous" becomes "many", "in the event that" becomes "if". The fancier synonym is rarely clearer.

--- a/blog/2026-08-10-whats-different-in-pnpm-12.md
+++ b/blog/2026-08-10-whats-different-in-pnpm-12.md
@@ -6,23 +6,23 @@ authors: zkochan
 tags: [release]
 ---
 
-pnpm 12 is a rewrite of pnpm in Rust, **stable since v12.0.0**. Upgrading is not meant to be a migration: apart from the differences below, it keeps the commands, flags, settings, and lockfile format of pnpm 11, and the [documentation](/motivation) applies to both versions.
+pnpm 12 is a rewrite of pnpm in Rust, and it is stable. Upgrading should not feel like a migration. Apart from the differences below, it keeps the commands, flags, settings, and lockfile format of pnpm 11, and [the documentation](/motivation) applies to both versions.
 
-Seven things differ, and one of them — a removed flag — fails outright rather than behaving differently. This post collects them in one place.
+Seven things differ. Six of them change a result, and one, a removed flag, fails outright. This post collects them in one place.
 
 <!--truncate-->
 
 ## Project-aware global bins
 
-A globally installed `node`, `deno`, or `bun` now follows the version the current project pins, instead of always running the globally installed one.
+A globally installed `node`, `deno`, or `bun` now runs the version the current project pins.
 
-If a project pins a runtime — through [`devEngines.runtime`](/package_json#devenginesruntime), or by installing a runtime as a dependency — then running `node` inside that project uses the pinned version, while running it outside any project uses the global one. You no longer need a separate version manager to get that behavior.
+A project pins a runtime through [`devEngines.runtime`](/package_json#devenginesruntime) or by installing the runtime as a dependency. Run `node` inside that project and you get the pinned version. Run it outside any project and you get the global one. You no longer need a separate version manager for this.
 
 The setting that controls this is [`globalShims`](/settings/other#globalshims), and the full description is in [Project-aware global bins](/global-packages#project-aware-global-bins).
 
 ## Git dependency resolution
 
-For repositories on GitHub, GitLab, and Bitbucket, a specifier is now an **identity**, not a choice of transport. All of these name the same dependency and resolve identically:
+For repositories on GitHub, GitLab, and Bitbucket, a specifier now only says which repository you want, not how to reach it. All of these name the same dependency and resolve the same way:
 
 ```
 kevva/is-positive
@@ -31,23 +31,23 @@ git+https://github.com/kevva/is-positive.git
 git+ssh://git@github.com/kevva/is-positive.git
 ```
 
-Each resolves through the host's canonical HTTPS URL, and pnpm never records an SSH URL for those hosts. Which transport a given machine uses to reach the host is that machine's Git configuration, not a property of the project — so a lockfile written on a laptop with SSH keys still installs on a CI runner without them.
+Each resolves through the host's HTTPS URL, and pnpm never records an SSH URL for those hosts. How a machine reaches the host is that machine's Git configuration, not something the project decides. A lockfile written on a laptop with SSH keys installs on a CI runner without them.
 
-In pnpm 11 the resolver probed transports and could record `git@github.com:owner/repo.git`, which then failed for everyone whose machine had no key for that host. If you have such an entry in a lockfile written by an older pnpm, re-resolve those dependencies once with `pnpm update <package>` — pnpm will not rewrite the entry on its own, because the lockfile is the record of what to install.
+pnpm 11 tried transports in turn and could record `git@github.com:owner/repo.git`, which then failed for everyone without a key for that host. If an older lockfile has such an entry, run `pnpm update <package>` once to re-resolve it. pnpm does not rewrite the entry on its own. The lockfile is the record of what to install, and pnpm leaves it alone until you ask.
 
-To reach private repositories over SSH, configure the rewrite in Git rather than in the specifier:
+To reach private repositories over SSH, tell Git to rewrite the URL:
 
 ```sh
 git config --global url."git@github.com:".insteadOf https://github.com/
 ```
 
-pnpm shells out to `git`, so the rewrite applies to all of its Git operations automatically. Details, including how unknown hosts and credentialed URLs are handled, are in [How Git dependencies are resolved](/package-sources#how-git-dependencies-are-resolved).
+pnpm shells out to `git`, so the rewrite applies to every Git operation pnpm runs. Unknown hosts and URLs with embedded credentials are covered in [How Git dependencies are resolved](/package-sources#how-git-dependencies-are-resolved).
 
 ## Naming a package manager
 
-Since v12.0.0-rc.6, pnpm installs the other package managers too — npm, Yarn Classic, Yarn Berry, Yarn 6 (`yarnpkg/zpm`) and Bun — so naming one means the tool itself rather than the npm package that shares its name.
+pnpm 12 can install the other package managers: npm, Yarn Classic, Yarn Berry, Yarn 6 (`yarnpkg/zpm`), and Bun. As a result, naming one of them means the tool, not the npm package that shares its name.
 
-The reason is that those npm packages are not the tool: `yarn` on npm stops at Classic, Yarn 4 is published as `@yarnpkg/cli-dist`, Yarn 6 is not on npm at all, and `node` / `deno` there are wrappers that download a build. So `pnx yarn@4 install` used to fail with a missing version, and `pnpm add -g yarn` gave you Yarn 1.
+Those npm packages are not the tool. `yarn` on npm stops at Classic. Yarn 4 is published as `@yarnpkg/cli-dist`. Yarn 6 is not on npm at all. `node` and `deno` on npm are wrappers that download a build. So `pnx yarn@4 install` used to fail with a missing version, and `pnpm add -g yarn` gave you Yarn 1.
 
 | | pnpm 11 | pnpm 12 |
 |---|---|---|
@@ -57,33 +57,33 @@ The reason is that those npm packages are not the tool: `yarn` on npm stops at C
 | `pnx node@22` / `pnx deno` | runs the wrapper package | runs that release |
 | a globally installed package manager | always the global copy | defers to a project's pin where there is one |
 
-A specifier that locates a package rather than asking for a released version still installs what it names — `pnpm add yarn@npm:yarn@1.22.22`, `pnx yarn@yarnpkg/berry`.
+A specifier that points at a specific package still installs that package. `pnpm add yarn@npm:yarn@1.22.22` gives you the npm package, and `pnx yarn@yarnpkg/berry` runs Yarn from its repository.
 
-Two more things follow from it. A git-hosted dependency is prepared with the package manager *it* asks for, so a repository built with Yarn installs on a machine that has only pnpm. And [`pnpm shim add yarn`](/cli/shim) links a `yarn` command that runs whatever version the current project pins — a shim is never created as a side effect of `pnpm setup` or an install, since it shadows the rest of your `PATH`.
+Two more things follow. A git-hosted dependency is built with the package manager its own repository asks for, so a repository that uses Yarn installs on a machine that has only pnpm. And [`pnpm shim add yarn`](/cli/shim) links a `yarn` command that runs whatever version the current project pins. pnpm never creates such a shim as a side effect of `pnpm setup` or an install, because the shim shadows the rest of your `PATH`.
 
 The full description is in [Other package managers](/package-managers).
 
 ## Lockfiles of cyclic dependency graphs
 
-Since v12.0.0-rc.5, pnpm breaks dependency cycles at a fixed place instead of wherever the installation happens to walk into them: the packages in a cycle are ordered by package ID, and the edges that close the cycle are always cut at the same point.
+pnpm 12 breaks dependency cycles at a fixed place. It orders the packages in a cycle by package ID and always cuts the same edge, no matter where the install entered the cycle. pnpm 11 cut wherever it happened to walk in.
 
-The effect is that the lockfile is a function of the dependency graph alone. Reordering the `packages` globs in `pnpm-workspace.yaml`, reordering entries in `package.json`, or simply installing twice all produce a byte-identical lockfile — in pnpm 11 they could produce different ones for a project with cyclic dependencies. Cycle-heavy workspaces also resolve peers 2–3× faster, use about 25% less memory, and get a substantially smaller lockfile, because a package inside a cycle no longer gets a separate peer variant per path that reaches it.
+The lockfile now depends only on the dependency graph. Reorder the `packages` globs in `pnpm-workspace.yaml`, reorder entries in `package.json`, or install twice, and you get the same bytes. In pnpm 11 a project with cycles could get a different lockfile each time. Workspaces with many cycles also resolve peers 2–3× faster and use about 25% less memory. Their lockfiles shrink too, because a package inside a cycle no longer gets a separate peer variant for every path that reaches it.
 
-Existing lockfiles keep working: `--frozen-lockfile` installs consume them unchanged, and an install that doesn't re-resolve leaves them untouched. The first install that does re-resolve re-keys the peer variants of cyclic packages once, so expect a one-time lockfile diff on such projects. The details are in [How peers are resolved](/how-peers-are-resolved#cyclic-dependencies).
+Existing lockfiles keep working. `--frozen-lockfile` installs them as they are, and an install that doesn't re-resolve leaves them untouched. The first install that does re-resolve rewrites the peer variants of cyclic packages, so expect a one-time lockfile diff. Details in [How peers are resolved](/how-peers-are-resolved#cyclic-dependencies).
 
 ## `packageImportMethod: auto` hardlinks first on Linux
 
-On Linux, the default [`packageImportMethod: auto`](/settings/node-modules#packageimportmethod) now tries a hardlink before a reflink. A reflink materializes a new inode and copies extent bookkeeping inside the filesystem's metadata trees, where a hardlink is one directory entry — on btrfs this roughly halves the time an install spends materializing `node_modules` from a warm store.
+On Linux, the default [`packageImportMethod: auto`](/settings/node-modules#packageimportmethod) now tries a hardlink before a reflink. Hardlinks are cheaper to create, and on btrfs this roughly halves the time an install spends materializing `node_modules` from a warm store.
 
-Nothing changes on ext4, where cloning was never supported and `auto` already hardlinked, and macOS keeps clone-first, because APFS `clonefile` is that platform's cheap primitive. On Linux, cloning becomes the second rung rather than the first: a store that refuses a hardlink is cloned from instead, and copied from if it refuses that too. And `packageImportMethod: clone` still asks for a clone explicitly — which is what you want if you edit files inside `node_modules`, since a hardlinked file *is* the store's file.
+Cloning is still the second choice. A store that refuses a hardlink gets a clone, and a store that refuses that too gets a copy. `packageImportMethod: clone` still asks for a clone outright. Pick that if you edit files inside `node_modules`, because a hardlinked file is the store's file. Nothing changes on ext4, which never supported cloning, so `auto` already hardlinked there. macOS keeps clone-first because APFS `clonefile` is fast.
 
-pnpm 11 keeps clone-first on Linux: changing what the default materializes on disk is not a point-release change.
+pnpm 11 keeps clone-first on Linux. Changing what the default writes to disk is not something for a point release.
 
 ## `engineStrict` and optional subtrees
 
-Under [`engineStrict`](/settings/cli#enginestrict), an install now fails when an incompatible package is reached through a regular `dependencies` edge of a package that is itself being installed — even when that whole subtree hangs off an `optionalDependencies` entry. pnpm 11 installs the package and emits an install-check warning instead.
+With [`engineStrict`](/settings/cli#enginestrict) on, pnpm 12 fails the install when a package that is being installed depends, through regular `dependencies`, on a package with an incompatible engine. It no longer matters that the whole subtree sits under an `optionalDependencies` entry. pnpm 11 installs the package and prints an install-check warning.
 
-What is skipped rather than checked is unchanged in both versions: a package reachable only through optional edges, or through a package that was itself skipped, is still skipped ([#13286](https://github.com/pnpm/pnpm/issues/13286)).
+What gets skipped has not changed. A package reachable only through optional edges, or through a package that was itself skipped, is still skipped in both versions ([#13286](https://github.com/pnpm/pnpm/issues/13286)).
 
 ## `pnpm install --resolution-only` is gone
 
@@ -93,16 +93,16 @@ pnpm 12 does not implement this flag and rejects it:
 error: unexpected argument '--resolution-only' found
 ```
 
-The flag existed to print out peer dependency issues. [`pnpm peers check`](/cli/peers#check) does that directly — it reads the issues from the lockfile, so it needs neither a re-resolution nor an install:
+The flag existed to print peer dependency issues. [`pnpm peers check`](/cli/peers#check) does that instead. It reads the issues from the lockfile, so it needs neither a re-resolution nor an install:
 
 ```sh
 pnpm peers check
 ```
 
-If you call `--resolution-only` from a CI script, this is the one change here that will stop a build rather than change a result, so it is worth grepping for before you switch.
+If a CI script calls `--resolution-only`, this is the one change on this page that stops a build instead of changing a result. Grep for it before you switch.
 
 ## Trying it
 
-`latest` on npm still points at the pnpm 11 line, so pnpm 12 is installed from the `next-12` tag. Homebrew, winget, Scoop, and Chocolatey don't offer it yet. See [Installing pnpm 12](/installation#installing-pnpm-12) for the ways to install it.
+`latest` on npm still points at the pnpm 11 line, so install pnpm 12 from the `next-12` tag. Homebrew, winget, Scoop, and Chocolatey don't offer it yet. [Installing pnpm 12](/installation#installing-pnpm-12) lists the ways to install it.
 
 Please [report any issues](https://github.com/pnpm/pnpm/issues) you run into.

--- a/blog/releases/12.0.md
+++ b/blog/releases/12.0.md
@@ -5,15 +5,15 @@ tags: [release]
 date: 2026-08-26
 ---
 
-pnpm 12 is stable. It is a rewrite of pnpm in Rust, and it is deliberately not a migration: the commands, flags, settings, and lockfile format of pnpm 11 all carry over, and [the documentation](/motivation) describes both versions.
+pnpm 12 is stable. It is a rewrite of pnpm in Rust. Upgrading should not feel like a migration. The commands, flags, settings, and lockfile format of pnpm 11 all carry over, and [the documentation](/motivation) covers both versions.
 
-The short list of things that genuinely behave differently is in [What's different in pnpm 12](/blog/whats-different-in-pnpm-12). This post covers what pnpm 12 adds that pnpm 11 never shipped.
+The few things that behave differently are listed in [What's different in pnpm 12](/blog/whats-different-in-pnpm-12). This post covers what is new.
 
 <!-- truncate -->
 
 :::info Installing it
 
-`latest` on npm still points at the pnpm 11 line, so pnpm 12 is installed from the `next-12` tag:
+`latest` on npm still points at the pnpm 11 line, so install pnpm 12 from the `next-12` tag:
 
 ```sh
 pnpm self-update next-12
@@ -27,62 +27,59 @@ See [Installing pnpm 12](/installation#installing-pnpm-12) for the other ways, i
 
 ### Git dependencies are identities
 
-For repositories on GitHub, GitLab, and Bitbucket, a specifier now names a repository rather than choosing a transport. `github:owner/repo`, `owner/repo`, `git+https://…`, and `git+ssh://git@…` all resolve through the host's canonical HTTPS URL, and the lockfile never records an SSH URL for those hosts. To reach a private hosted repository over SSH, configure the *machine* with git's own URL rewriting:
+For repositories on GitHub, GitLab, and Bitbucket, a specifier now only says which repository you want. `github:owner/repo`, `owner/repo`, `git+https://…`, and `git+ssh://git@…` all resolve through the host's HTTPS URL, and the lockfile never records an SSH URL for those hosts. Whether a machine talks to the host over SSH is that machine's business. If you need SSH for private repositories, tell git to rewrite the URL:
 
 ```sh
 git config --global url."git@github.com:".insteadOf https://github.com/
 ```
 
-pnpm shells out to `git`, so the rewrite applies to all of its git operations. Unknown hosts keep their exact URL, SSH included, and a URL with embedded credentials is kept verbatim and never resolves to a host archive. Details in [How git dependencies are resolved](/package-sources#how-git-dependencies-are-resolved).
+pnpm shells out to `git`, so the rewrite applies to every git operation pnpm runs. Unknown hosts keep their exact URL, SSH included. A URL with embedded credentials is also kept as written. The full rules are in [How git dependencies are resolved](/package-sources#how-git-dependencies-are-resolved).
 
 ### An unrecognized setting in `pnpm-workspace.yaml` is reported
 
-A setting pnpm does not recognize used to be ignored in silence — a misspelled `minimumReleaseAge` dropped the policy it was meant to set, and nothing said so. It is now reported, with the closest real setting name suggested when the key looks like a typo.
+pnpm used to ignore settings it did not recognize. Misspell `minimumReleaseAge` and the policy was silently gone. pnpm 12 reports the unknown key and suggests the closest real setting name when the key looks like a typo.
 
-It **fails** the command with `ERR_PNPM_UNRECOGNIZED_WORKSPACE_SETTINGS` when the project pins a pnpm version the running pnpm satisfies: with the pin honored, the setting cannot have been meant for a different pnpm version, so it is a mistake to fix rather than a key to ignore. Everywhere else it is a warning, so a project that has yet to be cleaned up keeps working. The `pnpm config` subcommands never fail on it, so a broken file can still be inspected and repaired.
+Whether this is an error or a warning depends on the version pin. If the project pins a pnpm version and the running pnpm satisfies it, the command fails with `ERR_PNPM_UNRECOGNIZED_WORKSPACE_SETTINGS`. The setting cannot be meant for some other pnpm version, so it is a mistake. Without a matching pin it is a warning, and the command goes ahead. The `pnpm config` subcommands never fail on it, so you can still inspect and fix a broken file.
 
 ### Lockfiles of cyclic dependency graphs
 
-Dependency cycles are now broken canonically during peer resolution: the members of each cycle are ordered by package id, and the edges that close a cycle are always cut at the same place, wherever the installation walks into the cycle from.
+Peer resolution now breaks dependency cycles at a fixed place. It orders the packages in a cycle by package id and always cuts the same edge, no matter where the install entered the cycle.
 
-The lockfile therefore becomes a pure function of the dependency graph — reordered importers, reordered dependencies, and repeated installs all produce byte-identical lockfiles, which they could not before ([#13846](https://github.com/pnpm/pnpm/issues/13846), [#13865](https://github.com/pnpm/pnpm/issues/13865)). On large cycle-heavy workspaces peer resolution is 2–3× faster, uses about 25% less memory, and produces a substantially smaller lockfile.
+The lockfile now depends only on the dependency graph. Reordering workspace projects or dependencies, or installing twice, produces the same bytes. In pnpm 11 it could produce a different lockfile each time ([#13846](https://github.com/pnpm/pnpm/issues/13846), [#13865](https://github.com/pnpm/pnpm/issues/13865)). Large workspaces with many cycles also resolve peers 2–3× faster and use about 25% less memory, and their lockfiles shrink.
 
-Existing lockfiles keep working: `--frozen-lockfile` consumes them unchanged, and an install that skips resolution leaves them untouched. The first install that actually re-resolves re-keys the walk-order-dependent peer variants of cyclic packages once. See [How peers are resolved](/how-peers-are-resolved#cyclic-dependencies).
+Existing lockfiles keep working. `--frozen-lockfile` installs them as they are, and an install that does not re-resolve leaves them untouched. The first install that does re-resolve rewrites the peer variants of cyclic packages, so expect a one-time lockfile diff. Details in [How peers are resolved](/how-peers-are-resolved#cyclic-dependencies).
 
 ### `packageImportMethod: auto` hardlinks first on Linux
 
-A reflink materializes a new inode and copies extent bookkeeping inside the filesystem's metadata trees, where a hardlink is one directory entry — on btrfs that roughly halves the time an install spends materializing `node_modules` from a warm store. So on Linux, [`auto`](/settings/node-modules#what-auto-tries-first) now tries the hardlink first.
+On Linux, [`auto`](/settings/node-modules#what-auto-tries-first) now tries a hardlink before a reflink. Hardlinks are cheaper to create, and on btrfs this roughly halves the time an install spends materializing `node_modules` from a warm store.
 
-ext4 is unchanged (cloning was never supported there, so `auto` already hardlinked), and macOS keeps clone-first, where APFS `clonefile` is the platform's cheap primitive. On Linux, cloning becomes the second rung rather than the first, so a store that refuses a hardlink still gets a clone; `packageImportMethod: clone` still asks for one outright.
+Cloning is still the second choice, so a store that refuses a hardlink gets a clone, and `packageImportMethod: clone` still asks for one outright. Nothing changes on ext4, which never supported cloning, so `auto` already hardlinked there. macOS keeps clone-first because APFS `clonefile` is fast.
 
 ### `engineStrict` follows the edge, not the subtree
 
-Under [`engineStrict`](/settings/cli#enginestrict), an install now fails when an incompatible package is reached through a regular `dependencies` edge of an installable package, even when that whole subtree hangs off an `optionalDependencies` entry. pnpm 11 installs the package and emits an install-check warning instead. Packages reachable only through optional edges, or through a package that was itself skipped, are still skipped in both versions ([#13286](https://github.com/pnpm/pnpm/issues/13286)).
+With [`engineStrict`](/settings/cli#enginestrict) on, pnpm 12 fails the install when a package that is being installed depends, through regular `dependencies`, on a package with an incompatible engine. It no longer matters that the whole subtree sits under an `optionalDependencies` entry. pnpm 11 installs the package and prints an install-check warning. A package reachable only through optional edges, or through a package that was itself skipped, is still skipped in both versions ([#13286](https://github.com/pnpm/pnpm/issues/13286)).
 
 ## New features
 
-Not all of these are exclusive to pnpm 12. **Registry revisions**, the **remote
-side-effects cache**, **`audit.ignorePrune`**, **batch staged approval**, and the
-**`pnpm init` latest-tag pin** ship in pnpm 11.25 as well; the rest are v12 only,
-because they belong to the Rust rewrite.
+Some of these also ship in pnpm 11.25: registry revisions, the remote side-effects cache, `audit.ignorePrune`, batch staged approval, and the `pnpm init` change. The rest depend on the Rust rewrite and are pnpm 12 only.
 
 ### Project-aware global bins
 
-A globally installed `node`, `deno`, or `bun` follows the version the current project pins, instead of always running the globally installed one — no shell hooks, no `use`-style command. The new [`globalShims`](/settings/other#globalshims) setting picks which globally installed packages get such a shim; it defaults to `{ node: true, deno: true, bun: true }` and merges key-wise, so `globalShims: { typescript: true }` adds one without restating the rest.
+A globally installed `node`, `deno`, or `bun` now runs the version the current project pins. There is no shell hook to install and no `use` command to run. The new [`globalShims`](/settings/other#globalshims) setting chooses which global packages get this treatment. It defaults to `{ node: true, deno: true, bun: true }`, and your own value is merged into that default, so `globalShims: { typescript: true }` adds TypeScript without repeating the three runtimes.
 
-A stable Node.js release is authenticated against the Node.js release team's signatures and switches without asking. Everything else — Deno, Bun, Node.js prereleases, ordinary package bins you enable — asks *Do you trust this project?* once per project and per candidate, and remembers the answer machine-locally. `PNPM_SHIM_BYPASS=1` bypasses the feature for one invocation. See [Project-aware global bins](/global-packages#project-aware-global-bins).
+Stable Node.js releases switch without asking, because pnpm verifies them against the Node.js release team's signatures. Deno, Bun, Node.js prereleases, and package bins you enabled yourself all ask "Do you trust this project?" once per project and per version. pnpm remembers the answer on that machine. Set `PNPM_SHIM_BYPASS=1` to skip the shim for one command. See [Project-aware global bins](/global-packages#project-aware-global-bins).
 
 ### pnpm installs the other package managers
 
-pnpm now provisions npm, Yarn Classic, Yarn Berry, Yarn 6 (`yarnpkg/zpm`), and Bun, each fetched through the trusted package-manager registries, and each npm-published one verified against npm's signature for its exact version before it runs.
+pnpm can now install npm, Yarn Classic, Yarn Berry, Yarn 6 (`yarnpkg/zpm`), and Bun. Each comes from its own trusted source, and the ones published to npm are checked against npm's signature for that exact version before they run.
 
-Three things use it. A **git-hosted dependency** is prepared with the package manager *it* asks for, so a repository built with Yarn installs on a machine that only has pnpm. **[`pnx`](/cli/pnx)** runs one for a single command — `pnx yarn@4 install`, `pnx npm@11 ci`, `pnx node@22`. And **[`pnpm shim add yarn`](/cli/shim)** links a `yarn` that runs whatever the current project pins.
+This shows up in a few places. A git-hosted dependency is built with the package manager its own repository asks for, so a repository that uses Yarn installs fine on a machine that only has pnpm. [`pnx`](/cli/pnx) runs one for a single command, as in `pnx yarn@4 install`, `pnx npm@11 ci`, or `pnx node@22`. And [`pnpm shim add yarn`](/cli/shim) links a `yarn` command that runs whatever version the current project pins.
 
-Naming a package manager therefore means the tool rather than the npm package that shares its name: `pnpm add -g yarn@4` installs Yarn Berry, and in a project `pnpm add yarn@4` records `"packageManager": "yarn@4.18.0"` — what Corepack reads — while every other package manager is recorded in `devEngines.packageManager`. A specifier that locates a package still installs what it names (`pnpm add yarn@npm:yarn@1.22.22`). See [Other package managers](/package-managers).
+One consequence is that the name now means the tool, not the npm package that happens to share its name. `pnpm add -g yarn@4` installs Yarn Berry. Inside a project, `pnpm add yarn@4` writes `"packageManager": "yarn@4.18.0"` to `package.json`, since that is the field Corepack reads. The other package managers are recorded in `devEngines.packageManager`. If you want the npm package, say so with an explicit source, as in `pnpm add yarn@npm:yarn@1.22.22`. More in [Other package managers](/package-managers).
 
 ### Registry revisions
 
-A registry can serve a **replacement artifact** for an already-published version — a rebuild with a vulnerability patched out — without changing the version number and without rewriting the bytes the canonical `name@version` URL has always served. pnpm calls each such artifact a *revision*, addresses it by its complete SHA-512 digest, and records it in the lockfile as one extra line:
+A registry can now offer a replacement tarball for a version that is already published, for example a rebuild with a vulnerability patched out. The version number stays the same, and the original tarball at the `name@version` URL is never rewritten. pnpm calls the replacement a revision, identifies it by its full SHA-512 digest, and records it in the lockfile as one extra line:
 
 ```yaml title="pnpm-lock.yaml"
 packages:
@@ -92,41 +89,41 @@ packages:
       revision: 1
 ```
 
-An entry with no `revision` is revision 0, the original — which is what every entry pnpm has ever written means, so a lockfile that has adopted no replacements is byte-identical to today's.
+An entry without a `revision` line is revision 0, the original tarball. That is what every existing lockfile entry already means, so a lockfile that uses no replacements does not change at all.
 
-A dependency or override may pin a revision explicitly as `<version>+rN`, and [`pnpm update --patches`](/cli/update#--patches) refreshes the locked artifacts without changing a single version. [pnpr](/pnpr) serves revisions for the packages it hosts and proxies them for an upstream registry that advertises them. See [Registry revisions](/registry-revisions).
+A dependency or override can pin a revision as `<version>+rN`. [`pnpm update --patches`](/cli/update#--patches) picks up new revisions without changing any version. [pnpr](/pnpr) serves revisions for the packages it hosts and passes them through from an upstream registry that has them. The format is described in [Registry revisions](/registry-revisions).
 
 ### `pnpm init` pins the latest pnpm
 
-`pnpm init` pins the **latest** released pnpm rather than the version that ran the command, so a project scaffolded by an outdated pnpm no longer inherits that staleness through its own pin ([#7490](https://github.com/pnpm/pnpm/issues/7490)). If the `latest` lookup cannot answer — no network, a slow registry, `offline`, or a `latest` that `minimumReleaseAge` or `trustPolicy` rejects — the running version is pinned as before. The lookup never fails or hangs the command.
+`pnpm init` now pins the latest released pnpm, not the version that ran the command. A project scaffolded with an old pnpm used to inherit that old version through its own pin ([#7490](https://github.com/pnpm/pnpm/issues/7490)). If pnpm cannot find out what `latest` is, because there is no network, the registry is slow, `offline` is set, or `minimumReleaseAge` or `trustPolicy` rejects it, it pins the running version as before. The lookup never fails or hangs the command.
 
 ### Batch approval for staged publishing
 
-[`pnpm stage approve`](/cli/stage#approve) approves several staged packages at once. Run it with no stage id to pick from the staged versions interactively, or pass a list. The whole batch is approved with a **single** one-time password, and pnpm asks for a new one only once the registry stops accepting it. Inside a workspace the packages are approved in dependency order, and one whose workspace dependency could not be approved is skipped rather than published against a dependency that never reached the registry.
+[`pnpm stage approve`](/cli/stage#approve) can approve several staged packages at once. Run it without a stage id to pick from a list, or pass the ids. One one-time password covers the whole batch, and pnpm only asks for a new one when the registry stops accepting it. In a workspace, packages are approved in dependency order. If a package's workspace dependency fails to get approved, pnpm skips that package too, so nothing gets published that points at a version the registry never received.
 
 ### `audit.ignorePrune`
 
-Set [`audit.ignorePrune: true`](/cli/audit#auditignoreprune) and `pnpm audit --fix` removes the ignored GHSA entries that no longer appear in the audit report, so a list of tolerated advisories stops accumulating entries for dependencies that are long gone.
+With [`audit.ignorePrune: true`](/cli/audit#auditignoreprune), `pnpm audit --fix` drops ignored GHSA entries that no longer show up in the audit report. Your list of tolerated advisories stops collecting entries for dependencies you removed long ago.
 
 ### Global commands refuse to run under `sudo`
 
-`pnpm setup`, `pnpm self-update`, and any command that modifies the global installation now fail with `ERR_PNPM_SUDO_NOT_SUPPORTED` under `sudo`, instead of silently operating on the root user's home directory. pnpm keeps global packages and configuration in the invoking user's home, so these commands never need root. Read-only global commands such as `pnpm bin --global` still work.
+`pnpm setup`, `pnpm self-update`, and every other command that changes the global installation now fail under `sudo` with `ERR_PNPM_SUDO_NOT_SUPPORTED`. Before, they quietly modified root's home directory. pnpm keeps global packages and configuration in your own home, so none of these commands needs root. Read-only global commands such as `pnpm bin --global` still work under `sudo`.
 
 ### A remote side-effects cache (proof of concept)
 
-An opt-in proof of concept lets installs reuse a dependency's build output across machines, by publishing and restoring **signed**, organization-scoped artifacts through [pnpr](/pnpr) instead of running the lifecycle scripts locally.
+This is an opt-in proof of concept. Instead of running a dependency's lifecycle scripts on every machine, an install can upload the build output to [pnpr](/pnpr), signed and scoped to your organization, and later installs download it.
 
-A repository names only the eligible [`remoteSideEffectsCache.organization` and `packages`](/settings/build#sideeffectscacheremote); everything describing the act of signing is refused in `pnpm-workspace.yaml` and read from the global config file or the environment instead, so a cloned repository cannot turn the machine's key into a signing oracle. Every cache failure falls back to the ordinary local build. It restores on Linux/glibc x64 and arm64 only for now — see [Shared side-effects cache](/pnpr/shared-side-effects-cache).
+The repository only declares which organization and which packages take part, through [`remoteSideEffectsCache.organization` and `packages`](/settings/build#sideeffectscacheremote). Signing settings are refused in `pnpm-workspace.yaml` and must come from the global config file or the environment. A repository you cloned therefore cannot make your machine sign artifacts with your key. Whenever the cache fails, pnpm runs the build locally as usual. Restoring works on Linux/glibc x64 and arm64 only for now. See [Shared side-effects cache](/pnpr/shared-side-effects-cache).
 
 ## Fixes worth knowing about
 
 ### The compatibility database drops its static-analysis entries
 
-The built-in compatibility database no longer adds dependencies that were detected by static analysis of published packages. Those entries named packages a dependent only imports for its *types*, so installing them was at best unnecessary and at worst broke the dependent: `@typescript-eslint/types` gained a `typescript` dependency resolved to the newest release, which put TypeScript 7 under older `@typescript-eslint` versions and made ESLint fail with `Cannot read properties of undefined (reading 'Intrinsic')`. The `@yarnpkg/extensions` entries and pnpm's own curated ones stay.
+The built-in compatibility database no longer contains the dependencies that static analysis of published packages found. Many of those were packages a dependent imports only for its types. Installing them was unnecessary at best. At worst it broke things. `@typescript-eslint/types` got a `typescript` dependency that resolved to the newest release, which put TypeScript 7 under older `@typescript-eslint` versions, and ESLint failed with `Cannot read properties of undefined (reading 'Intrinsic')`. The `@yarnpkg/extensions` entries and pnpm's own hand-written entries stay.
 
 ### A store inside the project when nothing above it is linkable
 
-When no directory above the project accepts a hard link — an AI agent sandbox that grants write access only to the project, or a container with just the project mounted writable — the default store is created at `<project>/node_modules/.pnpm-store` instead of in the pnpm home directory. In those environments the home store is either read-only or on another volume, which forces every package to be copied instead of hard linked ([#13525](https://github.com/pnpm/pnpm/issues/13525)).
+If no directory above the project accepts a hard link, pnpm now creates the default store at `<project>/node_modules/.pnpm-store` instead of in the pnpm home directory. This happens in an AI agent sandbox that grants write access only to the project, or in a container where only the project is mounted writable. In those environments the home store is read-only or on another volume, and every package had to be copied instead of hard linked ([#13525](https://github.com/pnpm/pnpm/issues/13525)).
 
 ### The `filterLog` pnpmfile hook is deprecated
 


### PR DESCRIPTION
Follow-up to https://github.com/orgs/pnpm/discussions/14399, where the 12.0 release post was called hard to read. The second comment there suggests the [`unslop` skill](https://github.com/cursor/plugins/blob/main/pstack/skills/unslop/SKILL.md), so this PR applies it to both pnpm 12 posts.

## What changed

- `blog/releases/12.0.md` and `blog/2026-08-10-whats-different-in-pnpm-12.md` are rewritten in place. All links, issue references, and code spans from the originals are still present.
- Em dashes: 25 to 0 across both posts. "rather than" / "instead of" contrast framing: 19 to 3. Bold and italic emphasis words: 20 to 0.
- Sentences that explained the reasoning behind a behavior are cut to the behavior itself. Filesystem internals in the `packageImportMethod` section are replaced with the observable effect. Long sentences are split.
- The "Since v12.0.0-rc.x" stamps in the What's different post are dropped, since 12.0 is stable.
- The skill is added at `.claude/skills/unslop/SKILL.md`, unchanged from upstream, so future posts can be checked with `/unslop`.

The skill's "add voice" step is intentionally not applied. That needs the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XtDoGVb7JYAkfJFqQnDRiz


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Refined the pnpm 11 and pnpm 12 comparison guide for clearer, more concise explanations.
  - Updated the pnpm 12 release post with improved wording and structure across breaking changes, features, and fixes.
  - Preserved all documented commands, settings, error codes, version details, and technical behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->