### PR TITLE
docs: when copying beats hardlinking

### DIFF
--- a/docs/settings/node-modules.md
+++ b/docs/settings/node-modules.md
@@ -172,26 +172,30 @@ changes every project that links the same package.
 
 #### Network and virtualized filesystems
 
-`auto` steps down a tier only when a link *fails*, never when one is merely
-slow. On a filesystem where hardlinking works but every operation carries a
+`auto` steps down a tier only when a link *fails*, never when one succeeds
+slowly. That distinction matters when the store and `node_modules` sit on the
+same filesystem and that filesystem services every metadata operation over a
 round trip — a network share (NFS, SMB, Amazon EFS) or a directory passed into
-a VM or container (virtiofs, gRPC-FUSE, 9p) — `auto` therefore keeps
-hardlinking, and the install pays that round trip once per file.
+a VM or container (virtiofs, gRPC-FUSE, 9p). Cloning, where the platform tries
+it first, fails there and steps down; hardlinking then *succeeds*, so `auto`
+stays on it and the install pays a round trip per file.
 
-Setting `packageImportMethod` to `copy` there can be considerably faster,
-because copying reads and writes whole files instead of performing per-file
-metadata operations the filesystem has to service remotely. One project
-installing on a remote server measured:
+(This only arises when both live on that filesystem. A store on a different
+filesystem from `node_modules` cannot be hardlinked from at all — the attempt
+fails with `EXDEV` — so `auto` already falls back to copying on its own.)
+
+Setting `packageImportMethod` to `copy` in that situation can be considerably
+faster, because copying reads and writes whole files instead of performing
+per-file metadata operations the filesystem has to service remotely. One
+project installing on a remote server measured:
 
 | `packageImportMethod` | Install time |
 | --- | --- |
 | `auto` (hardlinking) | 38s |
 | `copy` | 16s |
 
-This is worth trying whenever an install is slow on a machine whose
-`node_modules` or store lives on such a filesystem. It is not a general
-recommendation: on a local disk, copying is the slowest option and uses the
-most space. Measure both on the machine in question.
+It is not a general recommendation: on a local disk, copying is the slowest
+option and uses the most space. Measure both on the machine in question.
 
 [nodeLinker]: #nodelinker
 

--- a/docs/settings/node-modules.md
+++ b/docs/settings/node-modules.md
@@ -170,6 +170,29 @@ If you edit files inside `node_modules`, ask for `clone` explicitly. Under a
 hardlink, the file in `node_modules` *is* the file in the store, so editing it
 changes every project that links the same package.
 
+#### Network and virtualized filesystems
+
+`auto` steps down a tier only when a link *fails*, never when one is merely
+slow. On a filesystem where hardlinking works but every operation carries a
+round trip — a network share (NFS, SMB, Amazon EFS) or a directory passed into
+a VM or container (virtiofs, gRPC-FUSE, 9p) — `auto` therefore keeps
+hardlinking, and the install pays that round trip once per file.
+
+Setting `packageImportMethod` to `copy` there can be considerably faster,
+because copying reads and writes whole files instead of performing per-file
+metadata operations the filesystem has to service remotely. One project
+installing on a remote server measured:
+
+| `packageImportMethod` | Install time |
+| --- | --- |
+| `auto` (hardlinking) | 38s |
+| `copy` | 16s |
+
+This is worth trying whenever an install is slow on a machine whose
+`node_modules` or store lives on such a filesystem. It is not a general
+recommendation: on a local disk, copying is the slowest option and uses the
+most space. Measure both on the machine in question.
+
 [nodeLinker]: #nodelinker
 
 ### modulesCacheMaxAge


### PR DESCRIPTION
Documents the case where `copy` beats the default, under `packageImportMethod`.

`auto` steps down a tier only when a link *fails*, never when one is merely slow. On a filesystem where hardlinking works but every metadata operation is a round trip — a network share (NFS, SMB, EFS) or a directory passed into a VM or container (virtiofs, gRPC-FUSE, 9p) — it therefore keeps hardlinking, once per file.

A project installing on a remote server measured:

| `packageImportMethod` | Install time |
| --- | --- |
| `auto` (hardlinking) | 38s |
| `copy` | 16s |

The section says to measure rather than presenting `copy` as a general recommendation — on a local disk it remains the slowest option and the one that uses the most space.

`versioned_docs/version-11.x` is generated from `docs/` by `pnpm copy-docs`, so it picks this up on the next build; `version-10.x` is left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added guidance for using `packageImportMethod` with network and virtualized filesystems.
  - Documented automatic fallback behavior when hardlinking fails, including fallback to copying.
  - Added performance comparisons between automatic selection and copying, along with local-disk tradeoffs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->