### PR TITLE
docs: clarify frozen lockfile flag migration

### DIFF
--- a/blog/2026-08-10-whats-different-in-pnpm-12.md
+++ b/blog/2026-08-10-whats-different-in-pnpm-12.md
@@ -8,7 +8,7 @@ tags: [release]
 
 pnpm 12 is a rewrite of pnpm in Rust, and it is stable. Upgrading should not feel like a migration. Apart from the differences below, it keeps the commands, flags, settings, and lockfile format of pnpm 11, and [the documentation](/motivation) applies to both versions.
 
-Seven things differ. Six of them change a result, and one, a removed flag, fails outright. This post collects them in one place.
+Eight things differ. Six of them change a result, and two reject command-line syntax that pnpm 11 accepted. This post collects them in one place.
 
 <!--truncate-->
 
@@ -106,3 +106,7 @@ If a CI script calls `--resolution-only`, this is the one change on this page th
 `latest` on npm still points at the pnpm 11 line, so install pnpm 12 from the `latest-12` tag. Homebrew, winget, Scoop, and Chocolatey don't offer it yet. [Installing pnpm 12](/installation) lists the ways to install it.
 
 Please [report any issues](https://github.com/pnpm/pnpm/issues) you run into.
+
+## Explicit frozen-lockfile values
+
+`pnpm install --frozen-lockfile false` is no longer supported. Use `pnpm install --no-frozen-lockfile` to disable frozen-lockfile mode. To enable it, use `pnpm install --frozen-lockfile` without a separate `true` argument ([pnpm/pnpm#14741](https://github.com/pnpm/pnpm/issues/14741)).

--- a/blog/2026-08-10-whats-different-in-pnpm-12.md
+++ b/blog/2026-08-10-whats-different-in-pnpm-12.md
@@ -99,14 +99,14 @@ The flag existed to print peer dependency issues. [`pnpm peers check`](/cli/peer
 pnpm peers check
 ```
 
-If a CI script calls `--resolution-only`, this is the one change on this page that stops a build instead of changing a result. Grep for it before you switch.
+If a CI script calls `--resolution-only`, replace it before switching to pnpm 12.
+
+## Explicit frozen-lockfile values
+
+`pnpm install --frozen-lockfile false` is no longer supported. Use `pnpm install --no-frozen-lockfile` to disable frozen-lockfile mode. To enable it, use `pnpm install --frozen-lockfile` without a separate `true` argument ([pnpm/pnpm#14741](https://github.com/pnpm/pnpm/issues/14741)).
 
 ## Trying it
 
 `latest` on npm still points at the pnpm 11 line, so install pnpm 12 from the `latest-12` tag. Homebrew, winget, Scoop, and Chocolatey don't offer it yet. [Installing pnpm 12](/installation) lists the ways to install it.
 
 Please [report any issues](https://github.com/pnpm/pnpm/issues) you run into.
-
-## Explicit frozen-lockfile values
-
-`pnpm install --frozen-lockfile false` is no longer supported. Use `pnpm install --no-frozen-lockfile` to disable frozen-lockfile mode. To enable it, use `pnpm install --frozen-lockfile` without a separate `true` argument ([pnpm/pnpm#14741](https://github.com/pnpm/pnpm/issues/14741)).

--- a/blog/releases/12.0.md
+++ b/blog/releases/12.0.md
@@ -5,7 +5,7 @@ tags: [release]
 date: 2026-08-26
 ---
 
-pnpm 12 is stable. It is a rewrite of pnpm in Rust. Upgrading should not feel like a migration. The commands, flags, settings, and lockfile format of pnpm 11 all carry over. [The documentation](/motivation) now defaults to pnpm 12, with the pnpm 11 documentation available from the version selector.
+pnpm 12 is stable. It is a rewrite of pnpm in Rust. Upgrading should not feel like a migration. [The documentation](/motivation) now defaults to pnpm 12, with the pnpm 11 documentation available from the version selector.
 
 The few things that behave differently are listed in [What's different in pnpm 12](/blog/whats-different-in-pnpm-12). This post covers what is new.
 
@@ -24,6 +24,10 @@ See [Installing pnpm 12](/installation) for the other ways, including without No
 :::
 
 ## Breaking changes
+
+### Explicit frozen-lockfile values
+
+`pnpm install --frozen-lockfile false` is no longer supported. Use `pnpm install --no-frozen-lockfile` to disable frozen-lockfile mode. To enable it, use `pnpm install --frozen-lockfile` without a separate `true` argument ([pnpm/pnpm#14741](https://github.com/pnpm/pnpm/issues/14741)).
 
 ### Git dependencies are identities
 


### PR DESCRIPTION
Document that pnpm 12 rejects `pnpm install --frozen-lockfile false` and that users should replace it with `pnpm install --no-frozen-lockfile`. Add the migration note to the v12.0 release article and the linked differences guide, and remove the release article's claim that all v11 flags carry over.

Companion documentation for https://github.com/pnpm/pnpm/pull/14765, addressing https://github.com/pnpm/pnpm/issues/14741. The GitHub v12.0.0 release notes already contain the same guidance.

Validation: English Docusaurus production build passed.

---
Written by an agent (Codex, GPT-6).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated pnpm 12 documentation to reflect eight differences from pnpm 11.
  - Documented that `pnpm install --frozen-lockfile false` is no longer supported.
  - Clarified that `--no-frozen-lockfile` disables frozen-lockfile mode, while `--frozen-lockfile` enables it without a separate `true` argument.
  - Updated migration guidance for replacing `--resolution-only` before switching to pnpm 12.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->