### PR TITLE
docs: package map is written only under nodeExperimentalPackageMap

### DIFF
--- a/docs/settings/node-modules.md
+++ b/docs/settings/node-modules.md
@@ -41,9 +41,9 @@ Added in: v11.8.0
 * Default: **false**
 * Type: **Boolean**
 
-When `true`, pnpm injects the generated `node_modules/.package-map.json` into pnpm-managed Node.js script environments by adding Node's `--experimental-package-map` option to `NODE_OPTIONS`.
+When `true`, pnpm writes `node_modules/.package-map.json` during isolated and hoisted installs and injects it into pnpm-managed Node.js script environments by adding Node's `--experimental-package-map` option to `NODE_OPTIONS`.
 
-The package map is generated during isolated and hoisted installs. This setting only controls whether pnpm passes the generated map to scripts.
+Nothing reads the map without this setting, so pnpm does not write one. An install that stops writing the map also removes one an earlier install left.
 
 CLI and environment configuration use the kebab-case name `node-experimental-package-map`.
 

--- a/versioned_docs/version-11.x/settings/node-modules.md
+++ b/versioned_docs/version-11.x/settings/node-modules.md
@@ -41,9 +41,9 @@ Added in: v11.8.0
 * Default: **false**
 * Type: **Boolean**
 
-When `true`, pnpm injects the generated `node_modules/.package-map.json` into pnpm-managed Node.js script environments by adding Node's `--experimental-package-map` option to `NODE_OPTIONS`.
+When `true`, pnpm writes `node_modules/.package-map.json` during isolated and hoisted installs and injects it into pnpm-managed Node.js script environments by adding Node's `--experimental-package-map` option to `NODE_OPTIONS`.
 
-The package map is generated during isolated and hoisted installs. This setting only controls whether pnpm passes the generated map to scripts.
+Nothing reads the map without this setting, so pnpm does not write one. An install that stops writing the map also removes one an earlier install left.
 
 CLI and environment configuration use the kebab-case name `node-experimental-package-map`.
 


### PR DESCRIPTION
`node_modules/.package-map.json` is currently described as always generated, with `nodeExperimentalPackageMap` deciding only whether scripts receive it:

> The package map is generated during isolated and hoisted installs. This setting only controls whether pnpm passes the generated map to scripts.

pnpm/pnpm#14511 makes generation conditional on the setting in both stacks — nothing reads the file without it, and building it costs every install a pass over the lockfile — and makes an install that stops writing the map remove the one a previous install left. This updates the current and the `version-11.x` settings pages to match.

**Merge this with the release that carries pnpm/pnpm#14511**, not before: until then the published docs are correct as they stand.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015YZGn6jMwYeMveHf8RHKfU


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that enabling `nodeExperimentalPackageMap` creates `.package-map.json` during isolated and hoisted installs.
  * Documented that the package map is injected into pnpm-managed Node.js script environments when the setting is enabled.
  * Clarified that disabling the setting prevents map creation and removes a map generated by an earlier install.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->