### PR TITLE
fix: clarify purpose of minimumReleaseAge to mention defective packages

### DIFF
--- a/docs/settings/dependency-resolution.md
+++ b/docs/settings/dependency-resolution.md
@@ -251,7 +251,7 @@ Added in: v10.16.0
 * Default: **1440** (since v11), **0** (before v11)
 * Type: **number (minutes)**
 
-To reduce the risk of installing compromised packages, you can delay the installation of newly published versions. In most cases, malicious releases are discovered and removed from the registry within an hour.
+To reduce the risk of installing compromised or defective packages, you can delay the installation of newly published versions. In most cases, malicious releases are discovered and removed from the registry within an hour.
 
 `minimumReleaseAge` defines the minimum number of minutes that must pass after a version is published before pnpm will install it. This applies to **all dependencies**, including transitive ones.
 

--- a/versioned_docs/version-10.x/settings.md
+++ b/versioned_docs/version-10.x/settings.md
@@ -205,7 +205,7 @@ Added in: v10.16.0
 * Default: **0**
 * Type: **number (minutes)**
 
-To reduce the risk of installing compromised packages, you can delay the installation of newly published versions. In most cases, malicious releases are discovered and removed from the registry within an hour.
+To reduce the risk of installing compromised or defective packages, you can delay the installation of newly published versions. In most cases, malicious releases are discovered and removed from the registry within an hour.
 
 `minimumReleaseAge` defines the minimum number of minutes that must pass after a version is published before pnpm will install it. This applies to **all dependencies**, including transitive ones.
 

--- a/versioned_docs/version-11.x/settings/dependency-resolution.md
+++ b/versioned_docs/version-11.x/settings/dependency-resolution.md
@@ -251,7 +251,7 @@ Added in: v10.16.0
 * Default: **1440** (since v11), **0** (before v11)
 * Type: **number (minutes)**
 
-To reduce the risk of installing compromised packages, you can delay the installation of newly published versions. In most cases, malicious releases are discovered and removed from the registry within an hour.
+To reduce the risk of installing compromised or defective packages, you can delay the installation of newly published versions. In most cases, malicious releases are discovered and removed from the registry within an hour.
 
 `minimumReleaseAge` defines the minimum number of minutes that must pass after a version is published before pnpm will install it. This applies to **all dependencies**, including transitive ones.
 


### PR DESCRIPTION
Improves the purpose of the `minimumReleaseAge` setting. It can deal with not only compromised but also defective (e.g. depending on packages that have not been published yet or having critical non-security bugs by mistake) packages.

By the way, I once published a version like that, and right in the middle of working on fixing those kinds of flaws, someone opened an unsolicited, annoying AI slop issue pointing out the flaw. minimumReleaseAge is useful in times like this too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified that delaying newly published packages can reduce the risk of installing compromised or defective releases.
  - Applied this clarification to the current dependency-resolution documentation and the versioned documentation for supported releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->