### PR TITLE
docs: document publishConfig.registry and publishConfig.access

### DIFF
--- a/docs/package_json.md
+++ b/docs/package_json.md
@@ -272,9 +272,15 @@ However, `foo` is optional, but only to the required version specification.
 
 ## publishConfig
 
-It is possible to override some fields in the manifest before the package is
-packed.
-The following fields may be overridden:
+This field carries settings that change how a package is published:
+[`registry`](#publishconfigregistry), [`access`](#publishconfigaccess),
+[`directory`](#publishconfigdirectory),
+[`linkDirectory`](#publishconfiglinkdirectory), and
+[`executableFiles`](#publishconfigexecutablefiles). These are preserved in the
+published `package.json`.
+
+Additionally, `publishConfig` can be used to override several other fields in the
+manifest before the package is packed. The following fields may be overridden:
 
 * [`bin`](https://github.com/stereobooster/package.json#bin)
 * [`main`](https://github.com/stereobooster/package.json#main)
@@ -316,6 +322,54 @@ Will be published as:
     "version": "1.0.0",
     "main": "lib/index.js",
     "typings": "lib/index.d.ts"
+}
+```
+
+### publishConfig.registry
+
+Added in: v8.6.8
+
+The registry this package publishes to. It overrides the `registry` setting, any
+scope route in [`registries`](./settings/dependency-resolution.md#registries),
+and `pnpm publish --registry`.
+
+```json
+{
+  "name": "foo",
+  "version": "1.0.0",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
+  }
+}
+```
+
+Only the URL belongs here. pnpm matches it against the auth settings in
+[`.npmrc`](./npmrc.md), so the example above publishes with
+`//registry.npmjs.org/:_authToken=...`.
+
+Each package in a `pnpm publish -r` run goes to its own target registry, so one
+command can release a workspace to several registries.
+[`--batch`](./cli/publish.md#--batch) then sends one request per registry.
+
+### publishConfig.access
+
+Added in: v11.2.0
+
+Tells the registry whether the published package should be `public` or
+`restricted`. Same as
+[`pnpm publish --access`](./cli/publish.md#--access-publicrestricted).
+
+Left unset, pnpm sends no access level, so the registry applies its own default
+and the level of an already published package is left alone. Unscoped packages
+cannot be `restricted`.
+
+```json
+{
+  "name": "@acme/foo",
+  "version": "1.0.0",
+  "publishConfig": {
+    "access": "public"
+  }
 }
 ```
 


### PR DESCRIPTION
The `publishConfig` section of the `package.json` page described the field as a way to override manifest fields before packing, and listed only the fields that get hoisted onto the packed manifest. `registry` and `access` are consumed by `pnpm publish` and stay inside `publishConfig` in the tarball, so neither appeared anywhere on the page. A reader looking for "install from one registry, publish to another" had no way to learn that pnpm supports it.

This reframes the section to lead with the settings that change how a package is published, keeps the manifest-override list as a second use of the field, and adds a section for `registry` and one for `access`.

Both fields work in pnpm 11 and 12:

- `publishConfig.registry` — resolved by `findRegistryInfo` in `pnpm11/releasing/commands/src/publish/publishPackedPkg.ts` and `find_registry_info` in `pnpm/crates/publish/src/publish_options.rs`, where it takes precedence over the configured and scoped registries. Added in pnpm/pnpm#6803 (v8.6.8).
- `publishConfig.access` — added in pnpm/pnpm#11746 (v11.2.0).

Two things worth a reviewer's eye:

- The registry section states that `publishConfig.registry` overrides `pnpm publish --registry`. That is verified against two local registries: with `publishConfig.registry` pointing at one and `--registry` at the other, pnpm publishes to the manifest's registry, while npm 11.16.0 publishes to the one named on the command line. It is documented here as the behavior pnpm has; whether the divergence from npm should be fixed is a separate question.
- The access section does not state a default per scope. npm 11's own config definition gives the default as "'public' for new packages, existing packages it will not change the current level", with `restricted` unavailable to unscoped packages, and pnpm sends `access: null` when the field is unset, leaving the decision to the registry. The text says that rather than asserting a scoped-vs-unscoped default.

Grouping packages by target registry is a `--batch` behavior. Plain `pnpm -r publish` sends each package to its own registry one request at a time, which is how the text describes it.

Only `docs/` is edited, since `versioned_docs/version-12.x` is generated by `pnpm copy-docs` and the 10.x/11.x snapshots change only at version cuts.

---
Written by an agent (Claude Code, claude-opus-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded package publication configuration documentation.
  - Clarified which publication settings are preserved and which manifest fields can be overridden before packaging.
  - Added guidance for registry selection, authentication matching, workspace publishing, access values, and defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->