### PR TITLE
docs: a store in a container image layer is copied up, not linked

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -71,6 +71,12 @@ The recipes further down this page start from this image and let pnpm install No
 
 The recipes below use the official pnpm image, which already sets `PNPM_HOME=/pnpm` and puts `/pnpm/bin` on `PATH`, so the store the cache mounts target is at `/pnpm/store`.
 
+:::caution
+
+Baking a warm store into an image layer — running an install during the build so later containers have nothing to download — does not make linking free. A hardlink to a file in a lower image layer succeeds, but overlayfs copies that file into the container's writable layer first, so an install copies most of the store out of the image while reporting that it hardlinked. [`packageImportMethod: copy`](./settings/node-modules.md#a-store-baked-into-a-container-image-layer) is usually faster in that setup, and measurably so on ext4. A BuildKit cache mount does not have this problem, because the store is a mount rather than a layer.
+
+:::
+
 ### Example 1: Build a bundle in a Docker container
 
 Since `devDependencies` is only necessary for building the bundle, `pnpm install --prod` will be a separate stage

--- a/docs/settings/node-modules.md
+++ b/docs/settings/node-modules.md
@@ -220,9 +220,10 @@ failure to step down on.
 The same "succeeds, but slowly" shape appears when the store and
 `node_modules` sit on the same filesystem and that filesystem services every
 metadata operation over a round trip — a network share (NFS, SMB, Amazon EFS)
-or a directory passed into a VM (virtiofs, gRPC-FUSE, 9p). Cloning, where the
-platform tries it first, fails there and steps down; hardlinking then
-succeeds, so `auto` stays on it and the install pays a round trip per file.
+or a directory shared from a host into a VM or container (virtiofs,
+gRPC-FUSE, 9p). Cloning, where the platform tries it first, fails there and
+steps down; hardlinking then succeeds, so `auto` stays on it and the install
+pays a round trip per file.
 Copying reads and writes whole files instead of performing per-file metadata
 operations the filesystem has to service remotely.
 

--- a/docs/settings/node-modules.md
+++ b/docs/settings/node-modules.md
@@ -176,30 +176,40 @@ changes every project that links the same package.
 slowly. Two setups produce links that succeed and are expensive, and on both
 `packageImportMethod: copy` can be considerably faster.
 
-It is not a general recommendation: on a local disk, copying is the slowest
-option and uses the most space. Measure both on the machine in question.
+Neither is a reason to reach for `copy` generally. On an ordinary install —
+store and `node_modules` on the same everyday filesystem, no image layer in
+between — copying is the slowest option and the one that uses the most space.
+Measure both on the machine in question.
 
 #### A store baked into a container image layer
 
 Container runtimes assemble an image from stacked layers, usually with
 overlayfs. A hardlink to a file that lives in a lower layer *succeeds* there,
 but the file is copied into the writable upper layer first. An image that
-ships a pre-populated pnpm store leaves that store in a lower layer, so every
-hardlink into `node_modules` copies a file up — and pnpm's "Packages are hard
-linked from the content-addressable store" line stays accurate while the
-install pays a copy per file anyway.
+ships a pre-populated pnpm store leaves that store in a lower layer, so the
+first link to any store file copies that file up — and pnpm's "Packages are
+hard linked from the content-addressable store" line stays accurate while the
+install copies most of the store out anyway.
 
-Measured on a 13-project workspace, 2074 packages, store fully pre-populated
-so nothing was downloaded, timing only the phase that writes `node_modules`:
+The cost is per file, not per link: a package linked into several projects is
+copied up once and linked cheaply after that. It still lands on most of the
+store, because an install links nearly every file it needs at least once. The
+run below made 69k links and copied up 36.7k distinct files.
+
+Measured with pnpm 12 (through `@pnpm/napi` 12.1.0) on a 13-project workspace,
+2074 packages, store fully pre-populated so nothing was downloaded, timing
+only the phase that writes `node_modules`. Rootless podman on the kernel
+`overlay` storage driver with `metacopy` off, backed by btrfs, `--cpus=8`:
 
 | `packageImportMethod` | Link phase | System time | Written |
 | --- | --- | --- | --- |
 | `auto` (hardlinking) | 2.1s | 8.0s | 36.7k files copied up, 366 MB |
 | `copy` | 1.5s | 5.6s | 874 MB, nothing copied up |
 
-That was on btrfs, where a copy-up is cheap. On ext4 it is a full data copy,
-and the gap widens: one project's CI, running this shape on ext4, went from
-38s to 16s by switching to `copy`.
+Backing that overlay with btrfs is what keeps the gap small: a copy-up there
+can share extents rather than duplicate them. On ext4 every copy-up is a full
+data copy, and the gap widens — one project's CI, running this shape on an
+ext4 boot disk, went from 38s to 16s by switching to `copy`.
 
 Note that the `EXDEV` fallback below does not help here. A cross-layer
 hardlink does not fail — it copies up and reports success — so `auto` has no

--- a/docs/settings/node-modules.md
+++ b/docs/settings/node-modules.md
@@ -170,32 +170,56 @@ If you edit files inside `node_modules`, ask for `clone` explicitly. Under a
 hardlink, the file in `node_modules` *is* the file in the store, so editing it
 changes every project that links the same package.
 
-#### Network and virtualized filesystems
+#### When a link succeeds but costs more than a copy
 
 `auto` steps down a tier only when a link *fails*, never when one succeeds
-slowly. That distinction matters when the store and `node_modules` sit on the
-same filesystem and that filesystem services every metadata operation over a
-round trip — a network share (NFS, SMB, Amazon EFS) or a directory passed into
-a VM or container (virtiofs, gRPC-FUSE, 9p). Cloning, where the platform tries
-it first, fails there and steps down; hardlinking then *succeeds*, so `auto`
-stays on it and the install pays a round trip per file.
-
-(This only arises when both live on that filesystem. A store on a different
-filesystem from `node_modules` cannot be hardlinked from at all — the attempt
-fails with `EXDEV` — so `auto` already falls back to copying on its own.)
-
-Setting `packageImportMethod` to `copy` in that situation can be considerably
-faster, because copying reads and writes whole files instead of performing
-per-file metadata operations the filesystem has to service remotely. One
-project installing on a remote server measured:
-
-| `packageImportMethod` | Install time |
-| --- | --- |
-| `auto` (hardlinking) | 38s |
-| `copy` | 16s |
+slowly. Two setups produce links that succeed and are expensive, and on both
+`packageImportMethod: copy` can be considerably faster.
 
 It is not a general recommendation: on a local disk, copying is the slowest
 option and uses the most space. Measure both on the machine in question.
+
+#### A store baked into a container image layer
+
+Container runtimes assemble an image from stacked layers, usually with
+overlayfs. A hardlink to a file that lives in a lower layer *succeeds* there,
+but the file is copied into the writable upper layer first. An image that
+ships a pre-populated pnpm store leaves that store in a lower layer, so every
+hardlink into `node_modules` copies a file up — and pnpm's "Packages are hard
+linked from the content-addressable store" line stays accurate while the
+install pays a copy per file anyway.
+
+Measured on a 13-project workspace, 2074 packages, store fully pre-populated
+so nothing was downloaded, timing only the phase that writes `node_modules`:
+
+| `packageImportMethod` | Link phase | System time | Written |
+| --- | --- | --- | --- |
+| `auto` (hardlinking) | 2.1s | 8.0s | 36.7k files copied up, 366 MB |
+| `copy` | 1.5s | 5.6s | 874 MB, nothing copied up |
+
+That was on btrfs, where a copy-up is cheap. On ext4 it is a full data copy,
+and the gap widens: one project's CI, running this shape on ext4, went from
+38s to 16s by switching to `copy`.
+
+Note that the `EXDEV` fallback below does not help here. A cross-layer
+hardlink does not fail — it copies up and reports success — so `auto` has no
+failure to step down on.
+
+#### Network and virtualized filesystems
+
+The same "succeeds, but slowly" shape appears when the store and
+`node_modules` sit on the same filesystem and that filesystem services every
+metadata operation over a round trip — a network share (NFS, SMB, Amazon EFS)
+or a directory passed into a VM (virtiofs, gRPC-FUSE, 9p). Cloning, where the
+platform tries it first, fails there and steps down; hardlinking then
+succeeds, so `auto` stays on it and the install pays a round trip per file.
+Copying reads and writes whole files instead of performing per-file metadata
+operations the filesystem has to service remotely.
+
+This only arises when both live on that filesystem. A store on a genuinely
+different filesystem from `node_modules` cannot be hardlinked from at all —
+the attempt fails with `EXDEV` — so `auto` already falls back to copying on
+its own.
 
 [nodeLinker]: #nodelinker
 


### PR DESCRIPTION
Follow-up to #913, which attributed its numbers to the wrong mechanism.

Those 38s → 16s came from CI running a **container image that ships a pre-populated pnpm store**, not from a network filesystem. The cause is overlayfs copy-up: a hardlink to a file in a lower image layer *succeeds*, but the file is copied into the writable upper layer first. So the store baked into the image gets copied out file by file, while pnpm truthfully reports "Packages are hard linked from the content-addressable store".

Two consequences #913 got wrong:

- It described the cost as per-file metadata round trips over a network. Here it is local data movement.
- It reasoned that a store on a different filesystem is already handled, since the hardlink fails with `EXDEV` and `auto` steps down. A cross-layer link does not fail — it copies up and returns success — so `auto` has no failure to step down on.

Measured on a 13-project workspace, 2074 packages, store fully pre-populated so nothing was downloaded, timing only the phase that writes `node_modules`:

| `packageImportMethod` | Link phase | System time | Written |
| --- | --- | --- | --- |
| `auto` (hardlinking) | 2.1s | 8.0s | 36.7k files copied up, 366 MB |
| `copy` | 1.5s | 5.6s | 874 MB, nothing copied up |

That run was on btrfs, where copy-up is cheap — hence only 0.6s. The CI that reported 38s → 16s runs on ext4, where the copy-up is a full data copy.

The network-filesystem case is real and stays, under its own heading; the numbers move under the case that produced them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded guidance on choosing between copying and hardlinking dependencies.
  - Added benchmark-based recommendations for container image layers, including overlay filesystems where copying may be faster.
  - Clarified that network and virtualized filesystem considerations apply when the store and `node_modules` share a filesystem.
  - Added Docker guidance recommending copying for stores baked into image layers and noting that BuildKit cache mounts avoid this issue.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->