### PR TITLE
docs: document pnpm 11.26, 12.2, 12.3, 12.4 and pnpr 0.1.0-alpha.11

### DIFF
--- a/blog/releases/11.26.md
+++ b/blog/releases/11.26.md
@@ -1,0 +1,127 @@
+---
+title: pnpm 11.26
+authors: zkochan
+tags: [release]
+date: 2026-09-07
+---
+
+pnpm 11.26 brings the JavaScript CLI level with what pnpm 12 gained over the
+past two weeks: `workspace:` ranges in catalogs, the supply-chain flags on
+`remove` and `update`, `pnpm change check` for CI, and `pnpm deploy` without
+injected dependencies.
+
+<!-- truncate -->
+
+## Minor Changes
+
+### Catalogs can hold a `workspace:` range
+
+A [catalog](/catalogs#workspace-dependencies-in-a-catalog) entry may now be a
+`workspace:` range, so the version a workspace dependency is linked by lives in
+`pnpm-workspace.yaml` with every other version:
+
+```yaml title="pnpm-workspace.yaml"
+catalog:
+  '@example/utils': workspace:^
+```
+
+Both protocols are replaced on publish.
+
+### Supply-chain flags on `remove` and `update`
+
+[`pnpm remove`](/cli/remove#supply-chain-policy-flags) and
+[`pnpm update`](/cli/update#supply-chain-policy-flags) accept
+`--trust-lockfile`, `--no-trust-lockfile`, `--trust-policy`,
+`--trust-policy-exclude`, and `--trust-policy-ignore-after`. `pnpm remove`
+checks the whole lockfile against the active policies unless `--trust-lockfile`
+is set, because removing a package rewrites it.
+
+### `pnpm change check`
+
+[`pnpm change check`](/cli/change#check) validates the versions already
+committed in the workspace against the `versioning.epics` bands and
+`versioning.fixed` groups, without reading any change intent. That makes it the
+step to run on every pull request: a version that drifted out of its band is
+caught where it was introduced rather than at release time, and every violation
+is listed at once.
+
+## `pnpm deploy` without injected dependencies
+
+[`pnpm deploy`](/cli/deploy) no longer requires `injectWorkspacePackages`. Where
+a workspace dependency's peer has more than one possible version in the deployed
+graph the binding is ambiguous, and the deploy fails with
+`ERR_PNPM_DEPLOY_AMBIGUOUS_PEER` naming the conflicting versions. Pin the peer
+with `overrides` to deploy without injection
+([#9386](https://github.com/pnpm/pnpm/issues/9386)).
+
+## Build approval before the package is installed
+
+`pnpm add --allow-build=!<pkg>` now denies a build rather than dropping the
+decision, global installs included. Previously `pnpm add -g` left the package
+undecided, so the post-install prompt offered the very build you had just
+rejected.
+
+[`pnpm approve-builds <pkg>`](/cli/approve-builds) and
+`pnpm approve-builds !<pkg>` also save a decision when nothing is awaiting
+approval, warning about a package that is not awaiting one instead of erroring
+out ([#14067](https://github.com/pnpm/pnpm/issues/14067)).
+
+## Other changes
+
+- Fetch and tarball errors and retry logs hide URL credentials, query strings,
+  and fragments that could expose secrets.
+- `pnpm audit` excludes ignored advisories from the vulnerability totals and
+  severity counts, and reports them separately
+  ([#14535](https://github.com/pnpm/pnpm/issues/14535)). `--fix` works without a
+  value and when another flag follows it, and `--fix=override` respects
+  `saveExact` and `savePrefix`
+  ([#13261](https://github.com/pnpm/pnpm/issues/13261),
+  [#11523](https://github.com/pnpm/pnpm/issues/11523)).
+- `pnpm install` accepts a symlinked lockfile again when config dependencies are
+  unchanged, the arrangement Bazel and Nix use. Writes through a symlinked
+  lockfile stay blocked, and a lockfile with a byte order mark survives a config
+  dependency update ([#14372](https://github.com/pnpm/pnpm/issues/14372)).
+- `pnpm install` relinks workspace packages when `publishConfig.linkDirectory`
+  changes; a frozen install asks for the lockfile to be regenerated
+  ([#14488](https://github.com/pnpm/pnpm/issues/14488)).
+- `pnpm install --node-linker=hoisted` no longer downloads skipped optional
+  dependencies when `node_modules` already exists
+  ([#14139](https://github.com/pnpm/pnpm/issues/14139)).
+- An auto-installed optional peer satisfies its declared range even when the
+  workspace root uses a version outside it
+  ([#13867](https://github.com/pnpm/pnpm/issues/13867)).
+- The JavaScript pnpm can again switch to a project's pinned pnpm version on a
+  host with no matching native binary. Where a version requires an unavailable
+  binary, the error names the unsupported host
+  ([#13622](https://github.com/pnpm/pnpm/issues/13622)).
+- `pnpm self-update`, `pnpm with`, and automatic version switching no longer
+  wait through registry retries when a configured registry has no signatures and
+  `registry.npmjs.org` is unavailable
+  ([#14483](https://github.com/pnpm/pnpm/issues/14483)).
+- Node.js downloads from `nodeDownloadMirrors` carry the URL-scoped npm
+  credentials, bearer tokens, basic auth, and `tokenHelper` included
+  ([#14334](https://github.com/pnpm/pnpm/issues/14334)).
+- Relative `scriptShell` paths resolve from the workspace root; a bare command
+  name such as `bash` still goes through `PATH`
+  ([#14422](https://github.com/pnpm/pnpm/issues/14422)).
+- Argument forwarding on Windows with `shellEmulator` preserves trailing
+  backslashes, line breaks, and literal shell expressions
+  ([#14548](https://github.com/pnpm/pnpm/issues/14548)).
+- `pnpm import` preserves the project-local lockfile when `lockfileDir` points
+  elsewhere, and restores the destination lockfile on failure
+  ([#14563](https://github.com/pnpm/pnpm/issues/14563)).
+- `catalogMode` and `--save-catalog` no longer move local paths, tarballs, or
+  `workspace:<path>` specifiers into catalogs
+  ([#14437](https://github.com/pnpm/pnpm/issues/14437)).
+- `--side-effects-cache`, `--no-side-effects-cache`, and
+  `PNPM_CONFIG_SIDE_EFFECTS_CACHE` toggle only the local cache, leaving a remote
+  cache configured in `sideEffectsCache` in place.
+- `pnpm unpublish` handles a registry's two-factor challenge through web
+  authentication or a one-time password prompt
+  ([#14464](https://github.com/pnpm/pnpm/issues/14464)).
+- `pnpm outdated` and `pnpm update` follow GitHub Actions referenced with the
+  self-repository syntax, `uses: $/.github/actions/setup`.
+- `pnpm remove` accepts `--unsafe-perm`.
+
+For the complete list of changes, see the [v11.26.0 release
+notes](https://github.com/pnpm/pnpm/releases/tag/v11.26.0).

--- a/blog/releases/12.2-12.3.md
+++ b/blog/releases/12.2-12.3.md
@@ -1,0 +1,191 @@
+---
+title: pnpm 12.2-12.3
+authors: zkochan
+tags: [release]
+date: 2026-09-02
+---
+
+pnpm 12.2 and 12.3 are largely a catch-up pair: a long list of things pnpm 11
+did that the Rust CLI did not, put back. Catalogs learned the `workspace:`
+protocol, `pnpm remove` and `pnpm update` gained the supply-chain flags, every
+project-aware global command became a real executable, and hostname resolution
+went back to the system resolver on Linux and Windows. Large workspaces install
+noticeably faster.
+
+<!-- truncate -->
+
+## Minor Changes
+
+### Catalogs can hold a `workspace:` range
+
+A [catalog](/catalogs#workspace-dependencies-in-a-catalog) entry may now be a
+`workspace:` range, so the version a workspace dependency is linked by is
+written in one place like every other version:
+
+```yaml title="pnpm-workspace.yaml"
+catalog:
+  '@example/utils': workspace:^
+```
+
+A `package.json` referencing `"@example/utils": "catalog:"` links the workspace
+project, and both protocols are replaced on publish.
+
+### Supply-chain flags on `remove` and `update`
+
+[`pnpm remove`](/cli/remove#supply-chain-policy-flags) and
+[`pnpm update`](/cli/update#supply-chain-policy-flags) now take
+`--trust-lockfile`, `--no-trust-lockfile`, `--trust-policy`,
+`--trust-policy-exclude`, and `--trust-policy-ignore-after`, the same flags
+`install` and `add` take, so a policy can be relaxed or tightened for one run.
+
+Removing a package rewrites the lockfile, so `pnpm remove` verifies the whole
+lockfile against the active policies rather than only the entries of the package
+it is removing. `pnpm` also honors `--config.trust-lockfile=<value>` and accepts
+the bare `--trust-lockfile` / `--no-trust-lockfile` spelling on the commands that
+previously read the setting from the config file alone.
+
+### Project-aware global commands are native executables
+
+Every context-aware global command, `node`, `deno`, `bun`, and the shims
+[`pnpm shim add`](/cli/shim#the-shim-is-a-real-executable) creates, is now a
+native executable on every platform. On Windows, `<name>.exe` replaces the
+`.cmd` and `.ps1` pair.
+
+The practical difference: no shell sits between you and the command, so an
+environment variable whose name is not a valid shell identifier survives the
+hop. Shims written by earlier pnpm 12 releases are migrated on the next global
+install or `pnpm self-update`.
+
+## Installs in large workspaces
+
+Most of the work in these two releases went here, all of it under
+[#14352](https://github.com/pnpm/pnpm/issues/14352):
+
+- Workspace patterns are probed concurrently and the discovered `package.json`
+  files are read in parallel. Literal directories and trailing-star patterns
+  take a shortcut.
+- `pnpm-lock.yaml` is parsed while the projects are being discovered, and the
+  resolver no longer copies the whole lockfile before it starts.
+- The workspace dependency graph is built once per run instead of twice.
+- The check that decides whether the lockfile needs updating stopped comparing
+  every project against every lockfile entry.
+- Each named `workspace:` dependency is resolved once and reused by every
+  project that declares it, and `link:` dependencies re-anchor in
+  lockfile-relative space.
+- Peer ranges are parsed once and cached, and the peer-dependency report at the
+  end of a resolving install inspects only the projects resolution flagged
+  ([#14359](https://github.com/pnpm/pnpm/issues/14359)).
+- Sorting and rendering the big lockfile sections happens in parallel.
+
+Workspace patterns also follow pnpm 11's dot-directory rule again: a wildcard
+does not match a dot-prefixed directory, so `packages/*` and `**` skip
+`packages/.cache` and `.git`. A pattern that names one explicitly still matches.
+
+## Networking
+
+On both Linux and Windows, pnpm now resolves registry hostnames through the
+system resolver instead of its own DNS client.
+
+On Windows the built-in client bound a UDP socket per lookup, which made
+Defender Firewall ask to allow `pnpm.exe` again after every `pnpm self-update`
+([#14405](https://github.com/pnpm/pnpm/issues/14405)). On Linux an
+`/etc/resolv.conf` carrying an option the bundled resolver did not recognize,
+such as `options no_tld_query`, made pnpm ignore the configured nameservers and
+silently query Google's public DNS instead
+([#14469](https://github.com/pnpm/pnpm/issues/14469)).
+
+Fetch and tarball errors no longer print the secrets of the URL they name.
+Inline `user:pass@` credentials and the query string or fragment of a signed URL
+are hidden, so a failed install cannot leak them into terminal scrollback or CI
+logs.
+
+## `pnpm deploy` without injected dependencies
+
+[`pnpm deploy`](/cli/deploy) no longer requires `injectWorkspacePackages`. A
+linked workspace dependency is rewritten to a `file:` dependency in the
+dedicated deploy lockfile, and the peer dependencies it declares are bound to
+the deployed graph's own resolution.
+
+Where a peer resolves to more than one version in that graph the binding is
+ambiguous, and choosing between the candidates is exactly what injecting the
+package would have decided, so the deploy still fails. It now fails with
+`ERR_PNPM_DEPLOY_AMBIGUOUS_PEER`, naming the package, the peer, and the
+competing versions, and suggesting an `overrides` entry, instead of refusing
+every non-injected workspace up front
+([#9386](https://github.com/pnpm/pnpm/issues/9386)).
+
+## Other changes
+
+- `pnpm add <local directory>`, `pnpm add <local tarball>`, `pnpm add file:<path>`
+  and `pnpm add <tarball URL>` work again. A specifier given without a `<name>@`
+  prefix is no longer read as a registry package name
+  ([#14437](https://github.com/pnpm/pnpm/issues/14437)).
+- `pnpm update --interactive` renders its checklist the way pnpm 11 does. Group
+  headings and column headers are separators the cursor skips, columns line up
+  across groups, `a` toggles all and `i` inverts, and the confirmed selection is
+  echoed ([#14423](https://github.com/pnpm/pnpm/issues/14423)).
+- `pnpm run`, `pnpm exec`, `pnpm rebuild`, the script shortcuts, and
+  `pnpm link`, `pnpm outdated`, `pnpm import`, and the packing commands all load
+  the [pnpmfile](/pnpmfile), so `updateConfig` settings such as `extraEnv` and
+  `extraBinPaths` reach the processes they spawn
+  ([#14433](https://github.com/pnpm/pnpm/issues/14433),
+  [#14377](https://github.com/pnpm/pnpm/issues/14377)).
+- `pnpm run "/pattern/"` runs the matched scripts concurrently up to
+  `workspaceConcurrency`, with prefixed output. Filtered and recursive `run` and
+  `exec` no longer hang when a script reads from the terminal, so interactive
+  prompts work again wherever pnpm never runs a second script alongside
+  ([#14397](https://github.com/pnpm/pnpm/issues/14397)).
+- pnpm keeps the surrounding quotes out of `.npmrc` values, restoring
+  authentication with registries configured as `:_authToken="${TOKEN}"`
+  ([#14427](https://github.com/pnpm/pnpm/issues/14427)).
+- `minimumReleaseAgeStrict` defaults to `true` whenever `minimumReleaseAge` is
+  explicitly configured, wherever it was set. The built-in 1440-minute default
+  stays non-strict ([#14409](https://github.com/pnpm/pnpm/issues/14409)).
+- `pnpm unpublish` completes a registry's two-factor challenge instead of
+  failing with `ERR_PNPM_UNAUTHORIZED` while logged in
+  ([#14464](https://github.com/pnpm/pnpm/issues/14464)).
+- `catalogMode` and `--save-catalog` no longer move a local path, tarball, or
+  `workspace:<path>` specifier into a catalog: such a specifier is resolved
+  against the project that declares it, so one catalog entry cannot mean the
+  same directory for every project
+  ([#14437](https://github.com/pnpm/pnpm/issues/14437)).
+- `pnpm config` accepts `-g`, `--location`, and `--json` before its subcommand,
+  and a global `pnpm config` skips project version switching, so registry
+  authentication can be configured before pnpm downloads a project-pinned
+  version ([#14421](https://github.com/pnpm/pnpm/issues/14421),
+  [#14463](https://github.com/pnpm/pnpm/issues/14463)).
+- Detached child processes survive on Windows, including when another program
+  launches `pnpm` directly without a shell, as `nr` from `@antfu/ni` does
+  ([#14447](https://github.com/pnpm/pnpm/issues/14447)).
+- Transient Windows file-lock errors are retried while linking dependencies with
+  the isolated linker and while replacing hoisted packages
+  ([#14407](https://github.com/pnpm/pnpm/issues/14407),
+  [#14349](https://github.com/pnpm/pnpm/issues/14349)).
+- `globalDir` and `globalBinDir` are honored wherever they are set, so
+  `pnpm add -g` no longer fails after `pnpm config set -g global-bin-dir`
+  ([#14336](https://github.com/pnpm/pnpm/issues/14336)).
+- Resolution works against registries whose version manifests carry `_npmUser`,
+  `dist.attestations`, `dist.unpackedSize`, `dist.fileCount`, or
+  `peerDependenciesMeta` in a shape npm does not use. Such a version was skipped
+  as though it had never been published.
+- `pnpm audit --fix` works without a value and when another flag follows it, and
+  `--fix=override` respects `saveExact` and `savePrefix`
+  ([#13261](https://github.com/pnpm/pnpm/issues/13261),
+  [#11523](https://github.com/pnpm/pnpm/issues/11523)).
+
+## pnpr 0.1.0-alpha.10
+
+A shared build artifact publication that cannot unregister itself no longer
+stops the registry reclaiming space or refusing further publications. A
+publication says at intervals that it is still working, and a registration that
+has gone quiet for an hour is written off. A publication whose bookkeeping write
+failed therefore stops holding back the collector that reclaims unreferenced
+blobs, returns the compatibility scopes it claimed, and stops counting toward the
+limit on publications in flight.
+
+For the complete client changes, see the [v12.2.0][] and [v12.3.0][] release
+notes. The server changes are in the [pnpr 0.1.0-alpha.10 release notes][pnpr].
+
+[v12.2.0]: https://github.com/pnpm/pnpm/releases/tag/v12.2.0
+[v12.3.0]: https://github.com/pnpm/pnpm/releases/tag/v12.3.0
+[pnpr]: https://github.com/pnpm/pnpm/releases/tag/pnpr%400.1.0-alpha.10

--- a/blog/releases/12.4.md
+++ b/blog/releases/12.4.md
@@ -1,0 +1,301 @@
+---
+title: pnpm 12.4
+authors: zkochan
+tags: [release]
+date: 2026-09-10
+---
+
+pnpm 12.4 installs crates and Python packages next to npm packages in the same
+workspace, adds `pnpm pipeline` to run a workspace's tasks the way a CI job
+would, and ships binaries for six more platforms. pnpr 0.1.0-alpha.11, released
+alongside 12.4.1, serves Cargo, Python, and container registries beside npm,
+publishes across all of them in one transaction, and signs users in through
+OIDC.
+
+<!-- truncate -->
+
+## Minor Changes
+
+### One workspace, three ecosystems
+
+pnpm can now manage npm, Python, and Cargo dependencies in the same workspace.
+Enable [`cargo.enabled`](/cargo) or [`python.enabled`](/python) in
+`pnpm-workspace.yaml`, then install them all with one `pnpm install`.
+
+```yaml title="pnpm-workspace.yaml"
+cargo:
+  enabled: true
+python:
+  enabled: true
+```
+
+```sh
+pnpm add crate:serde
+pnpm add pypi:httpx
+pnpm install
+```
+
+Each ecosystem keeps its own semantics. [Cargo](/cargo) dependencies live in
+`Cargo.toml` and `Cargo.lock`, resolve against crates.io or the sparse registry
+named by `cargo.indexUrl`, and are vendored into a Cargo directory source that
+pnpm wires up through `.cargo/config.toml`. Crates pinned to a git revision,
+through a git dependency or `[patch.crates-io]`, are checked out and vendored the
+way `cargo vendor` lays them out. Registry authentication goes through pnpm's own
+credentials, plus `CARGO_REGISTRY_TOKEN` or `$CARGO_HOME/credentials.toml` for
+crates.io.
+
+[Python](/python) dependencies live in `pyproject.toml` and a standard
+`pylock.toml`, with a managed `.venv` per project that `pnpm run` and `pnpm exec`
+put on `PATH`. The lockfile format was validated independently with `uv`.
+
+What is shared is everything below the ecosystem boundary: one HTTP and
+authentication budget, one verified-artifact ingestion path, one
+content-addressable store. Frozen and offline installs work for all three, and
+both new ecosystems can offload resolution to
+[`pnprServer`](/pnpr/install-acceleration), falling back to local resolution
+when the server does not serve it
+([#14566](https://github.com/pnpm/pnpm/issues/14566)).
+
+This is early. The settings and the layout pnpm writes may still change.
+
+### `pnpm pipeline`
+
+[`pnpm pipeline [name]`](/cli/pipeline) installs frozen dependencies and runs a
+named set of workspace tasks. It selects the affected projects, runs their task
+graph, and keeps going after a task fails, so one run reports every failure
+rather than the first.
+
+```yaml title="pnpm-workspace.yaml"
+tasks:
+  build:
+    dependsOn: ['^build']
+    outputs: ['dist/**']
+  test:
+    dependsOn: ['build']
+    outputs: []
+
+pipelines:
+  default: [build, test]
+```
+
+Declaring `outputs` is what makes a task cacheable, `outputs: []` included as the
+positive statement that a task writes no files. `inputs` narrows the key, `env`
+adds environment values to it, and `cache: false` opts back out. A hit restores
+the output files and replays the log.
+
+Cargo tasks can reuse local build state between worktrees through
+`tasks.<name>.cargoTargetDir`, and `pnpm pipeline --dry-run` prints the graph
+without installing anything or running a hook.
+
+### Six more platforms
+
+pnpm 12.4 ships binaries for Android on arm64 and x64, FreeBSD on x64, and Linux
+on ppc64le, s390x, and RISC-V. See [supported
+platforms](/installation#supported-platforms) for the full list
+([#14431](https://github.com/pnpm/pnpm/issues/14431),
+[#14597](https://github.com/pnpm/pnpm/issues/14597),
+[#7582](https://github.com/pnpm/pnpm/issues/7582)).
+
+### `trustPolicyExcludePrune`
+
+[`trustPolicyExcludePrune`](/settings/dependency-resolution#trustpolicyexcludeprune)
+removes the entries of `trustPolicyExclude` that the freshly written lockfile no
+longer resolves. It is off by default. Name patterns such as `@scope/*` are kept,
+and the cleanup is skipped when `sharedWorkspaceLockfile` is `false`.
+
+### `pnpm change check`
+
+[`pnpm change check`](/cli/change#check) validates the versions committed in the
+workspace against the `versioning.epics` bands and `versioning.fixed` groups. It
+reads no change intents, so it belongs in CI on every pull request. Every
+violation is reported, including ones in packages the current release does not
+touch.
+
+## Registry metadata is keyed by the full URL
+
+Registry metadata is now kept separate for registries that differ in URL path or
+scheme. That stops an install using another registry's package versions or
+tarball URLs, and stops metadata fetched over HTTP being reused for HTTPS
+([#13558](https://github.com/pnpm/pnpm/issues/13558)).
+
+The first install after upgrading refetches registry metadata; the package store
+is untouched. `pnpm cache view` now shows full registry URLs, so a script that
+parses the directory names out of `pnpm cache list-registries` or
+`pnpm cache list` needs updating.
+
+## Other changes
+
+- A [patch](/cli/patch) that adds a build script or a `binding.gyp` now makes the
+  package buildable, subject to build approval. Until it is approved, the package
+  is listed under "Ignored build scripts"
+  ([#14648](https://github.com/pnpm/pnpm/issues/14648)).
+- `pnpm add --allow-build=!<pkg>` rejects a build before the package is
+  installed, global installs included, and `pnpm approve-builds <pkg>` saves a
+  decision even when nothing is awaiting approval
+  ([#14067](https://github.com/pnpm/pnpm/issues/14067)).
+- A registry configured in `.npmrc` outranks a route `pnpm login` saved in the
+  global `config.yaml`, so logging in cannot redirect a project that names its
+  registry ([#14614](https://github.com/pnpm/pnpm/issues/14614)).
+- [`fetchTimeout`](/settings/network#fetchtimeout) now limits how long a request
+  may go without making progress, so a large download over a slow connection is
+  no longer cut off while data is still arriving
+  ([#14604](https://github.com/pnpm/pnpm/issues/14604)).
+- `pnpm add --workspace <pkg>` works again, saving the dependency with the
+  `workspace:` protocol and failing when no workspace project provides it
+  ([#14602](https://github.com/pnpm/pnpm/issues/14602)). Protocol-prefixed
+  selectors such as `jsr:@scope/pkg`, `npm:pkg@^1.0.0`, and `workspace:pkg@*`
+  are accepted too ([#14590](https://github.com/pnpm/pnpm/issues/14590)).
+- Boolean flags accept an explicit inline value: `pnpm install --prod=false`
+  installs devDependencies ([#14553](https://github.com/pnpm/pnpm/issues/14553)).
+- Commands run from a project's subdirectory find the nearest ancestor with a
+  manifest, so `pnpm bin` stops reporting paths under the wrong directory.
+  `pnpm init` still creates its manifest where you stand, and `pnpm exec` still
+  runs there ([#14622](https://github.com/pnpm/pnpm/issues/14622)).
+- `pnpm patch-commit` produces valid patches when files are added or deleted,
+  and `pnpm install` accepts patches that delete files without listing their
+  contents, and patch files with CRLF line endings
+  ([#14559](https://github.com/pnpm/pnpm/issues/14559),
+  [#14557](https://github.com/pnpm/pnpm/issues/14557)).
+- Version ranges with partial upper bounds behave: `<=16` includes every 16.x
+  version ([#14419](https://github.com/pnpm/pnpm/issues/14419)).
+- Workspace package patterns accept `.` and `..` segments and repeated slashes,
+  so `./packages/*` and `!./packages/foo` match
+  ([#14571](https://github.com/pnpm/pnpm/issues/14571)).
+- [`packageConfigs`](/settings#packageconfigs) settings apply to the projects
+  they name when `sharedWorkspaceLockfile` is `false`, and a workspace on a
+  shared lockfile is told which entries were ignored
+  ([#14556](https://github.com/pnpm/pnpm/issues/14556)).
+- Invalid certificates in `ca` or `cafile` no longer fail the install with
+  `Invalid CA certificate`; the valid ones still apply
+  ([#14646](https://github.com/pnpm/pnpm/issues/14646)).
+- `pnpm audit` summaries exclude advisories ignored through `audit.ignore` and
+  report them separately ([#14535](https://github.com/pnpm/pnpm/issues/14535)).
+- Shell completions cover the `pn` alias in bash, fish, pwsh, and zsh
+  ([#11955](https://github.com/pnpm/pnpm/issues/11955)), and `pnpm version`
+  accepts `-m` for `--message`
+  ([#14567](https://github.com/pnpm/pnpm/issues/14567)).
+- Warm installs in workspaces with many projects are faster
+  ([#14540](https://github.com/pnpm/pnpm/issues/14540)), and `pnpm deploy` is
+  faster in large workspaces and no longer fails with
+  `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` when the project has a `.pnpmfile.mjs`
+  ([#14539](https://github.com/pnpm/pnpm/issues/14539),
+  [#14671](https://github.com/pnpm/pnpm/issues/14671)).
+
+## 12.4.1
+
+The follow-up release fixes installs that failed on filesystems refusing hard
+links or clones, on Android, and under `nodeLinker: hoisted`, and makes repeat
+installs faster.
+
+- `pnpm install` copies a file instead of failing with `Operation not permitted`
+  when the filesystem refuses a hard link or a copy-on-write clone, under
+  `packageImportMethod: auto` and `clone-or-copy`
+  ([#14722](https://github.com/pnpm/pnpm/issues/14722)). EdenFS checkouts, which
+  have no hard links, and rootless containers, which refuse the clone syscall,
+  both hit this. pnpm also copies a file whose store entry has reached the
+  filesystem's limit on names for one file, 1024 on NTFS and 65000 on ext4.
+- Registry requests on Android crashed because pnpm found no system CA
+  certificates, so it uses bundled ones there
+  ([#14777](https://github.com/pnpm/pnpm/issues/14777)).
+- Under `nodeLinker: hoisted`, a repeat install no longer re-imports packages
+  that are already in place. It used to replace the whole `node_modules` tree and
+  report `Packages: +N`, lifecycle scripts included.
+- A build whose whole effect lands outside its own package directory, such as a
+  git hook installer, runs again when its side-effects cache entry has no files
+  to restore ([#14717](https://github.com/pnpm/pnpm/issues/14717)).
+- `ignoredOptionalDependencies` is applied by `pnpm install`, `pnpm add`, and
+  `pnpm dedupe`. pnpm 12 installed those dependencies whenever it resolved from
+  scratch ([#14729](https://github.com/pnpm/pnpm/issues/14729)).
+- Ctrl+C is passed on to the script pnpm started, and pnpm waits for it to shut
+  down instead of exiting first and letting a still-writing script land on the
+  shell prompt ([#14723](https://github.com/pnpm/pnpm/issues/14723)).
+- `pnpm dedupe` processes every workspace project by default, including
+  workspaces that keep a lockfile per project
+  ([#14732](https://github.com/pnpm/pnpm/issues/14732)).
+- The [`updateConfig` pnpmfile hook](/pnpmfile#what-the-hook-receives) receives
+  the resolved configuration, with scoped registries under `registriesByScope`
+  and credentials under `configByUri`
+  ([#14676](https://github.com/pnpm/pnpm/issues/14676)).
+- Repeat installs are faster: the store's files are checked only for the packages
+  pnpm links into `node_modules`, and creating the command shims makes about
+  1,500 fewer filesystem calls in a 76 project workspace
+  ([#14540](https://github.com/pnpm/pnpm/issues/14540)).
+- pnpm warns when the root `package.json` declares a non-empty `workspaces` array
+  and the project has no `pnpm-workspace.yaml`. Such an install linked no project
+  and said nothing about why
+  ([#2255](https://github.com/pnpm/pnpm/issues/2255)).
+
+## pnpr 0.1.0-alpha.11
+
+### Cargo, Python, and container registries
+
+pnpr now serves [Cargo and Python registries](/pnpr/ecosystems) alongside npm
+from one instance. Hosted Cargo registries support `cargo publish`, `cargo yank`,
+`cargo search`, and crate downloads; hosted Python registries support
+`pip install --index-url` and `twine upload`. Upstream registries can proxy
+crates.io and PyPI with checksum-verified downloads, and one router can combine
+sources from all three ecosystems.
+
+A registry that serves more than one ecosystem addresses them through `/npm/`,
+`/cargo/`, and `/pypi/`. A registry that serves only one keeps serving packages
+at the root, so existing npm URLs still work. Registry names can be reused across
+ecosystems by grouping configuration under `registries.npm`, `registries.cargo`,
+`registries.pypi`, or `registries.oci`.
+
+[Container images](/pnpr/container-images) are the fourth ecosystem. Declare a
+registry with `ecosystem: oci`, then push to it with `docker`, `podman`, or
+`skopeo`. The distribution API answers at `/v2/` on the host root, and an image
+keeps its own name with no registry key in the path. Ranged blob downloads,
+cross-repository blob mounts, the referrers API, and paginated tag and repository
+listings are supported, and pnpr can cache pulls from Docker Hub and GHCR with
+per-repository bearer tokens and digest verification
+([#14630](https://github.com/pnpm/pnpm/issues/14630)).
+
+`PUT /-/pnpr/v0/publish` publishes packages of more than one ecosystem in a
+single transaction, so a workspace that ships an npm package, a crate, and a
+Python distribution releases them together. A batch that fails a check publishes
+none of it, and a server that stops midway finishes the release on the next
+startup.
+
+### OIDC
+
+pnpr supports [OpenID Connect](/pnpr/oidc) browser sign-in. Administrators map
+provider subjects to registry users, and GitHub Actions can publish npm packages
+without a persistent registry token, restricted to the packages you configure.
+
+### Builds, pipelines, and discovery
+
+- pnpr can share [Cargo compilation caches](/pnpr/compiler-cache) between CI and
+  developers through sccache, with read and publication access granted
+  separately.
+- pnpr can store [`pnpm pipeline` run reports](/pnpr/pipeline-runs), with a
+  listing API, a detail API, and a web viewer. Records live with the hosted
+  packages, so a run submitted through one replica is served by every other.
+- [Browser registry UIs](/pnpr/discovery) can be served through an origin
+  allowlist, with paginated search, maintainer filters, organization listings,
+  and per-registry upstream discovery. A registry directory endpoint lists the
+  named registries, ecosystem endpoints, and routing order the caller can see.
+- Every command-line option can come from an environment variable named after
+  the flag with a `PNPR_` prefix, so `--public-url` becomes `PNPR_PUBLIC_URL`.
+
+### Fixes
+
+- A package name carrying `?`, `#`, `%`, whitespace, or a control character is
+  rejected, artifact filenames held to the same rule. A percent-encoded delimiter
+  let a request read an upstream package under a name the access rules had not
+  checked.
+- JSR packages resolve with no configuration: `npm.jsr.io` is a built-in public
+  route, like the npm registry.
+- A staged publish is approved once, whichever replica of a shared registry the
+  approval reaches; a second approval answers `409`
+  ([#12199](https://github.com/pnpm/pnpm/issues/12199)).
+- A publish that loses a write race reports `document_write_conflict` on every
+  registry surface, naming the package document
+  ([#14599](https://github.com/pnpm/pnpm/issues/14599)).
+
+For the complete client changes, see the [v12.4.0][] and [v12.4.1][] release
+notes. The server changes are in the [pnpr 0.1.0-alpha.11 release notes][pnpr].
+
+[v12.4.0]: https://github.com/pnpm/pnpm/releases/tag/v12.4.0
+[v12.4.1]: https://github.com/pnpm/pnpm/releases/tag/v12.4.1
+[pnpr]: https://github.com/pnpm/pnpm/releases/tag/pnpr%400.1.0-alpha.11

--- a/docs/cargo.md
+++ b/docs/cargo.md
@@ -73,7 +73,14 @@ A crate pinned to a git revision, whether through `[patch.crates-io]` or a plain
 
 The store slot is keyed by the commit, so a second install links it without cloning again, offline included. `--frozen-lockfile` leaves the pinned revision untouched.
 
-A workspace whose resolution declares `[patch]` or `[replace]` is refused rather than resolved without them: `cargo metadata` does not report either table, so the lockfile would name the replaced package.
+A `[patch]` or `[replace]` table is honored when pnpm installs from a committed `Cargo.lock`, which is the usual way a patched workspace is set up. What pnpm cannot do is *resolve* one from scratch: `cargo metadata` reports neither table, so a lockfile pnpm generated would name the replaced package instead of the patched one. Rather than resolve it wrongly, pnpm refuses, and the error says what to do:
+
+```
+Cargo.toml declares [patch], which pnpm cannot resolve.
+Commit the Cargo.lock that `cargo generate-lockfile` writes for it.
+```
+
+With that lockfile committed, installs, `--frozen-lockfile`, and offline installs all work.
 
 ## Faster resolution through pnpr
 

--- a/docs/cargo.md
+++ b/docs/cargo.md
@@ -1,0 +1,96 @@
+---
+id: cargo
+title: Cargo dependencies
+---
+
+Added in: v12.4.0 (pnpm v12 only)
+
+:::warning
+
+Multi-ecosystem support is experimental. The settings and the layout it writes may change.
+
+:::
+
+pnpm can install the crates a Cargo workspace depends on, next to the npm packages in the same repository. One `pnpm install` resolves both graphs, fetches over one shared connection budget, and puts each crate in pnpm's content-addressable store, so a crate downloaded for one project is not downloaded again for the next.
+
+Turn it on in `pnpm-workspace.yaml`:
+
+```yaml title="pnpm-workspace.yaml"
+cargo:
+  enabled: true
+```
+
+Then install as usual:
+
+```sh
+pnpm install
+```
+
+## Adding a crate
+
+Prefix the crate name with `crate:`:
+
+```sh
+pnpm add crate:serde
+pnpm add crate:serde@^1.0.200
+```
+
+pnpm writes the dependency into `Cargo.toml` without reformatting anything else in the file, and regenerates `Cargo.lock`. With no version requirement, the latest stable release is selected. A repository that has only a `Cargo.toml` needs no `package.json`: `pnpm add crate:` does not scaffold one.
+
+## What an install does
+
+1. Reads the workspace's `Cargo.toml`, including its members.
+2. Resolves the graph against the sparse index and writes a deterministic `Cargo.lock`. When `Cargo.lock` is already there, it is used as-is.
+3. Verifies each locked `.crate` archive against its checksum and unpacks it into pnpm's store.
+4. Links the store slots into a Cargo [directory source](https://doc.rust-lang.org/cargo/reference/source-replacement.html) under `.pnpm/crates/crates-io`, generating the `.cargo-checksum.json` files Cargo expects.
+5. Writes a source-replacement block into `.cargo/config.toml`, between the markers `# >>> pnpm-managed cargo sources >>>` and `# <<< pnpm-managed cargo sources <<<`. Anything you wrote outside those markers is left alone.
+
+`cargo build` then compiles offline against the vendored sources. pnpm does not compile anything itself.
+
+Crates are recorded in `Cargo.lock`, never in `pnpm-lock.yaml`. The two lockfiles stay independent.
+
+`--lockfile-only`, `--frozen-lockfile`, and `--offline` mean for crates what they mean for npm packages: resolve without materializing, fail rather than change the lockfile, and refuse the network.
+
+## Registries
+
+```yaml title="pnpm-workspace.yaml"
+cargo:
+  enabled: true
+  indexUrl: https://index.crates.io
+```
+
+`indexUrl` is the sparse index root. It defaults to crates.io. The registry a crate came from is recorded in `Cargo.lock`, and pnpm points Cargo's source replacement at that registry, so a local resolve and a [pnpr-accelerated](/pnpr/install-acceleration) one record the same source.
+
+A dependency that names a third-party registry of its own (`registry = "..."` in `Cargo.toml`) is rejected: pnpm resolves one index per workspace.
+
+### Authentication
+
+Index and archive requests go through pnpm's URL-scoped credentials, the same map that authenticates npm registries. For crates.io, pnpm also reads `CARGO_REGISTRY_TOKEN` and `$CARGO_HOME/credentials.toml`. Cargo tokens keep their bare `Authorization` form and are only ever sent to the index host they belong to.
+
+## Git-sourced crates
+
+A crate pinned to a git revision, whether through `[patch.crates-io]` or a plain git dependency, is checked out at the commit `Cargo.lock` names and vendored the way `cargo vendor` lays a git package out: the package's own directory, a `.cargo-checksum.json` with a null `package`, and a source replacement for the git source. Vendored git packages get their own directory, `.pnpm/crates/git`, because a git package and a registry crate may share a name and version, and one directory source cannot hold both.
+
+The store slot is keyed by the commit, so a second install links it without cloning again, offline included. `--frozen-lockfile` leaves the pinned revision untouched.
+
+A workspace whose resolution declares `[patch]` or `[replace]` is refused rather than resolved without them: `cargo metadata` does not report either table, so the lockfile would name the replaced package.
+
+## Faster resolution through pnpr
+
+With [`pnprServer`](/pnpr/install-acceleration) set, pnpm asks the server to resolve the Cargo graph instead of fetching one sparse-index file per crate. A server that does not answer for Cargo makes pnpm fall back to resolving locally.
+
+## Settings
+
+### cargo.enabled
+
+* Default: **false**
+* Type: **Boolean**
+
+Whether `pnpm install` resolves and installs the workspace's Cargo dependencies.
+
+### cargo.indexUrl
+
+* Default: **https://index.crates.io**
+* Type: **String**
+
+The sparse index root pnpm resolves crates against.

--- a/docs/catalogs.md
+++ b/docs/catalogs.md
@@ -134,7 +134,7 @@ catalogs:
 
 ### Workspace dependencies in a catalog
 
-Added in: v11.26.0, v12.2.0
+Added in: v12.2.0
 
 A catalog entry may hold a [`workspace:` range](./workspaces.md#workspace-protocol-workspace), so the version a workspace dependency is linked by is written once too:
 

--- a/docs/catalogs.md
+++ b/docs/catalogs.md
@@ -132,6 +132,28 @@ catalogs:
     react-dom: ^18.2.0
 ```
 
+### Workspace dependencies in a catalog
+
+Added in: v11.26.0, v12.2.0
+
+A catalog entry may hold a [`workspace:` range](./workspaces.md#workspace-protocol-workspace), so the version a workspace dependency is linked by is written once too:
+
+```yaml title="pnpm-workspace.yaml"
+catalog:
+  '@example/utils': workspace:^
+```
+
+```json title="packages/example-app/package.json"
+{
+  "name": "@example/app",
+  "dependencies": {
+    "@example/utils": "catalog:"
+  }
+}
+```
+
+pnpm expands the `catalog:` reference to `workspace:^` and then links the workspace project, exactly as if the `package.json` had declared `workspace:^` itself. On publish both protocols are replaced, so the example above ships as `"^1.4.0"` when `@example/utils` is at 1.4.0.
+
 ## Publishing
 
 The `catalog:` protocol is removed when running `pnpm publish` or `pnpm pack`. This is similar to the [`workspace:` protocol](./workspaces.md#workspace-protocol-workspace), which is [also replaced on publish](./workspaces.md#publishing-workspace-packages).

--- a/docs/cli/add.md
+++ b/docs/cli/add.md
@@ -16,6 +16,8 @@ By default, any new package is installed as a production dependency.
 | `pnpm add -g sax `                     | Install package globally           |
 | `pnpm add sax@next`                    | Install from the `next` tag        |
 | `pnpm add sax@3.0.0`                   | Specify version `3.0.0`            |
+| `pnpm add crate:serde`                 | Add a [Cargo](../cargo.md) crate   |
+| `pnpm add pypi:httpx`                  | Add a [Python](../python.md) package |
 
 ## Supported package sources
 
@@ -27,6 +29,7 @@ pnpm supports installing packages from various sources. See the [Supported packa
 - Local file system (tarballs and directories)
 - Remote tarballs
 - Git repositories (with semver, subdirectories, and more)
+- crates.io and PyPI, through the `crate:` and `pypi:` prefixes
 
 ## Adding a package manager or a runtime
 
@@ -43,6 +46,16 @@ writes `"packageManager": "yarn@4.18.0"`, and every other package manager is rec
 Globally, `pnpm add -g yarn` installs the current Yarn line rather than the Classic-only `yarn` package, and `pnpm add -g node@22` installs that Node.js release rather than a wrapper that downloads one.
 
 A specifier that locates a package rather than asking for a released version — `pnpm add yarn@npm:yarn@1.22.22`, `pnpm add yarn@yarnpkg/berry` — installs what it names, as an ordinary dependency.
+
+## Protocol-prefixed selectors
+
+A selector may carry the protocol in front of the name rather than after it:
+
+```sh
+pnpm add jsr:@scope/pkg
+pnpm add npm:pkg@^1.0.0
+pnpm add workspace:pkg@*
+```
 
 ## Options
 
@@ -103,7 +116,11 @@ Each space-separated package is installed into its own isolated directory. To bu
 
 ### --workspace
 
-Only adds the new dependency if it is found in the workspace.
+Only adds the new dependency if it is found in the workspace. The dependency is
+saved with the [`workspace:` protocol](../workspaces.md#workspace-protocol-workspace)
+and linked from the workspace project that provides it. When no workspace
+project provides the package, the command fails instead of falling back to the
+registry.
 
 
 ### --allow-build
@@ -119,6 +136,14 @@ pnpm --allow-build=esbuild add my-bundler
 ```
 
 This will run `esbuild`'s postinstall script and also add it to the `allowBuilds` field of `pnpm-workspace.yaml`. So, `esbuild` will always be allowed to run its scripts in the future.
+
+Since v11.26.0 and v12.4.0, prefixing a name with `!` denies the build instead:
+
+```
+pnpm add --allow-build=!core-js my-bundler
+```
+
+writes `allowBuilds: { core-js: false }`, so the package is never asked about again. Global installs (`pnpm add -g`) record the denial too.
 
 ### --filter &lt;package_selector\>
 

--- a/docs/cli/add.md
+++ b/docs/cli/add.md
@@ -137,7 +137,7 @@ pnpm --allow-build=esbuild add my-bundler
 
 This will run `esbuild`'s postinstall script and also add it to the `allowBuilds` field of `pnpm-workspace.yaml`. So, `esbuild` will always be allowed to run its scripts in the future.
 
-Since v11.26.0 and v12.4.0, prefixing a name with `!` denies the build instead:
+Since v12.4.0, prefixing a name with `!` denies the build instead:
 
 ```
 pnpm add --allow-build=!core-js my-bundler

--- a/docs/cli/approve-builds.md
+++ b/docs/cli/approve-builds.md
@@ -21,6 +21,8 @@ pnpm approve-builds esbuild fsevents !core-js
 
 Prefix a package name with `!` to deny it. Only mentioned packages are affected; the rest are left untouched.
 
+Since v11.26.0 and v12.4.0, a decision is saved even when nothing is awaiting approval, so a policy can be written before the package is installed. A named package that is not awaiting approval is reported with a warning rather than an error, and is not rebuilt: it may not be installed yet, and rebuilding it would need a lockfile the project may not have. An argument that names no package at all is rejected before anything is written.
+
 During install, packages with ignored builds that are not yet listed in `allowBuilds` are automatically added to `pnpm-workspace.yaml` with a placeholder value, so you can manually set them to `true` or `false`.
 
 Since v11.23.0, writing `allowBuilds` also removes `onlyBuiltDependencies`, `onlyBuiltDependenciesFile`, `neverBuiltDependencies`, and `ignoredBuiltDependencies` from `pnpm-workspace.yaml`. `allowBuilds` replaced those settings in pnpm 11 and they have been ignored since, so a workspace migrated from pnpm 10 kept them around looking active.

--- a/docs/cli/approve-builds.md
+++ b/docs/cli/approve-builds.md
@@ -21,7 +21,7 @@ pnpm approve-builds esbuild fsevents !core-js
 
 Prefix a package name with `!` to deny it. Only mentioned packages are affected; the rest are left untouched.
 
-Since v11.26.0 and v12.4.0, a decision is saved even when nothing is awaiting approval, so a policy can be written before the package is installed. A named package that is not awaiting approval is reported with a warning rather than an error, and is not rebuilt: it may not be installed yet, and rebuilding it would need a lockfile the project may not have. An argument that names no package at all is rejected before anything is written.
+Since v12.4.0, a decision is saved even when nothing is awaiting approval, so a policy can be written before the package is installed. A named package that is not awaiting approval is reported with a warning rather than an error, and is not rebuilt: it may not be installed yet, and rebuilding it would need a lockfile the project may not have. An argument that names no package at all is rejected before anything is written.
 
 During install, packages with ignored builds that are not yet listed in `allowBuilds` are automatically added to `pnpm-workspace.yaml` with a placeholder value, so you can manually set them to `true` or `false`.
 

--- a/docs/cli/audit.md
+++ b/docs/cli/audit.md
@@ -131,7 +131,7 @@ audit:
     - GHSA-vh95-rmgr-6w4m
 ```
 
-Since v11.26.0 and v12.4.0, ignored advisories are left out of the vulnerability
+Since v12.4.0, ignored advisories are left out of the vulnerability
 total and the per-severity counts, and reported separately. When every advisory
 found is ignored, the summary says so rather than reporting a clean audit.
 

--- a/docs/cli/audit.md
+++ b/docs/cli/audit.md
@@ -131,6 +131,10 @@ audit:
     - GHSA-vh95-rmgr-6w4m
 ```
 
+Since v11.26.0 and v12.4.0, ignored advisories are left out of the vulnerability
+total and the per-severity counts, and reported separately. When every advisory
+found is ignored, the summary says so rather than reporting a clean audit.
+
 ### audit.ignorePrune
 
 Added in: v12.0.0

--- a/docs/cli/cache-list-registries.md
+++ b/docs/cli/cache-list-registries.md
@@ -10,3 +10,5 @@ This command is experimental
 :::
 
 Lists all registries that have their metadata cache locally.
+
+Since v12.4.0, the metadata cache is keyed by the registry's full URL, including its path and scheme, so two registries served from one host under different paths no longer share cached packuments and metadata fetched over HTTP is never reused for HTTPS. The command prints those full URLs. A script that parsed the old host-shaped directory names, here or in `pnpm cache list`, needs updating, and the first install after upgrading refetches registry metadata. The package store is untouched.

--- a/docs/cli/cache-view.md
+++ b/docs/cli/cache-view.md
@@ -10,3 +10,5 @@ This command is experimental
 :::
 
 Views information from the specified package's cache.
+
+Since v12.4.0, the output identifies each cached entry by the registry's full URL rather than by its host.

--- a/docs/cli/change.md
+++ b/docs/cli/change.md
@@ -10,6 +10,7 @@ Records a change intent: which packages a change affects, the bump type for each
 ```sh
 pnpm change [--bump <type>] [--summary <text>] [<pkg>...]
 pnpm change status
+pnpm change check
 ```
 
 Change intents are consumed later by [`pnpm version -r`](./version.md#recursive-releases). See [Release management](../versioning.md) for the whole workflow.
@@ -67,6 +68,18 @@ Release plan:
 ```
 
 The cause of each bump is one of `intent` (a change intent named the package), `dependencies` (a dependent was pulled in by propagation), `fixed` (a [fixed group](../versioning.md#fixed-groups) companion), or `epic` (an [epic](../versioning.md#epics) re-base).
+
+### check
+
+Added in: v11.26.0, v12.4.0
+
+Validate the versions committed in the workspace against the [epic](../versioning.md#epics) bands and [fixed group](../versioning.md#fixed-groups) lockstep declared in `pnpm-workspace.yaml`.
+
+```sh
+pnpm change check
+```
+
+Unlike `pnpm change status`, which reports the release the pending intents produce, `check` looks only at the versions already in the manifests. It reads no intents, so it is the step to run on every pull request: a package whose version drifted out of its epic's band, or out of step with its fixed group, fails the command. Every violation is listed, including ones in packages the current release does not touch.
 
 ## Options
 

--- a/docs/cli/change.md
+++ b/docs/cli/change.md
@@ -71,7 +71,7 @@ The cause of each bump is one of `intent` (a change intent named the package), `
 
 ### check
 
-Added in: v11.26.0, v12.4.0
+Added in: v12.4.0
 
 Validate the versions committed in the workspace against the [epic](../versioning.md#epics) bands and [fixed group](../versioning.md#fixed-groups) lockstep declared in `pnpm-workspace.yaml`.
 

--- a/docs/cli/dedupe.md
+++ b/docs/cli/dedupe.md
@@ -5,8 +5,20 @@ title: "pnpm dedupe"
 
 Perform an install removing older dependencies in the lockfile if a newer version can be used.
 
+## Workspace selection
+
+Since v12.4.1, `pnpm dedupe` processes every project in the workspace by default, including workspaces that keep [a lockfile per project](../workspaces.md#sharedworkspacelockfile). Narrow the run with the usual [filters](../filtering.md), for example `pnpm dedupe --filter ./packages/app`.
+
 ## Options
 
 ### `--check`
 
 Check if running dedupe would result in changes without installing packages or editing the lockfile. Exits with a non-zero status code if changes are possible.
+
+### `--filter <package_selector>`
+
+Restrict the command to the selected projects. [Read more about filtering.](../filtering.md)
+
+### `--fail-if-no-match`
+
+Exit with an error when no project matches the given filters, instead of doing nothing.

--- a/docs/cli/deploy.md
+++ b/docs/cli/deploy.md
@@ -7,7 +7,11 @@ Deploy a package from a workspace. During deployment, the files of the deployed 
 
 :::note
 
-By default, the deploy command only works with workspaces that have the `inject-workspace-packages` setting set to `true`. If you want to use deploy without "injected dependencies", use the `--legacy` flag or set `force-legacy-deploy` to `true`.
+Since v11.26.0 and v12.2.0, `pnpm deploy` no longer requires [`injectWorkspacePackages`](../workspaces.md#injectworkspacepackages). A linked workspace dependency is rewritten to a `file:` dependency in the dedicated deploy lockfile, and the peer dependencies it declares are bound to the deployed graph's own resolution.
+
+Where a peer resolves to more than one version in that graph, the binding is ambiguous, and the deploy fails with `ERR_PNPM_DEPLOY_AMBIGUOUS_PEER` naming the package, the peer, and the competing versions. Pin the peer to one version with an [`overrides`](../settings/dependency-resolution.md#overrides) entry, or turn `injectWorkspacePackages` on, which is the setting that decides between the candidates.
+
+Before those releases the command refused every non-injected workspace up front. `--legacy`, or `forceLegacyDeploy: true`, still selects the older implementation.
 
 :::
 
@@ -69,7 +73,9 @@ Packages in `devDependencies` won't be installed.
 
 Force legacy deploy implementation.
 
-By default, `pnpm deploy` will try creating a dedicated lockfile from a shared lockfile for deployment. The `--legacy` flag disables this behavior and also allows using the deploy command without the `inject-workspace-packages=true` setting.
+By default, `pnpm deploy` will try creating a dedicated lockfile from a shared lockfile for deployment. The `--legacy` flag disables this behavior.
+
+Since v12.4.1, the legacy implementation prefers the versions the source workspace lockfile pins, wherever they still satisfy the deployed project's ranges.
 
 ## Files included in the deployed project
 

--- a/docs/cli/deploy.md
+++ b/docs/cli/deploy.md
@@ -7,7 +7,7 @@ Deploy a package from a workspace. During deployment, the files of the deployed 
 
 :::note
 
-Since v11.26.0 and v12.2.0, `pnpm deploy` no longer requires [`injectWorkspacePackages`](../workspaces.md#injectworkspacepackages). A linked workspace dependency is rewritten to a `file:` dependency in the dedicated deploy lockfile, and the peer dependencies it declares are bound to the deployed graph's own resolution.
+Since v12.2.0, `pnpm deploy` no longer requires [`injectWorkspacePackages`](../workspaces.md#injectworkspacepackages). A linked workspace dependency is rewritten to a `file:` dependency in the dedicated deploy lockfile, and the peer dependencies it declares are bound to the deployed graph's own resolution.
 
 Where a peer resolves to more than one version in that graph, the binding is ambiguous, and the deploy fails with `ERR_PNPM_DEPLOY_AMBIGUOUS_PEER` naming the package, the peer, and the competing versions. Pin the peer to one version with an [`overrides`](../settings/dependency-resolution.md#overrides) entry, or turn `injectWorkspacePackages` on, which is the setting that decides between the candidates.
 

--- a/docs/cli/pipeline.md
+++ b/docs/cli/pipeline.md
@@ -1,0 +1,171 @@
+---
+id: pipeline
+title: "pnpm pipeline"
+---
+
+Added in: v12.4.0 (pnpm v12 only)
+
+:::warning
+
+`pnpm pipeline` is experimental. Its configuration and output may change.
+
+:::
+
+Runs a named set of workspace tasks the way a CI job would: a frozen install first, then the affected projects' task graph, with cached results restored instead of re-run.
+
+```sh
+pnpm pipeline [name]
+```
+
+The pipeline named `default` runs when no name is given.
+
+## Declaring a pipeline
+
+A pipeline is a set of task names, listed under `pipelines` in `pnpm-workspace.yaml`. It is a set, not a sequence: the order in which its tasks run comes from [`tasks.dependsOn`](../workspace-task-orchestration.md#configure-task-dependencies).
+
+```yaml title="pnpm-workspace.yaml"
+tasks:
+  build:
+    dependsOn: ['^build']
+    outputs: ['dist/**']
+  test:
+    dependsOn: ['build']
+    outputs: []
+  lint:
+    outputs: []
+
+pipelines:
+  default: [build, test, lint]
+  release: [build]
+```
+
+```sh
+pnpm pipeline          # build, test and lint
+pnpm pipeline release  # build only
+```
+
+## What a run does
+
+1. Installs with a frozen lockfile.
+2. Selects the projects affected since the base revision, plus the projects that depend on them.
+3. Builds the task graph over that selection and runs it.
+4. Restores each cacheable task whose key it has seen before, and runs the rest.
+5. Keeps going after a task fails, so one run reports every failure rather than the first.
+
+The workspace root is left out of the selection unless [`includeWorkspaceRoot`](../workspaces.md#includeworkspaceroot) is `true`.
+
+Use `--dry-run` to see the graph without installing configuration dependencies, running workspace hooks, or executing anything. Add `--json` for the nodes and edges.
+
+## Caching a task
+
+A task becomes cacheable by declaring `outputs`. Declaring `outputs: []` is the positive statement that a task produces no files, which is what makes a linter or a test run cacheable. A task with no `outputs` key runs every time.
+
+```yaml title="pnpm-workspace.yaml"
+tasks:
+  build:
+    dependsOn: ['^build']
+    outputs: ['dist/**']
+    inputs: ['src/**', 'tsconfig.json']
+    env: ['NODE_ENV']
+```
+
+| Key | Meaning |
+| --- | --- |
+| `outputs` | Globs, relative to the project directory, naming the files the task produces. Their presence makes the task cacheable. |
+| `inputs` | Globs narrowing what goes into the cache key. Without it, every tracked file of the project counts. An entry prefixed with `+` adds to that default instead of replacing it. |
+| `env` | Environment variable names whose values take part in the key. The values are hashed, never stored. |
+| `cache` | `false` opts a task with declared `outputs` back out of the cache. |
+
+Besides the declared inputs, a task's key covers the script text, the keys of the tasks it depends on, the lockfile, and the runtime. A cache hit restores the output files and replays the recorded log, so the run reads the same either way.
+
+`--no-cache` runs everything and neither reads nor writes cache entries.
+
+## Reusing Cargo build state
+
+A [Cargo](../cargo.md) task can keep its local build state between runs, and between git worktrees of the same repository:
+
+```yaml title="pnpm-workspace.yaml"
+tasks:
+  build:
+    cargoTargetDir: target
+```
+
+pnpm points Cargo's target and build directories at that path and always executes the task, restoring an immutable snapshot of the previous build state rather than the task's own outputs. The directory must be relative to the project and ignored by git. Snapshots are stored apart from installed packages, so evicting one can never break an installation.
+
+## Reporting a run
+
+Every run writes a summary and an event stream under pnpm's pipeline data directory. `--report` submits them to the [pnpr](/pnpr/pipeline-runs) server named by [`pnprServer`](/pnpr/install-acceleration); `--report-to <url>` submits them elsewhere, which is the better spelling when the server that stores runs is not the one that accelerates installs. A failed run is reported before the command exits non-zero.
+
+## Watching a repository
+
+```sh
+pnpm pipeline --repo https://github.com/acme/app.git --watch
+```
+
+The watch agent polls the repository and runs the pipeline for every new revision of the followed branch. It is a proof of concept, not a hosted CI service.
+
+## Options
+
+### --dry-run
+
+Print the task graph and exit, without installing or running anything.
+
+### --json
+
+With `--dry-run`, print the tasks and their resolved dependency edges as JSON.
+
+### --full
+
+Run over every workspace project instead of the affected-since-base selection.
+
+### --base &lt;ref&gt;
+
+The git ref the affected selection diffs against, through its merge base with `HEAD`. Overrides the `pipelineBase` setting, which itself defaults to `origin/main`.
+
+### --no-cache
+
+Run every task, reading and writing neither task results nor Cargo snapshots.
+
+### --report
+
+Publish the run's summary and event stream to the configured pnpr server once the run settles.
+
+### --report-to &lt;url&gt;
+
+Publish the run to this pnpr server instead of the one in `pnprServer`.
+
+### --repo &lt;repo&gt;
+
+The repository the watch agent polls: a URL or a local path, anything git accepts as a remote.
+
+### --watch
+
+Watch `--repo` and run the pipeline for every new revision instead of running once in the current directory.
+
+### --branch &lt;name&gt;
+
+The branch the watch agent follows. Defaults to `main`.
+
+### --interval &lt;seconds&gt;
+
+Seconds between polls of the watched repository. Defaults to `30`.
+
+### --once
+
+With `--watch`, poll once, build if there is a new revision, and exit.
+
+## Settings
+
+### pipelines
+
+* Default: **undefined**
+* Type: **Record&lt;string, string[]&gt;**
+
+Named sets of task names, keyed by pipeline name.
+
+### pipelineBase
+
+* Default: **origin/main**
+* Type: **String**
+
+The git ref the affected selection resolves its merge base against.

--- a/docs/cli/remove.md
+++ b/docs/cli/remove.md
@@ -33,6 +33,20 @@ Only remove the dependency from `optionalDependencies`.
 
 Only remove the dependency from `dependencies`.
 
+### --unsafe-perm
+
+Added in: v11.26.0
+
+Accepted for compatibility with `pnpm install`; see [`unsafePerm`](../settings/build.md#unsafeperm).
+
+### Supply-chain policy flags
+
+Added in: v11.26.0, v12.3.0
+
+`pnpm remove` accepts the same policy overrides as `pnpm install` and `pnpm add`: `--trust-lockfile`, `--no-trust-lockfile`, [`--trust-policy`](../settings/dependency-resolution.md#trustpolicy), [`--trust-policy-exclude`](../settings/dependency-resolution.md#trustpolicyexclude), and [`--trust-policy-ignore-after`](../settings/dependency-resolution.md#trustpolicyignoreafter).
+
+Removing a package rewrites the lockfile, so `pnpm remove` verifies the whole lockfile against the active policies the way `pnpm install` does, not only the entries of the package being removed. [`--trust-lockfile`](../settings/dependency-resolution.md#trustlockfile) skips that pass entirely.
+
 ### --filter &lt;package_selector\>
 
 [Read more about filtering.](../filtering.md)

--- a/docs/cli/remove.md
+++ b/docs/cli/remove.md
@@ -33,15 +33,9 @@ Only remove the dependency from `optionalDependencies`.
 
 Only remove the dependency from `dependencies`.
 
-### --unsafe-perm
-
-Added in: v11.26.0
-
-Accepted for compatibility with `pnpm install`; see [`unsafePerm`](../settings/build.md#unsafeperm).
-
 ### Supply-chain policy flags
 
-Added in: v11.26.0, v12.3.0
+Added in: v12.3.0
 
 `pnpm remove` accepts the same policy overrides as `pnpm install` and `pnpm add`: `--trust-lockfile`, `--no-trust-lockfile`, [`--trust-policy`](../settings/dependency-resolution.md#trustpolicy), [`--trust-policy-exclude`](../settings/dependency-resolution.md#trustpolicyexclude), and [`--trust-policy-ignore-after`](../settings/dependency-resolution.md#trustpolicyignoreafter).
 

--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -41,7 +41,9 @@ The selector must be written as a regular expression literal — that is, wrappe
 
 Matching is not anchored, so `"/build:.*/"` also matches `prebuild:web`. Anchor the pattern with `^` and `$` when you need an exact prefix.
 
-Matched scripts run in lexicographical order, so the selection is deterministic regardless of the order the scripts appear in `package.json`. To run them strictly one at a time, add [`--sequential`](#--sequential--s).
+Matched scripts run in lexicographical order, so the selection is deterministic regardless of the order the scripts appear in `package.json`. Since v12.2.0 they run concurrently, up to [`--workspace-concurrency`](./recursive.md#--workspace-concurrency), with each script's output prefixed by its name. To run them strictly one at a time, add [`--sequential`](#--sequential--s).
+
+With `--no-bail`, a failing script does not stop the others: every matched script is allowed to finish, and the command then exits with `ERR_PNPM_RUN_FAILED`, listing the ones that failed in selection order.
 
 Regular expression flags are not supported: `pnpm run "/^build:.*/i"` fails with `ERR_PNPM_UNSUPPORTED_SCRIPT_COMMAND_FORMAT`.
 

--- a/docs/cli/shim.md
+++ b/docs/cli/shim.md
@@ -66,6 +66,18 @@ If nothing in the project provides the command, the globally installed version r
 
 The [trust rules](../global-packages.md#trust) of project-aware global bins apply here too: an npm-published package manager is verified against npm's signature for its exact version and switches without asking, while Bun and Yarn 6 arrive as checksum-pinned platform archives and go through the confirmation prompt. That answer is remembered per project *and* per binary, so moving the project's pin to another version asks again.
 
+## The shim is a real executable
+
+Since v12.3.0, every project-aware global command pnpm writes is a native
+executable on every platform: the shims `pnpm shim add` creates, and the `node`,
+`deno`, and `bun` commands. On Windows that means `<name>.exe` instead of the
+`.cmd` and `.ps1` pair earlier pnpm 12 releases wrote.
+
+The practical difference is that a shell no longer sits between you and the
+command, so environment variables whose names are not valid shell identifiers
+survive the hop. Shims written by an earlier pnpm 12 are replaced on the next
+global install or `pnpm self-update`.
+
 ## Related
 
 * [Other package managers](../package-managers.md)

--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -25,6 +25,7 @@ Besides moving `pnpm-lock.yaml` to the newly resolved versions, `pnpm update` wr
 
 * In `package.json`, the range is moved onto the resolved version while the operator the dependency already declared is kept, so `^1.1.0` stays a caret range.
 * A dependency declared through the [`catalog:` protocol](../catalogs.md) is not rewritten in `package.json`. The catalog entry it points at is updated instead, in `pnpm-workspace.yaml`.
+* A dependency declared through the [`jsr:` protocol](../package-sources.md) keeps its `jsr:` prefix, and its range moves like an npm range.
 * A dependency declared through a dist-tag, such as `"foo": "latest"`, keeps tracking the tag. The tag stays in `package.json` and only the lockfile moves to the version behind it — with `--latest` as well.
 
 Pass [`--no-save`](#--no-save) to update the lockfile only and leave the declared ranges alone.
@@ -73,6 +74,10 @@ Updated actions are pinned to exact commit hashes, with their release tags prese
 ```yaml
 - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 ```
+
+Local actions are followed rather than looked up: a `./`-relative reference, and
+since v11.26.0 and v12.3.0 GitHub's self-repository spelling
+(`uses: $/.github/actions/setup`), resolve inside the repository.
 
 Checking for updates runs `git ls-remote` against every referenced repository. Actions whose refs cannot be read — for example, an action in a private repository — are skipped with a warning. If the actions are hosted on a different GitHub server (such as a GitHub Enterprise Server), set [`update.githubActionsServer`](../settings/dependency-resolution.md#updategithubactionsserver) (added in v11.17.0).
 
@@ -173,6 +178,12 @@ Set [`update.changeset`](../settings/dependency-resolution.md#updatechangeset) t
 Added in: v11.16.0
 
 Also update the GitHub Actions referenced by the repository's workflow files. See [Updating GitHub Actions](#updating-github-actions).
+
+### Supply-chain policy flags
+
+Added in: v11.26.0, v12.3.0
+
+`pnpm update` accepts the same policy overrides as `pnpm install` and `pnpm add`: `--trust-lockfile`, `--no-trust-lockfile`, [`--trust-policy`](../settings/dependency-resolution.md#trustpolicy), [`--trust-policy-exclude`](../settings/dependency-resolution.md#trustpolicyexclude), and [`--trust-policy-ignore-after`](../settings/dependency-resolution.md#trustpolicyignoreafter), so a policy can be relaxed or tightened for a single run without editing `pnpm-workspace.yaml`.
 
 ### --filter &lt;package_selector\>
 

--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -76,7 +76,7 @@ Updated actions are pinned to exact commit hashes, with their release tags prese
 ```
 
 Local actions are followed rather than looked up: a `./`-relative reference, and
-since v11.26.0 and v12.3.0 GitHub's self-repository spelling
+since v12.3.0 GitHub's self-repository spelling
 (`uses: $/.github/actions/setup`), resolve inside the repository.
 
 Checking for updates runs `git ls-remote` against every referenced repository. Actions whose refs cannot be read — for example, an action in a private repository — are skipped with a warning. If the actions are hosted on a different GitHub server (such as a GitHub Enterprise Server), set [`update.githubActionsServer`](../settings/dependency-resolution.md#updategithubactionsserver) (added in v11.17.0).
@@ -181,7 +181,7 @@ Also update the GitHub Actions referenced by the repository's workflow files. Se
 
 ### Supply-chain policy flags
 
-Added in: v11.26.0, v12.3.0
+Added in: v12.3.0
 
 `pnpm update` accepts the same policy overrides as `pnpm install` and `pnpm add`: `--trust-lockfile`, `--no-trust-lockfile`, [`--trust-policy`](../settings/dependency-resolution.md#trustpolicy), [`--trust-policy-exclude`](../settings/dependency-resolution.md#trustpolicyexclude), and [`--trust-policy-ignore-after`](../settings/dependency-resolution.md#trustpolicyignoreafter), so a policy can be relaxed or tightened for a single run without editing `pnpm-workspace.yaml`.
 

--- a/docs/completion.md
+++ b/docs/completion.md
@@ -27,6 +27,8 @@ To setup autocompletion for Fish, run:
 pnpm completion fish > ~/.config/fish/completions/pnpm.fish
 ```
 
+Since v12.4.0, the generated completions cover the [`pn` alias](./pnpm-cli.md#short-aliases) as well, in Bash, Fish, PowerShell, and Zsh.
+
 ## g-plane/pnpm-shell-completion
 
 [pnpm-shell-completion] is a shell plugin maintained by Pig Fang on Github.

--- a/docs/filtering.md
+++ b/docs/filtering.md
@@ -109,6 +109,12 @@ pnpm --filter "{packages/**}[origin/master]..." <cmd>
 pnpm --filter "...{packages/**}[origin/master]..." <cmd>
 ```
 
+The pattern language is the usual one: `*` and `?` match within one path
+segment, `**` crosses segments, and a character class such as `[ab]` matches one
+of the listed characters. Neither `*` nor `?` matches a name that begins with a
+dot, so `packages/*` skips `packages/.cache`. Name a dot-prefixed directory
+explicitly to select it.
+
 Or you may select all packages from a directory with names matching the given
 pattern:
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -9,6 +9,21 @@ pnpm 12 is a native executable and does not require Node.js after it is installe
 
 pnpm 12 is the current release line — the `latest` tag on npm points at it, so the commands below install pnpm 12 without naming a version.
 
+### Supported platforms
+
+pnpm 12 ships a prebuilt binary for each of these targets:
+
+| Operating system | Architectures |
+| --- | --- |
+| Linux (glibc) | x64, arm64, riscv64, ppc64le, s390x |
+| Linux (musl) | x64, arm64 |
+| macOS | arm64, x64 |
+| Windows | x64, arm64 |
+| FreeBSD | x64 |
+| Android | arm64, x64 |
+
+FreeBSD, ppc64le, s390x, RISC-V, and Android were added in v12.4.0. On a target with no binary, install the JavaScript [pnpm 11](https://www.npmjs.com/package/pnpm/v/11) instead.
+
 ## Using pnpm
 
 If you already have pnpm v11.10.0 or newer, update directly to pnpm 12:

--- a/docs/package-sources.md
+++ b/docs/package-sources.md
@@ -42,6 +42,19 @@ pnpm add jsr:@hono/hono@latest
 
 This works just like installing from npm, but tells pnpm to resolve the package through JSR instead.
 
+### crates.io and PyPI
+
+Added in: v12.4.0 (pnpm v12 only)
+
+A `crate:` or `pypi:` prefix asks for a package of another ecosystem, once that ecosystem is enabled in `pnpm-workspace.yaml`:
+
+```sh
+pnpm add crate:serde
+pnpm add pypi:httpx
+```
+
+Such a dependency is recorded in that ecosystem's own manifest and lockfile, not in `package.json` or `pnpm-lock.yaml`. See [Cargo dependencies](./cargo.md) and [Python dependencies](./python.md).
+
 ### Named registries
 
 Added in: v11.1.0

--- a/docs/pnpm-cli.md
+++ b/docs/pnpm-cli.md
@@ -28,11 +28,32 @@ is populated from the CLI options. In this case, you have the following options:
 1. explicitly set the env variable: `npm_config_target_arch=x64 pnpm install`
 1. force the unknown option with `--config.`: `pnpm install --config.target_arch=x64`
 
+## Boolean flags
+
+A boolean flag can be written on its own, negated with a `no-` prefix, or given an explicit value:
+
+```sh
+pnpm install --prod            # devDependencies are skipped
+pnpm install --no-prod         # devDependencies are installed
+pnpm install --prod=false      # the same, since v12.4.0
+pnpm install --prod=true       # the same as --prod
+```
+
+The `--config.` escape hatch takes a value the same way: `--config.trust-lockfile=false`.
+
 ## Options
 
 ### -C &lt;path\>, --dir &lt;path\>
 
 Run as if pnpm was started in `<path>` instead of the current working directory.
+
+### Which project a command acts on
+
+Run from a subdirectory of a project, a command acts on the nearest ancestor
+directory that has a manifest, so `pnpm bin` from `packages/app/src` reports
+paths under `packages/app`. Two commands stay where you are: `pnpm init`
+creates its manifest in the current directory, and `pnpm exec` runs the command
+there.
 
 ### -w, --workspace-root
 

--- a/docs/pnpmfile.md
+++ b/docs/pnpmfile.md
@@ -105,6 +105,30 @@ export const hooks = {
 }
 ```
 
+#### What the hook receives
+
+Since v12.4.1, `config` is the resolved configuration: every setting pnpm will
+act on, wherever it came from, including `.npmrc`, the command line, and the
+built-in defaults. A setting nobody set is absent from the object rather than
+present as `null`.
+
+Two entries describe registry routing and credentials:
+
+* `registriesByScope` maps a scope (`@acme`, or `default` for the main
+  registry) to the registry URL packages of that scope are fetched from.
+  Rewriting the map redirects those fetches.
+* `configByUri` maps a registry URI to its credentials, the way pnpm 11
+  reports them.
+
+#### Which commands load the pnpmfile
+
+Since v11.26.0 and v12.3.0, `pnpm run`, `pnpm exec`, `pnpm rebuild`, the script
+shortcuts such as `pnpm test`, and `pnpm link`, `pnpm outdated`, `pnpm import`,
+`pnpm pack`, `pnpm publish`, and `pnpm stage publish` all load the pnpmfile
+before doing their work, so `updateConfig` settings such as `extraEnv` and
+`extraBinPaths` reach the processes they spawn and hook-provided catalogs
+resolve at pack time.
+
 ### `hooks.afterAllResolved(lockfile, context): lockfile | Promise<lockfile>`
 
 Allows you to mutate the lockfile output before it is serialized.

--- a/docs/pnpmfile.md
+++ b/docs/pnpmfile.md
@@ -122,7 +122,7 @@ Two entries describe registry routing and credentials:
 
 #### Which commands load the pnpmfile
 
-Since v11.26.0 and v12.3.0, `pnpm run`, `pnpm exec`, `pnpm rebuild`, the script
+Since v12.3.0, `pnpm run`, `pnpm exec`, `pnpm rebuild`, the script
 shortcuts such as `pnpm test`, and `pnpm link`, `pnpm outdated`, `pnpm import`,
 `pnpm pack`, `pnpm publish`, and `pnpm stage publish` all load the pnpmfile
 before doing their work, so `updateConfig` settings such as `extraEnv` and

--- a/docs/python.md
+++ b/docs/python.md
@@ -1,0 +1,89 @@
+---
+id: python
+title: Python dependencies
+---
+
+Added in: v12.4.0 (pnpm v12 only)
+
+:::warning
+
+Multi-ecosystem support is experimental. The settings and the layout it writes may change.
+
+:::
+
+pnpm can install a project's Python dependencies alongside its npm packages. One `pnpm install` resolves both graphs, shares the same connection budget and credentials, and stores every verified wheel in pnpm's content-addressable store, so a wheel fetched for one project is reused by the next.
+
+Turn it on in `pnpm-workspace.yaml`:
+
+```yaml title="pnpm-workspace.yaml"
+python:
+  enabled: true
+```
+
+pnpm reads the project's `pyproject.toml`, writes a [`pylock.toml`](https://packaging.python.org/en/latest/specifications/pylock-toml/), and builds an environment for it.
+
+## Adding a package
+
+Prefix the requirement with `pypi:`:
+
+```sh
+pnpm add pypi:httpx
+pnpm add pypi:httpx@0.28.1
+pnpm add pypi:'httpx>=0.28'
+pnpm add -D pypi:pytest
+```
+
+A bare `name@version` is written as an exact pin (`httpx==0.28.1`). A requirement that already carries a comparison operator is kept as written, and the full [PEP 508](https://peps.python.org/pep-0508/) grammar is accepted, environment markers and extras included.
+
+## The environment
+
+Each project with a `pyproject.toml` gets a `.venv` in its own directory. It is a symlink into `.pnpm/python-envs/`, and pnpm swaps the link atomically when the environment changes, so a failed install leaves the previous environment in place.
+
+pnpm refuses to touch a `.venv` it did not create, so an existing hand-made virtual environment is never replaced.
+
+[`pnpm run`](./cli/run.md) and [`pnpm exec`](./cli/exec.md) put the environment's script directory (`.venv/bin`, or `.venv/Scripts` on Windows) at the front of `PATH`, so a script can call `pytest` or `ruff` without activating anything.
+
+Python requirement, marker, and lockfile semantics are kept separate from npm's and Cargo's. What is shared is the plumbing below them: the HTTP and authentication budget, artifact verification, and the store.
+
+`--lockfile-only`, `--frozen-lockfile`, and `--offline` apply to Python dependencies too.
+
+## Faster resolution through pnpr
+
+With [`pnprServer`](/pnpr/install-acceleration) set, the server resolves the Python graph, so pnpm does not have to download a wheel to find out what it requires. A server that does not answer for Python makes pnpm fall back to resolving locally.
+
+## Settings
+
+### python.enabled
+
+* Default: **false**
+* Type: **Boolean**
+
+Whether `pnpm install` resolves and installs the project's Python dependencies.
+
+### python.executable
+
+* Default: **python3** (**python** on Windows)
+* Type: **String**
+
+The interpreter pnpm probes and builds environments with.
+
+### python.indexUrl
+
+* Default: **https://pypi.org/simple/**
+* Type: **String**
+
+The [Simple Repository API](https://packaging.python.org/en/latest/specifications/simple-repository-api/) root pnpm resolves against.
+
+### python.extras
+
+* Default: **[]**
+* Type: **String[]**
+
+The [extras](https://packaging.python.org/en/latest/specifications/dependency-specifiers/#extras) of the project to install.
+
+### python.groups
+
+* Default: **['dev']**
+* Type: **String[]**
+
+The [dependency groups](https://peps.python.org/pep-0735/) to install.

--- a/docs/registries.md
+++ b/docs/registries.md
@@ -129,6 +129,10 @@ adds that machine-wide scope route to the global `registries` setting while it
 records the credential under `_auth`. A later login for the same scope moves the
 route rather than declaring it at two registries.
 
+Since v12.4.0, a registry configured in `.npmrc` outranks a route `pnpm login`
+saved in the global `config.yaml`, so logging in cannot redirect a project that
+names its registry explicitly.
+
 An entry that declares no routes describes a registry configured elsewhere — for example, the default registry set in `.npmrc`. Such an entry only takes effect when its URL is one the project actually resolves from; pnpm warns about entries that match no configured registry, since they would otherwise sit there inert (a stale URL, a scope that moved).
 
 Environment variables are **not** expanded in the URL keys of this setting, for the same reason they are not expanded in other [registry URLs in `pnpm-workspace.yaml`](./settings.md): the file is committed, and expanding env variables into a request destination could leak secrets to an attacker-controlled host. A key containing a `${...}` placeholder is ignored.

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -63,6 +63,22 @@ packages:
 The root package is always included, even when custom location wildcards are
 used.
 
+A pattern may be written with a `./` prefix, may contain `.` and `..` segments,
+and may repeat slashes: `./packages/*` and `packages//*` select the same
+projects, and `!./packages/legacy` excludes the same directory that
+`!packages/legacy` does. A `*` never matches a name beginning with a dot, so
+`packages/*` skips `packages/.cache`; name such a directory explicitly to
+include it.
+
+:::note
+
+pnpm reads the workspace from `pnpm-workspace.yaml`, not from the `workspaces`
+field of the root `package.json`. Since v12.4.1, a root manifest that declares a
+non-empty `workspaces` array in a project with no `pnpm-workspace.yaml` gets a
+warning, because such an install silently links no project at all.
+
+:::
+
 Catalogs are also defined in the `pnpm-workspace.yaml` file. See [_Catalogs_](./catalogs.md) for details.
 
 ```yaml title="pnpm-workspace.yaml"
@@ -113,6 +129,13 @@ packageConfigs:
     modulesDir: "node_modules"
     saveExact: true
 ```
+
+Settings that shape resolution or the layout of `node_modules` (`overrides`,
+`hoist`, `modulesDir`, `saveExact`, `savePrefix`, and their neighbours) take
+effect per project only where each project has its own lockfile, that is with
+[`sharedWorkspaceLockfile: false`](./workspaces.md#sharedworkspacelockfile). A
+workspace on the default shared lockfile has one resolution for every project,
+so pnpm reports which entries it ignored instead of applying them silently.
 
 ## Settings
 
@@ -345,4 +368,7 @@ These settings are configured in `pnpm-workspace.yaml` as well, but are document
 * [audit.level](./cli/audit.md#auditlevel), [audit.ignore](./cli/audit.md#auditignore) and [audit.ignorePrune](./cli/audit.md#auditignoreprune)
 * [initVersion](./cli/init.md#initversion), [initLicense](./cli/init.md#initlicense) and [initAuthorName / initAuthorEmail / initAuthorUrl](./cli/init.md#initauthorname-initauthoremail-initauthorurl)
 * [legacyDirFiltering](./filtering.md#legacydirfiltering)
+* [tasks](./workspace-task-orchestration.md#configure-task-dependencies), [pipelines](./cli/pipeline.md#pipelines) and [pipelineBase](./cli/pipeline.md#pipelinebase)
+* [cargo.enabled](./cargo.md#cargoenabled) and [cargo.indexUrl](./cargo.md#cargoindexurl)
+* [python.enabled](./python.md#pythonenabled), [python.executable](./python.md#pythonexecutable), [python.indexUrl](./python.md#pythonindexurl), [python.extras](./python.md#pythonextras) and [python.groups](./python.md#pythongroups)
 * Authorization settings, which are read from [`.npmrc`](./npmrc.md)

--- a/docs/settings/_catalogMode.mdx
+++ b/docs/settings/_catalogMode.mdx
@@ -11,3 +11,5 @@ Controls if and how dependencies are added to the default catalog, when running 
 - **prefer** - prefers catalog versions, but will fall back to direct dependencies if no compatible version is found.
 - **manual** (default) - does not automatically add dependencies to the catalog.
 
+
+Since v11.26.0 and v12.3.0, a specifier that names a location rather than a version is never moved into a catalog: local paths, local tarballs, tarball URLs, and `workspace:<path>` ranges stay in the `package.json` that declares them. Such a specifier is resolved relative to its own project, so one catalog entry could not mean the same directory for every project referencing it.

--- a/docs/settings/_catalogMode.mdx
+++ b/docs/settings/_catalogMode.mdx
@@ -12,4 +12,4 @@ Controls if and how dependencies are added to the default catalog, when running 
 - **manual** (default) - does not automatically add dependencies to the catalog.
 
 
-Since v11.26.0 and v12.3.0, a specifier that names a location rather than a version is never moved into a catalog: local paths, local tarballs, tarball URLs, and `workspace:<path>` ranges stay in the `package.json` that declares them. Such a specifier is resolved relative to its own project, so one catalog entry could not mean the same directory for every project referencing it.
+Since v12.3.0, a specifier that names a location rather than a version is never moved into a catalog: local paths, local tarballs, tarball URLs, and `workspace:<path>` ranges stay in the `package.json` that declares them. Such a specifier is resolved relative to its own project, so one catalog entry could not mean the same directory for every project referencing it.

--- a/docs/settings/_scriptShell.mdx
+++ b/docs/settings/_scriptShell.mdx
@@ -11,3 +11,4 @@ For instance, to force usage of Git Bash on Windows:
 pnpm config set scriptShell "C:\\Program Files\\git\\bin\\bash.exe"
 ```
 
+Since v12.4.0, a relative path in `pnpm-workspace.yaml` resolves from the workspace root, including for scripts that run in a nested package. A bare command name such as `bash` is still looked up on `PATH`.

--- a/docs/settings/build.md
+++ b/docs/settings/build.md
@@ -223,7 +223,9 @@ Denials by package name are not restricted this way: `foo: false` blocks `foo` w
 
 **Default behavior:** Packages not listed in `allowBuilds` are disallowed by default and are treated as unreviewed. By default, an error is printed ([`strictDepBuilds`](#strictdepbuilds) defaults to `true`). If `strictDepBuilds` is set to `false`, a warning is printed instead.
 
-During install, dependencies with ignored builds that are not yet listed in `allowBuilds` are automatically added to `pnpm-workspace.yaml` with a placeholder value, so you can manually set them to `true` or `false`. The [`--allow-build`](../cli/add.md) flag on `pnpm add` and `pnpm approve-builds` writes its entries here as well.
+During install, dependencies with ignored builds that are not yet listed in `allowBuilds` are automatically added to `pnpm-workspace.yaml` with a placeholder value, so you can manually set them to `true` or `false`. The [`--allow-build`](../cli/add.md#--allow-build) flag on `pnpm add` and `pnpm approve-builds` writes its entries here as well.
+
+**Patched packages:** since v12.4.0, a [patch](../cli/patch.md) that adds an install script or a `binding.gyp` makes the package buildable, and the build goes through the same approval. Until the package is allowed, it is listed under "Ignored build scripts".
 
 :::info Migrating from older settings
 

--- a/docs/settings/build.md
+++ b/docs/settings/build.md
@@ -66,6 +66,11 @@ the setting meant before it grew a remote tier. Writing without reading
 (`read: false, write: true`) populates a cache the run never consumes, which is
 what a job that warms one for others wants.
 
+Since v12.2.0, the `--side-effects-cache` and `--no-side-effects-cache` flags, and
+`PNPM_CONFIG_SIDE_EFFECTS_CACHE`, toggle the **local** cache only. A remote tier
+declared under `sideEffectsCache.remote` is left in place, so a run can turn the
+local cache off without losing the shared one.
+
 ### sideEffectsCacheReadonly
 
 * Default: **false**

--- a/docs/settings/cli.md
+++ b/docs/settings/cli.md
@@ -178,7 +178,6 @@ Since v12.4.0, a mirror is machine-level configuration as well: set it in the
 `PNPM_CONFIG_NODE_DOWNLOAD_MIRRORS`, so every project on the machine downloads
 Node.js from it.
 
-Downloads from a mirror carry the npm registry credentials configured for that
-URL, including bearer tokens, basic auth, and
-`tokenHelper`, so a mirror behind an authenticating
-proxy works without a separate credential.
+Since v12.2.0, downloads from a mirror carry the npm registry credentials
+configured for that URL, including bearer tokens, basic auth, and `tokenHelper`,
+so a mirror behind an authenticating proxy works without a separate credential.

--- a/docs/settings/cli.md
+++ b/docs/settings/cli.md
@@ -171,3 +171,14 @@ nodeDownloadMirrors:
   rc: https://npmmirror.com/mirrors/node-rc/
   nightly: https://npmmirror.com/mirrors/node-nightly/
 ```
+
+Since v12.4.0, a mirror is machine-level configuration as well: set it in the
+[global configuration file](../cli/config.md) with
+`pnpm config set --global node-download-mirrors`, or in the environment as
+`PNPM_CONFIG_NODE_DOWNLOAD_MIRRORS`, so every project on the machine downloads
+Node.js from it.
+
+Downloads from a mirror carry the npm registry credentials configured for that
+URL, including bearer tokens, basic auth, and
+`tokenHelper`, so a mirror behind an authenticating
+proxy works without a separate credential.

--- a/docs/settings/dependency-resolution.md
+++ b/docs/settings/dependency-resolution.md
@@ -309,9 +309,9 @@ Added in: v11.22.0
 * Default: **false**
 * Type: **Boolean**
 
-When set to `true`, `pnpm add`, `pnpm update`, and `pnpm remove` prune the entries of [`minimumReleaseAgeExclude`](#minimumreleaseageexclude) in `pnpm-workspace.yaml` that the freshly written lockfile no longer resolves: a version that is gone is dropped (an entry is removed once none of its versions remain), and an entry for a package that is no longer in the lockfile is removed too. Name patterns (`@myorg/*`) are always kept.
+When set to `true`, `pnpm install`, `pnpm add`, `pnpm update`, `pnpm remove`, and `pnpm dedupe` prune the entries of [`minimumReleaseAgeExclude`](#minimumreleaseageexclude) in `pnpm-workspace.yaml` that the freshly written lockfile no longer resolves: a version that is gone is dropped (an entry is removed once none of its versions remain), and an entry for a package that is no longer in the lockfile is removed too. Name patterns (`@myorg/*`) are always kept.
 
-The cleanup is skipped when the install's lockfile does not cover the whole workspace ([`sharedWorkspaceLockfile: false`](../workspaces.md#sharedworkspacelockfile)), since entries another project still needs would look stale.
+The cleanup is skipped when the install's lockfile does not cover the whole workspace ([`sharedWorkspaceLockfile: false`](../workspaces.md#sharedworkspacelockfile)), since entries another project still needs would look stale. Comments on the entries that are kept survive the rewrite.
 
 ### minimumReleaseAgeIgnoreMissingTime
 
@@ -339,7 +339,7 @@ Added in: v11.0.0
 
 Controls how pnpm behaves when no version of a dependency satisfies the [`minimumReleaseAge`](#minimumreleaseage) constraint within the requested range. When `false`, pnpm falls back to a version that doesn't meet the `minimumReleaseAge` constraint so installation can still succeed. When `true`, pnpm fails resolution instead.
 
-The default depends on whether you configured `minimumReleaseAge` yourself: if you set it explicitly (via `pnpm-workspace.yaml`, the CLI, or environment variables), strict mode is on by default so the setting is enforced. The built-in default of `minimumReleaseAge` (1440 minutes) is non-strict for backward compatibility.
+The default depends on whether you configured `minimumReleaseAge` yourself: if you set it explicitly (in `pnpm-workspace.yaml`, in the global `config.yaml`, through a `PNPM_CONFIG_*` variable, or on the command line), strict mode is on by default so the setting is enforced. The built-in default of `minimumReleaseAge` (1440 minutes) is non-strict for backward compatibility.
 
 ```yaml
 minimumReleaseAgeStrict: true
@@ -389,9 +389,9 @@ Added in: v12.4.0
 * Default: **false**
 * Type: **Boolean**
 
-When set to `true`, `pnpm add`, `pnpm update`, and `pnpm remove` prune the entries of [`trustPolicyExclude`](#trustpolicyexclude) in `pnpm-workspace.yaml` that the freshly written lockfile no longer resolves: a version that is gone is dropped (an entry is removed once none of its versions remain), and an entry for a package that is no longer in the lockfile is removed too. Name patterns (`@myorg/*`) are always kept.
+When set to `true`, `pnpm install`, `pnpm add`, `pnpm update`, `pnpm remove`, and `pnpm dedupe` prune the entries of [`trustPolicyExclude`](#trustpolicyexclude) in `pnpm-workspace.yaml` that the freshly written lockfile no longer resolves: a version that is gone is dropped (an entry is removed once none of its versions remain), and an entry for a package that is no longer in the lockfile is removed too. Name patterns (`@myorg/*`) are always kept.
 
-The cleanup is skipped when the install's lockfile does not cover the whole workspace ([`sharedWorkspaceLockfile: false`](../workspaces.md#sharedworkspacelockfile)), since entries another project still needs would look stale.
+The cleanup is skipped when the install's lockfile does not cover the whole workspace ([`sharedWorkspaceLockfile: false`](../workspaces.md#sharedworkspacelockfile)), since entries another project still needs would look stale. Comments on the entries that are kept survive the rewrite.
 
 ### trustLockfile
 

--- a/docs/settings/network.md
+++ b/docs/settings/network.md
@@ -46,6 +46,8 @@ The `.npmrc` also supports npm's legacy `proxy` setting, which is used as the fa
 
 A comma-separated string of domain extensions that a proxy should not be used for.
 
+An entry may be written with or without a leading dot: both `npmjs.org` and `.npmjs.org` bypass the proxy for the domain itself and for its subdomains.
+
 Empty, `false`, and `null` values behave as described for [`httpsProxy`](#httpsproxy).
 
 ### localAddress
@@ -127,8 +129,9 @@ The upper bound (in milliseconds) of the retry exponential backoff.
 * Default: **60000 (1 minute)**
 * Type: **Number**
 
-The maximum amount of time to wait for HTTP requests to connect and complete.
-This time should be enough to download the largest package over a reasonable connection.
+How long an HTTP request may go without making progress. The clock is reset on every chunk pnpm receives, so a large tarball on a slow connection is not cut off while data is still arriving; a stalled request is.
+
+Before v12.4.0, this bounded the whole request, which meant the value had to be large enough to download the largest package over the slowest connection you cared about.
 
 ### fetchWarnTimeoutMs
 

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -102,6 +102,10 @@ With the lead on `11.x`, members occupy majors `1100`–`1199`. Members move ind
 
 Membership is matched with pnpm's package selectors: name globs, `./`-prefixed directory globs, and `!`-prefixed negations. Selectors are evaluated in order and the last one to match decides, so a later include can re-admit a package an earlier negation excluded. The lead is never a member of its own band.
 
+## Checking committed versions
+
+[`pnpm change check`](./cli/change.md#check) validates the versions already committed in the workspace against the `versioning.epics` bands and the `versioning.fixed` groups, without reading any change intent. Run it in CI, next to the lint and test steps, so a version that drifted out of its band is caught on the pull request that introduced it rather than at release time.
+
 ## Changelogs
 
 By default (`versioning.changelog.storage: registry`) no `CHANGELOG.md` is committed. Each release's section is composed at publish time and packed into the published tarball on top of the previously published version's changelog. Consumed change intents are garbage-collected by a later `pnpm version -r` only once the registry confirms the version was published with its section.

--- a/docs/workspace-task-orchestration.md
+++ b/docs/workspace-task-orchestration.md
@@ -190,6 +190,12 @@ can prefix or aggregate it. Use [`--stream`](./cli/run.md#--stream) for immediat
 prefixed output or [`--aggregate-output`](./cli/run.md#--aggregate-output) to
 print each task's output together after it finishes.
 
+## Caching a task
+
+The `outputs`, `inputs`, `env`, `cache`, and `cargoTargetDir` keys of a task are
+read by [`pnpm pipeline`](./cli/pipeline.md#caching-a-task) only. A recursive
+`pnpm run` never restores a task from the cache.
+
 ## Commands that do not use `tasks`
 
 The `tasks` declarations configure recursive `run`. Recursive `exec` follows

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -187,6 +187,12 @@ workspace packages can still be linked by using the `workspace:` range protocol.
 
 Packages are only linked if their versions satisfy the dependency ranges.
 
+`true` links a workspace project only where a project of the workspace declares
+it directly. A transitive dependency declared with a plain version range is
+still installed from the registry, whatever
+[`preferWorkspacePackages`](#preferworkspacepackages) says. Set `deep` to link
+workspace projects into subdependencies as well.
+
 ### injectWorkspacePackages
 
 * Default: **false**

--- a/pnpr-docs/cli.md
+++ b/pnpr-docs/cli.md
@@ -5,6 +5,7 @@ title: CLI reference
 
 ```sh
 pnpr [OPTIONS]
+pnpr [OPTIONS] oci-gc --registry <name>
 ```
 
 ## Options
@@ -24,6 +25,35 @@ pnpr [OPTIONS]
 | `--disable-artifacts` | Disable the signed shared-artifact surface. Overrides `artifacts.enabled` independently of the resolver. |
 | `-h, --help` | Print help. |
 | `-V, --version` | Print version. |
+
+## Every flag has an environment variable
+
+Since v0.1.0-alpha.11, pnpr reads any option from an environment variable when
+the flag is omitted. The variable is the flag's name with a `PNPR_` prefix, so
+`--public-url` becomes `PNPR_PUBLIC_URL` and `--disable-resolver` becomes
+`PNPR_DISABLE_RESOLVER`. A flag given on the command line wins over its
+variable. Boolean flags accept `true`, `1`, `yes`, `on`, `false`, `0`, `no`,
+and `off`.
+
+```sh
+PNPR_LISTEN=0.0.0.0:7677 PNPR_PUBLIC_URL=https://registry.example.com pnpr
+```
+
+## Subcommands
+
+### oci-gc
+
+Added in: v0.1.0-alpha.11
+
+Reclaims [container image](container-images.md#reclaiming-space) blobs that no
+retained manifest references. Every writer sharing the store must be stopped for
+the whole run.
+
+| Flag | Description |
+| --- | --- |
+| `--registry <name>` | The concrete hosted OCI registry to collect, by its config name. Required. |
+| `--dry-run` | Report the candidates without deleting anything. |
+| `--min-age-secs <n>` | Keep blobs younger than this. Defaults to `86400`, so an interrupted push can still resume. `0` collects every unreferenced blob. |
 
 ## Logging
 

--- a/pnpr-docs/compiler-cache.md
+++ b/pnpr-docs/compiler-cache.md
@@ -1,0 +1,115 @@
+---
+id: compiler-cache
+title: Cargo compilation cache
+---
+
+Added in: v0.1.0-alpha.11
+
+pnpr's artifact service speaks [sccache](https://github.com/mozilla/sccache)'s
+WebDAV backend, so a Cargo compilation cache can be shared between CI and
+developer machines. No pnpm workspace or `package.json` is involved.
+
+## Declaring a cache
+
+```yaml
+artifacts:
+  enabled: true
+  compilerCaches:
+    acme:
+      access: [ci-builder, alice, bob]
+      publish: ci-builder
+```
+
+These are pnpr account names, and each caller supplies its own pnpr token.
+`access` is required for reads and writes alike; `publish` additionally gates
+writes. An empty list denies access, and the `$authenticated` token works here
+too. An undeclared cache is unavailable.
+
+This is what lets CI publish while developers only read, even where their tokens
+otherwise permit registry writes. Read-only token restrictions are enforced as
+well.
+
+## Configuring sccache
+
+Install [sccache 0.17.0 or newer](https://github.com/mozilla/sccache) with
+WebDAV support (`sccache --help` lists the enabled backends), then set the
+environment before starting sccache or invoking Cargo:
+
+```sh
+export RUSTC_WRAPPER=sccache
+export CARGO_INCREMENTAL=0
+export SCCACHE_MULTILEVEL_CHAIN=disk,webdav
+export SCCACHE_WEBDAV_ENDPOINT=https://cache.example.com/-/pnpr/v0/compiler-cache/acme
+export SCCACHE_WEBDAV_TOKEN="$PNPR_TOKEN"
+export SCCACHE_WEBDAV_RW_MODE=READ_ONLY
+
+cargo build
+sccache --show-stats
+```
+
+`PNPR_TOKEN` holds that caller's token; keep it in developer credentials or CI
+secrets. CI uses its builder account's token and sets
+`SCCACHE_WEBDAV_RW_MODE=READ_WRITE`. The pnpr policy enforces publication
+permission independently of that client setting.
+
+`SCCACHE_MULTILEVEL_CHAIN=disk,webdav` checks disk first, then pnpr, and
+backfills disk on a remote hit. `SCCACHE_DIR` and `SCCACHE_CACHE_SIZE` configure
+the local cache. With sccache's default multilevel write-error policy, a remote
+write failure does not fail a successful disk write. A running sccache daemon
+keeps its startup configuration, so restart it with `sccache --stop-server`
+after changing these settings, and use separate daemons for projects that need
+different cache settings concurrently.
+
+## What determines a hit
+
+Reuse depends on sccache's compilation keys: the compiler, target, features,
+flags, source inputs, and dependencies. Rust keys in sccache 0.17.0 also include
+the absolute compilation directory, so CI and developer builds need matching
+source paths, for example a common `/workspace` mount inside their build
+containers, with consistent Cargo registry source paths. `SCCACHE_BASEDIRS` does
+not lift that Rust restriction.
+
+Align toolchains and build profiles for useful hit rates. Rust incremental
+compilation must be off. System linking is not cached, and procedural macros
+with undeclared filesystem inputs have correctness limitations. See
+[sccache's Rust support](https://github.com/mozilla/sccache/blob/v0.17.0/docs/Rust.md).
+
+sccache 0.17.0 also treats a multilevel cache as read-only when any tier is
+read-only. Developers can read shared entries, and those hits backfill disk, but
+newly compiled misses are not added to disk in that mode. Builds still succeed.
+To cache new local compilations, use a disk-only daemon or a cache the developer
+may publish to. This is an upstream
+[multilevel-cache limitation](https://github.com/mozilla/sccache/blob/v0.17.0/src/cache/multilevel.rs).
+
+## Storage, limits, and trust
+
+Entries use the configured filesystem or S3 artifact store and the same quota
+accounting as [side effects](shared-side-effects-cache.md), in a separate
+compiler-cache namespace. A cache key is immutable: the first successful `PUT`
+wins. `SCCACHE_WEBDAV_KEY_PREFIX` can select a fresh namespace, though that does
+not reclaim old entries.
+
+The experimental limits are 256 MiB per compiler entry, 1 GiB per owner or cache
+name, and 10 GiB globally across artifacts. A compiler cache sharing a name with
+a side-effects owner shares its quota. Live compiler entries are not evicted
+automatically yet.
+
+Each server accepts at most two concurrent compiler uploads, acquiring capacity
+before reading request bodies. Further uploads get `503` with `Retry-After: 1`.
+`HEAD` inspects object metadata without downloading the entry; `GET` always
+verifies the full content digest.
+
+The WebDAV endpoint trusts pnpr and the accounts allowed to publish. Use HTTPS
+outside localhost, and grant publication only to trusted builds, keeping
+untrusted pull-request jobs out of the shared writer credentials. Stock sccache
+does not verify pnpm's signed side-effects envelopes. pnpr verifies stored
+compiler entries against a digest of their cache scope, key, and bytes before
+serving them, which detects storage corruption, not a malicious server or an
+authorized publisher.
+
+The endpoint implements `GET`, `HEAD`, and `PUT` at
+`/-/pnpr/v0/compiler-cache/<cache>/<key>`, plus `PROPFIND` for virtual parent
+directories. It is the subset sccache uses, not a general WebDAV filesystem.
+Local builds keep using ordinary Cargo commands. The pnpm
+[`sideEffectsCache`](/settings/build#sideeffectscache) setting governs npm
+dependency side effects and does not configure this integration.

--- a/pnpr-docs/configuration.md
+++ b/pnpr-docs/configuration.md
@@ -65,8 +65,8 @@ The hosted store can instead live in an S3-compatible object store — see
 ## `registries` and `defaultRegistry`
 
 The `registries:` map is pnpr's **only routing surface**. Every addressable
-registry origin is a named registry, exposed as an npm registry at
-`https://<pnpr>/~<name>/`. There are three kinds:
+registry origin is a named registry, exposed at `https://<pnpr>/~<name>/`. There
+are three kinds:
 
 - **`hosted`** — a registry pnpr itself is the authoritative origin for. The
   only kind that accepts writes (publish, dist-tags, unpublish).
@@ -90,7 +90,16 @@ serves no registry and clients must address a `/~<name>/` URL.
 
 A registry name is served as the single URL path segment `/~<name>/`, so it
 must be one URL-safe segment: it cannot be empty, `.` or `..`, start with `.`,
-or contain `/`, `\`, `:`, `%`, `?`, `#`, whitespace, or control characters.
+or contain `/`, `\`, `:`, `%`, `?`, `#`, whitespace, or control characters. The
+`~` must arrive unencoded: `%7E` does not select the named registry.
+
+Since v0.1.0-alpha.11, a registry also declares which package ecosystem it
+serves, through `ecosystem:` (`npm`, `cargo`, `pypi`, or `oci`; npm by default).
+A server that serves more than one addresses them through `/npm/`, `/cargo/`,
+and `/pypi/` path prefixes, and registry names can be reused across ecosystems
+by grouping the entries under an ecosystem key. See
+[Cargo and Python registries](ecosystems.md) and
+[Container images](container-images.md).
 
 ### The `packages` map
 
@@ -336,6 +345,32 @@ Because teams live in the config, they are served read-only over npm's
 team endpoints, and any attempt to create or modify one through the API is
 refused — see [Team endpoints](endpoints.md#team-endpoints).
 
+## `oci`
+
+Size limits for the [container image](container-images.md) surface, and the
+Bearer challenge it offers:
+
+```yaml
+oci:
+  bearerAuth: false
+  maxBlobBytes: 10737418240   # 10 GiB
+  maxManifestBytes: 4194304   # 4 MiB
+```
+
+Both limits must be greater than zero.
+
+## `cors`
+
+The exact browser origins allowed to call pnpr across origins. Cross-origin
+access stays off when the block is absent or its allowlist is empty. See
+[Browsing and discovery](discovery.md).
+
+```yaml
+cors:
+  allowedOrigins:
+    - https://registry-ui.example.com
+```
+
 ## `auth`
 
 By default users are stored in an htpasswd file and tokens in a local SQLite
@@ -361,6 +396,10 @@ the htpasswd file.
 To share auth state across several stateless pnpr replicas, move users and
 tokens into a shared SQL database — see [Auth backends](auth-backends.md).
 
+An `auth.oidc` list configures OpenID Connect browser sign-in and keyless CI
+publishing alongside the password backend — see
+[OpenID Connect](oidc.md).
+
 ## `secret`
 
 ```yaml
@@ -374,13 +413,14 @@ least 16 bytes. When omitted, a fresh random secret is generated per process,
 which means private cache entries only survive for that process's lifetime —
 set an explicit secret to keep private caches warm across restarts.
 
-## Registry, resolver, and artifact surfaces
+## Registry, resolver, artifact, and pipeline surfaces {#registry-resolver-and-artifact-surfaces}
 
-pnpr exposes three independently deployable HTTP surfaces:
+pnpr exposes four independently deployable HTTP surfaces:
 
-- The **npm registry surface** — packument and tarball reads, publish,
+- The **registry surface** — package and tarball reads, publish,
   unpublish, dist-tags, and search, on the path-less base and on every
-  `/~<name>/` endpoint. It has no config toggle: it is served exactly when at
+  `/~<name>/` endpoint, for [every ecosystem](ecosystems.md) the config
+  declares. It has no config toggle: it is served exactly when at
   least one registry is declared under `registries:`. The CLI flag
   `--disable-registry` turns it off for one process.
 - The **resolver surface** — the pnpr install-accelerator routes
@@ -401,12 +441,32 @@ resolver:
 ```yaml
 artifacts:
   enabled: true
+  compilerCaches:
+    acme:
+      access: [ci-builder, alice, bob]
+      publish: ci-builder
 ```
 
-The CLI flag `--disable-artifacts` overrides this setting. With artifacts off,
-its routes are not mounted and the `GET /-/pnpr` handshake advertises an empty
-artifact-version list. The handshake itself is served when either the resolver
-or artifact surface is enabled, so an artifact-only tier is discoverable.
+  The CLI flag `--disable-artifacts` overrides this setting. With artifacts off,
+  its routes are not mounted and the `GET /-/pnpr` handshake advertises an empty
+  artifact-version list. The handshake itself is served when either the resolver
+  or artifact surface is enabled, so an artifact-only tier is discoverable.
+
+  `compilerCaches` declares the [Cargo compilation caches](compiler-cache.md)
+  this server hosts and who may read and publish to each.
+
+- The **pipeline run surface** — the endpoints that store and serve
+  [`pnpm pipeline` run records](pipeline-runs.md), a peer of the artifact store.
+  It is off by default:
+
+```yaml
+pipeline:
+  enabled: true
+  workspaces:
+    acme-app:
+      access: [team:platform]
+      publish: ci-builder
+```
 
 Something must be served: a config with no registries (or the registry
 surface disabled by flag), the resolver disabled, and artifacts disabled is a

--- a/pnpr-docs/container-images.md
+++ b/pnpr-docs/container-images.md
@@ -1,0 +1,216 @@
+---
+id: container-images
+title: Container images
+---
+
+Added in: v0.1.0-alpha.11
+
+pnpr serves the OCI distribution API, so `docker`, `podman`, and `skopeo` can
+push to and pull from the same server that hosts your packages.
+
+```yaml
+registries:
+  images:
+    type: hosted
+    ecosystem: oci
+    org: images
+    packages:
+      'acme/*': {}
+
+defaultRegistry: images
+```
+
+```sh
+printf '%s' "$PNPR_TOKEN" | docker login pnpr.example.com -u alice --password-stdin
+docker push pnpr.example.com/acme/app:1.0
+docker pull pnpr.example.com/acme/app:1.0
+skopeo copy docker://pnpr.example.com/acme/app:1.0 oci:./app:1.0
+```
+
+Use a pnpr token as the password. The username is not checked, as on every
+registry that takes a personal access token.
+
+## Why `/v2/` is at the root
+
+A client derives the API root from the image reference's host, so
+`pnpr.example.com/acme/app:1.0` always requests
+`/v2/acme/app/manifests/1.0`. `/v2/` therefore answers at the host root
+whatever else pnpr serves, and this is the one ecosystem that cannot be moved
+under a prefix. There is no reserved path segment: the image name you push is
+the image name, and the repository name alone selects the registry through the
+same declared-provenance rules every other surface uses.
+
+`/oci/v2/` and `/oci/~<name>/v2/` answer as well, for `podman` and
+`containerd`, whose `registries.conf` `location` and `hosts.toml` `server` both
+accept a path.
+
+A `packages:` key is either one repository name or `<namespace>/*`, which claims
+every repository under one leading path component. The namespace is a single
+component, so two namespace claims are either identical or disjoint. Repository
+names follow the distribution spec's grammar and are folded to lowercase, so
+`ACME/App` and `acme/app` are one repository rather than two directories on a
+case-insensitive filesystem.
+
+## Authentication
+
+`GET /v2/` answers `401` with a `Basic` challenge to an anonymous caller even
+where reads are open. A client settles its authentication scheme on that one
+response, so a `200` would leave it with no way to authenticate a later push. A
+client with no credentials carries on regardless, and a repository that admits
+anonymous reads still answers its later requests.
+
+Set `oci.bearerAuth: true` to offer a Bearer challenge instead. Clients then
+exchange their pnpr credential at `/v2/token` for a five-minute token scoped to
+`pull`, `push`, or `delete` on one repository. The endpoint grants only the
+actions the caller already has; the parent credential's revocation, read-only
+flag, and network restrictions all still apply. Anonymous tokens can pull public
+repositories. Scoped tokens reach neither the other pnpr APIs nor the whole
+catalog. Use the same [`secret:`](configuration.md#secret) and registry
+configuration on every replica so their tokens interoperate.
+
+## Uploads and limits
+
+Blobs are uploaded in one request or in chunks, streamed to disk rather than
+held in memory, and verified against the digest the client promised before
+anything is stored.
+
+```yaml
+oci:
+  maxBlobBytes: 10737418240   # 10 GiB, the default
+  maxManifestBytes: 4194304   # 4 MiB, the default
+```
+
+The blob limit applies to a whole resumable upload, mounted layers included, and
+also bounds an uncached upstream download.
+
+The manifest write is the point a release becomes visible. It goes through the
+same publish journal as every other ecosystem, so it either lands whole or
+leaves nothing behind. A blob no manifest references is invisible rather than
+half-published, which also means unreferenced blobs accumulate until they are
+collected.
+
+## What the API supports
+
+* Ranged blob downloads on filesystem and S3 storage, including open-ended and
+  suffix ranges. Responses carry `Accept-Ranges` and an ETag; `If-Range` resumes
+  a matching blob or returns the whole one. Unsupported or malformed ranges are
+  ignored.
+* Cross-repository blob mounts, reusing a layer from a repository the caller may
+  read. The caller also needs publish permission on the destination. A missing or
+  inaccessible source starts an ordinary upload. Mounts stream through local
+  scratch for digest verification rather than asking the client to resend.
+* `GET /v2/<name>/referrers/<digest>`, returning an image index of the manifests
+  and indexes attached to that subject, with the `artifactType` filter and
+  annotations. A push acknowledges its subject with `OCI-Subject`. Follow the
+  `Link` header to collect every page, even when a filtered page is empty. Each
+  page reads at most 32 manifests and 8 MiB of manifest content.
+* Pagination on `tags/list` and `_catalog` through `n` and `last`, with a `Link`
+  header when another page follows. `last` is an exclusive lexical cursor, and
+  `n=0` returns an empty list with no continuation link.
+
+## Uploads across replicas
+
+With S3 storage, upload sessions and their accepted chunks live in the bucket, so
+a client can continue an upload on another replica that shares the storage prefix
+and registry configuration. Each request stores only its new chunk. Completion
+streams the accepted chunks to local scratch for digest verification, then
+streams large blobs back to S3 in 8 MiB parts, so allow scratch space for
+concurrent requests and completed layers.
+
+Concurrent changes to one session are rejected; a client can query the session's
+current offset and retry. A session accepts up to 10,000 nonempty chunks.
+Completion freezes the chunk list and digest before promotion; if promotion
+fails, retry completion with that digest and an empty body. Frozen sessions
+reject further chunks and cancellation, and expire after 24 hours of inactivity.
+
+Startup removes upload sessions idle for more than 24 hours, chunks included. On
+a long-running deployment, restart rolling to reclaim abandoned uploads, and
+configure the bucket's lifecycle policy to abort incomplete multipart uploads as
+well, since a process killed mid-request cannot send its abort.
+
+Filesystem storage keeps upload sessions local, so every request for one session
+must reach the same instance.
+
+## Reclaiming space
+
+To collect blobs that no retained manifest references, stop **every writer**
+sharing the store and run:
+
+```sh
+pnpr -c config.yaml oci-gc --registry images --dry-run
+pnpr -c config.yaml oci-gc --registry images
+```
+
+`--registry` takes the concrete hosted OCI registry's config name. The command
+recovers the local publish journal before scanning, so recover journals on every
+replica's scratch volume before collecting shared storage, and keep writers
+stopped for the whole scan and deletion. `--dry-run` reports candidates without
+deleting them. `--min-age-secs` defaults to `86400`, which preserves recent
+uploads so an interrupted push can resume; set it to zero to collect every
+unreferenced blob.
+
+Collection keeps untagged manifests, the children of retained indexes, and their
+config and layer blobs, so removing a tag alone does not make its image
+collectible. A missing or corrupt retained manifest stops collection before any
+blob is deleted. The inventory covers unpublished repositories and nested
+repository names, and is streamed into a temporary SQLite database, so local
+temporary storage needs room for it.
+
+`DELETE /v2/<name>/blobs/<digest>` removes an unreferenced blob for a caller with
+`unpublish` permission, which the registry default denies. A blob reachable from
+any retained manifest or index is refused. A stored deletion marker blocks
+concurrent manifest publication, and a generation counter rejects publishes
+staged before the deletion. If a deletion is interrupted, stop all writers and
+run `oci-gc` without `--dry-run` to finish it and unblock the repository;
+recovering an explicit deletion ignores `--min-age-secs`. Every replica sharing a
+store must run this version before online deletion is used.
+
+## Caching Docker Hub and GHCR
+
+```yaml
+registries:
+  dockerhub:
+    type: upstream
+    ecosystem: oci
+    url: https://registry-1.docker.io/
+    public: true
+
+defaultRegistry: dockerhub
+```
+
+An official Hub image is then pulled as `pnpr.example.com/library/alpine:latest`.
+For GHCR, use `https://ghcr.io/` and the full repository name. Private origins
+use the ordinary upstream [`auth:`](configuration.md#upstream-registries)
+configuration and access rules.
+
+pnpr negotiates repository-scoped pull tokens and restricts layer redirects to
+the origin's known CDN hosts, so configured credentials never travel to a layer
+CDN. A custom origin may use a token endpoint and downloads on its own origin.
+
+Manifest bodies are verified before caching. Blob bodies are verified while
+streaming and cached only after a successful digest check; a mismatch aborts the
+response stream, and clients still verify the bytes they received. Tags refresh
+on the configured upstream cache lifetime, and digest-addressed content is
+immutable. `cache: false` disables the cache.
+
+Upstream writes, catalog enumeration, tag listing, and referrer discovery are not
+proxied.
+
+## Publishing a manifest in a batch
+
+An OCI entry in the [cross-ecosystem publish](ecosystems.md#one-publish-for-a-workspace-that-spans-ecosystems)
+publishes a manifest whose layers have already been uploaded:
+
+```json
+{
+  "ecosystem": "oci",
+  "name": "acme/app",
+  "reference": "1.0",
+  "manifest": "<base64-encoded manifest bytes>"
+}
+```
+
+`contentType` is optional when the manifest carries its own media type. An
+index's child manifests must already be published. The batch body keeps the
+endpoint's size limit, so upload large layers through the streaming `/v2/` API
+first.

--- a/pnpr-docs/discovery.md
+++ b/pnpr-docs/discovery.md
@@ -1,0 +1,76 @@
+---
+id: discovery
+title: Browsing and discovery
+---
+
+Added in: v0.1.0-alpha.11
+
+Cross-origin browser access and upstream discovery are both off by default. Turn
+them on to run a registry UI on its own origin.
+
+```yaml
+cors:
+  allowedOrigins:
+    - https://registry-ui.example.com
+
+registries:
+  local:
+    type: hosted
+    access: $all
+    packages:
+      '@example/*': {}
+  npmjs:
+    type: upstream
+    url: https://registry.npmjs.org/
+    public: true
+    search: true
+  main:
+    type: router
+    sources: [local, npmjs]
+
+defaultRegistry: main
+```
+
+An allowed origin must contain only an `http` or `https` scheme, a host, and an
+optional port. Listing an exact origin is the whole grant: there is no wildcard.
+
+The upstream `search` setting opts one registry into browser-facing search, and
+also enables `/-/org/{scope}/package` discovery for it. pnpr applies registry
+routing and access rules to the entries it returns, and uses only the upstream
+credentials from its own configuration, never a browser caller's authorization
+header. Discovery refuses redirects, and configured upstream headers are sent
+only over HTTPS or loopback HTTP. Search totals count visible, deduplicated
+results and are exact across every participating source.
+
+## Browsing without a search term
+
+```text
+GET /-/v1/search?browse=true&size=20&from=0
+GET /cargo/api/v1/crates?browse=true&per_page=20&page=1
+```
+
+`browse=true` pages through the npm packages and Cargo crates a registry hosts.
+Use the [ecosystem prefix and named registry mount](ecosystems.md#addressing-an-ecosystem)
+your server needs. Browse results follow registry routing and access rules,
+exclude upstreams and staged publications, and use the same response format and
+pagination limits as search. An empty search without `browse=true` still returns
+nothing.
+
+To bound the work one browser request can cause, pnpr rejects an upstream search
+that would scan more than 2,000 upstream results or eight upstream pages, and
+rejects an offset that would need a larger scan. Refine the search term when a
+query reaches that limit.
+
+## The registry directory
+
+`GET /-/pnpr/v0/registries` lists the named registries the caller can see. It
+returns `registries`, the visible `defaultRegistries` keyed by ecosystem, and
+the mounted `ecosystems` with their `available` and `prefixed` flags.
+
+Each entry carries its `name`, its `kind` (`hosted`, `upstream`, or `router`),
+and its `ecosystem`; the identity is the pair `(ecosystem, name)`. Concrete
+registries report their namespace `patterns` and routers their ordered
+`sources`, and either field is `null` when the caller's access rules do not
+permit disclosing it. Upstream addresses, credentials, storage paths, and
+package access rules are never returned. Responses are private and must not be
+cached.

--- a/pnpr-docs/ecosystems.md
+++ b/pnpr-docs/ecosystems.md
@@ -215,15 +215,24 @@ valid one.
 }
 ```
 
-Every entry is authorized and verified before any of them is written, and the
-write is one journaled transaction: the release either lands whole or leaves
-nothing behind, and one interrupted by a crash is finished on the next startup
-rather than staying half-published. A read that arrives while the transaction
-applies can still see part of the release.
+Every entry is authorized and verified before any of them is written. Two
+different failures follow from that, so it is worth keeping them apart.
 
-If another writer has already published one of the files, that package is left
-out and reported with `409` while the rest of the release stands: the bytes that
-won the slot are someone else's published release.
+**A batch that fails a check publishes nothing.** Authorization, validation, and
+the version-conflict check all run up front, and any entry that fails one of them
+aborts the whole batch before a byte is written.
+
+**A batch that passes its checks is committed as one journaled transaction.** It
+lands whole or leaves nothing behind, and one interrupted by a crash is finished
+on the next startup rather than staying half-published. A read that arrives while
+the transaction applies can still see part of the release.
+
+The one case that ends in a partial release is losing a write race: another
+writer publishing the same file between the check and the commit. That entry is
+left out and reported with `409` while the rest of the release stands, because
+the bytes that won the slot are someone else's published release and overwriting
+them would be the worse outcome. Republishing the batch after bumping the
+conflicting version completes the release.
 
 An [image manifest](container-images.md) whose layers are already uploaded can
 ride along in the same batch. `GET /-/pnpr` advertises support as

--- a/pnpr-docs/ecosystems.md
+++ b/pnpr-docs/ecosystems.md
@@ -1,0 +1,235 @@
+---
+id: ecosystems
+title: Cargo and Python registries
+---
+
+Added in: v0.1.0-alpha.11
+
+pnpr serves npm, Cargo, Python, and [container image](container-images.md)
+registries from one instance. Every registry declares which ecosystem it serves,
+and each ecosystem keeps its own protocol, its own routing, and its own default
+registry.
+
+## Addressing an ecosystem
+
+When more than one ecosystem is configured, a path prefix selects it:
+
+| Ecosystem | Prefix |
+| --- | --- |
+| npm | `/npm/` |
+| Cargo | `/cargo/` |
+| Python | `/pypi/` |
+| Container images | `/oci/` |
+
+`/<ecosystem>/~<name>/` addresses a named registry and `/<ecosystem>/` the
+ecosystem's default. A server that configures only one ecosystem omits the
+prefix entirely, so existing npm URLs keep working unchanged.
+
+Two things sit outside the prefixes. Container image registries answer at
+`/v2/` on the host root whatever else is configured, because a client derives
+that path from the image reference itself. And the endpoints that belong to no
+single ecosystem stay at the root: `/-/ping`, the `/-/pnpr/v0/` protocols
+(resolve, verify-lockfile, shared artifacts, pipeline runs, and the
+cross-ecosystem publish), and the account endpoints that mint and manage tokens.
+
+A `/~<name>/` prefix must arrive with a literal `~`. A percent-encoded `%7E`
+does not select the named registry. `~` is unreserved, so a conforming client
+sends it as written.
+
+## Declaring registries
+
+Give a hosted or upstream registry an `ecosystem:`; npm is the default. A router
+may list sources of every ecosystem, because a request only ever sees the
+sources that speak its own protocol, so one router can be the default target for
+all of them.
+
+```yaml
+registries:
+  local:
+    type: hosted
+    packages:
+      '@example/*': {}
+  npmjs:
+    type: upstream
+    url: https://registry.npmjs.org/
+    public: true
+  crates:
+    type: hosted
+    ecosystem: cargo
+    org: crates
+    packages:
+      my-crate: {}
+  crates-io:
+    type: upstream
+    ecosystem: cargo
+    url: https://index.crates.io/
+    public: true
+  python:
+    type: hosted
+    ecosystem: pypi
+    org: python
+    packages:
+      my-package: {}
+  pypi-org:
+    type: upstream
+    ecosystem: pypi
+    url: https://pypi.org/simple/
+    public: true
+  main:
+    type: router
+    sources: [local, npmjs, crates, crates-io, python, pypi-org]
+
+defaultRegistry: main
+```
+
+For a `cargo` upstream, `url` is a sparse index root; for `pypi`, a Simple API
+root.
+
+### Reusing a name across ecosystems
+
+Group the registries under an ecosystem key to give each protocol its own
+registry of the same name:
+
+```yaml
+registries:
+  npm:
+    internal:
+      type: hosted
+      packages:
+        '@example/*': {}
+    public:
+      type: upstream
+      url: https://registry.npmjs.org/
+      public: true
+    main:
+      type: router
+      sources: [internal, public]
+  cargo:
+    internal:
+      type: hosted
+    main:
+      type: router
+      sources: [internal]
+
+defaultRegistry:
+  npm: main
+  cargo: main
+```
+
+`/npm/~internal` and `/cargo/~internal` are then independent registries. Router
+sources resolve within their own group and cannot cross into another, and each
+ecosystem gets its own default. Access rules, teams, upstream credentials, and
+caches belong to the individual registry.
+
+A grouped hosted registry defaults to the storage namespace
+`<ecosystem>~<name>`. Set `org` explicitly to keep an existing namespace when
+moving a flat registry into a group, `org: ''` included for the flat storage
+root. Two hosted registries still cannot share a namespace. The flat
+configuration format and its shared `defaultRegistry: main` remain supported.
+
+## Cargo
+
+A Cargo registry serves a sparse index at `/cargo/index/` and the crates API at
+`/cargo/api/v1/crates/`, or under `/cargo/~<name>/...` for a named registry.
+Point `cargo` at it:
+
+```toml title=".cargo/config.toml"
+[registries.pnpr]
+index = "sparse+https://pnpr.example.com/cargo/index/"
+```
+
+`cargo publish --registry pnpr`, `cargo yank --registry pnpr`, and dependencies
+with `registry = "pnpr"` then go through pnpr. The `config.json` pnpr serves
+points downloads back at itself, so proxied crates are cached and verified
+against the upstream index checksum.
+
+Use a pnpr token as the registry token. `cargo` sends it as a bare
+`Authorization` header, and pnpr accepts that alongside `Bearer`. A registry
+that is not anonymously readable advertises `auth-required`, so `cargo` sends
+the token on index and download requests too.
+
+Crate names are compared case-insensitively, and an exact `packages:` key must
+be a valid crate name.
+
+`cargo search` works against a pnpr registry, matching on crate name over the
+crates it hosts. Each result reports the crate's newest release that is not
+yanked; a crate whose releases are all yanked reports its newest release.
+
+## Python
+
+A Python registry serves the Simple Repository API at `/pypi/simple/` (PEP 503
+HTML and PEP 691 JSON, chosen by `Accept`), files at
+`/pypi/files/<project>/<filename>`, and accepts uploads on the legacy API at
+`/pypi/legacy/`. A named registry answers under `/pypi/~<name>/...`.
+
+```sh
+pip install --index-url https://pnpr.example.com/pypi/simple/ my-package
+twine upload --repository-url https://pnpr.example.com/pypi/legacy/ dist/*
+```
+
+Use `__token__` as the username and a pnpr token as the password, the PyPI
+convention.
+
+Project names are compared PEP 503 normalized, so `My_Package`, `my.package`,
+and `my-package` are one project, and exact `packages:` keys are normalized the
+same way. Proxied files are fetched from the URL the upstream page lists,
+verified against its `sha256`, and cached. The project list at `/pypi/simple/`
+enumerates hosted projects only.
+
+## Proxying crates.io and PyPI
+
+Cargo and Python proxies restrict downloads and redirects to their configured
+upstream origin and the existing [`routes.public`](configuration.md#routes)
+allowlist. The official crates.io and PyPI upstreams also permit their download
+hosts, `static.crates.io` and `files.pythonhosted.org`. A custom registry that
+serves downloads from a separate host needs that host declared:
+
+```yaml
+routes:
+  public:
+    - registry: https://downloads.example.com/
+```
+
+Configured headers are sent only over HTTPS or loopback HTTP, and a redirect
+rebuilds its headers per destination, so configured credentials stay on the
+upstream origin. Upstream credentials are never sent to the separate host an
+index points downloads at.
+
+## One publish for a workspace that spans ecosystems
+
+`PUT /-/pnpr/v0/publish` publishes packages of any ecosystem in a single
+transaction. Each entry names its `ecosystem`, and an entry without one is an
+npm publish document, so the body the npm batch endpoint already takes is a
+valid one.
+
+```json
+{
+  "packages": [
+    { "name": "@acme/ui", "versions": {}, "_attachments": {} },
+    { "ecosystem": "cargo", "metadata": { "name": "acme", "vers": "0.1.0" },
+      "archive": "<base64 .crate>" },
+    { "ecosystem": "pypi", "name": "acme", "version": "0.1.0",
+      "filetype": "bdist_wheel", "filename": "acme-0.1.0-py3-none-any.whl",
+      "content": "<base64 wheel>" }
+  ]
+}
+```
+
+Every entry is authorized and verified before any of them is written, and the
+write is one journaled transaction: the release either lands whole or leaves
+nothing behind, and one interrupted by a crash is finished on the next startup
+rather than staying half-published. A read that arrives while the transaction
+applies can still see part of the release.
+
+If another writer has already published one of the files, that package is left
+out and reported with `409` while the rest of the release stands: the bytes that
+won the slot are someone else's published release.
+
+An [image manifest](container-images.md) whose layers are already uploaded can
+ride along in the same batch. `GET /-/pnpr` advertises support as
+`publish: [0]`. The npm-only `PUT /-/pnpm/v1/publish` stays where it is.
+
+## JSR
+
+`npm.jsr.io` is a built-in public route, like the npm registry, so JSR packages
+resolve with no configuration. The built-in routes are reachable over HTTPS only.

--- a/pnpr-docs/endpoints.md
+++ b/pnpr-docs/endpoints.md
@@ -4,20 +4,29 @@ title: HTTP endpoints
 ---
 
 pnpr exposes a set of always-on endpoints (health, user accounts, and tokens)
-plus three surfaces:
+plus four surfaces:
 
 - **Registry surface** - npm-compatible package, publish, staged-publish, and
-  team endpoints. Served exactly when at least one registry is declared under
+  team endpoints, plus the [Cargo, Python, and image](ecosystems.md) protocols.
+  Served exactly when at least one registry is declared under
   [`registries:`](configuration.md#registries-and-defaultregistry);
   `--disable-registry` turns it off for one process. On a resolver-only server
   these routes aren't mounted at all — they answer `404`, not `403`.
 - **Resolver surface** (`resolver.enabled`) - pnpr install-accelerator
   endpoints under `/-/pnpr`.
 - **Shared-artifact surface** (`artifacts.enabled`) - signed artifact publish,
-  lookup, and blob endpoints under `/-/pnpr`. It may run without the resolver.
+  lookup, and blob endpoints under `/-/pnpr`, plus the
+  [compiler cache](compiler-cache.md). It may run without the resolver.
+- **Pipeline run surface** (`pipeline.enabled`) - the
+  [`pnpm pipeline` run records](pipeline-runs.md) under `/-/pnpr`.
 
-See [Configuration](configuration.md#registry-resolver-and-artifact-surfaces) for
-the config keys and [CLI reference](cli.md) for the command-line overrides.
+See [Configuration](configuration.md#registry-resolver-and-artifact-surfaces)
+for the config keys and [CLI reference](cli.md) for the command-line overrides.
+
+The tables below show npm paths on the path-less base. Each is equally available
+under a `/~<name>/` prefix and, on a server that declares more than one
+ecosystem, under `/npm/`. Cargo, Python, and image endpoints are documented on
+their own pages.
 
 ## Always available
 
@@ -60,9 +69,6 @@ Every request routes through the registry graph:
 - Served `dist.tarball` URLs are rewritten onto the configured `public_url`
   and stay canonical for the base the client addressed (path-less or
   `/~<name>/`), so lockfiles don't bake in a registry name.
-
-The endpoint tables below show path-less shapes; each is equally available
-under a `/~<name>/` prefix.
 
 ## pnpr protocol endpoints
 
@@ -122,6 +128,33 @@ organization's name must equal the authenticated username.
 | `PUT` | `/-/pnpr/v0/artifacts` | Stores one immutable opaque signed envelope and its inline content-addressed blobs in the authenticated organization's namespace. At most eight variants per input key; a different artifact whose compatible consumers overlap an existing variant gets `409 Conflict`. |
 | `POST` | `/-/pnpr/v0/artifacts/resolve` | One batched lookup for candidate input keys. Returns at most eight signed variants per key; scanned envelope bytes plus the serialized response share one 16 MiB budget. |
 | `POST` | `/-/pnpr/v0/artifacts/blob` | Reads one owner-scoped blob by its SHA-512 integrity. |
+| `GET` `HEAD` `PUT` | `/-/pnpr/v0/compiler-cache/{cache}/{key}` | One [Cargo compilation cache](compiler-cache.md) entry, over the subset of WebDAV sccache uses. `PROPFIND` answers for virtual parent directories. Added in v0.1.0-alpha.11. |
+
+### Cross-ecosystem endpoints
+
+Added in: v0.1.0-alpha.11
+
+These belong to no single ecosystem, so they stay at the root whatever prefixes
+the server mounts.
+
+| Method | Path | Description |
+| --- | --- | --- |
+| `PUT` | `/-/pnpr/v0/publish` | [Publish packages of any ecosystem](ecosystems.md#one-publish-for-a-workspace-that-spans-ecosystems) in one journaled transaction. Advertised as `publish: [0]` in the handshake. |
+| `GET` | `/-/pnpr/v0/registries` | The [registry directory](discovery.md#the-registry-directory): the named registries, ecosystem endpoints, and routing order the caller may see. |
+
+### Pipeline run endpoints
+
+Added in: v0.1.0-alpha.11
+
+Mounted when `pipeline.enabled` is true. See
+[Pipeline run records](pipeline-runs.md).
+
+| Method | Path | Description |
+| --- | --- | --- |
+| `PUT` | `/-/pnpr/v0/pipeline/runs` | Record one run. Requires `publish` on its workspace. |
+| `GET` | `/-/pnpr/v0/pipeline/runs` | Recent run summaries, newest first. Accepts `workspace` and `limit`. |
+| `GET` | `/-/pnpr/v0/pipeline/runs/{workspace}/{run_id}` | One run's full record, event stream included. |
+| `GET` | `/-/pnpr/v0/pipeline` | A static web viewer over the two read endpoints. |
 
 ## Registry read endpoints
 
@@ -138,7 +171,8 @@ are checked against the serving registry's matching
 | `GET` | `/{name}/-/{filename}` | Unscoped tarball. |
 | `GET` | `/@scope/{name}/-/{filename}` | Scoped tarball. |
 | `GET` | `/-/package/{package}/dist-tags` | Package `dist-tags` object. Use a percent-encoded scoped package name, for example `@scope%2Fname`. |
-| `GET` | `/-/v1/search?text=<query>&size=<n>` | npm search v1 shape. Searches locally hosted packages by package-name substring; search is local-only and never proxied upstream. Results are filtered by access policy. |
+| `GET` | `/-/v1/search?text=<query>&size=<n>` | npm search v1 shape. Searches locally hosted packages by package-name substring, and, since v0.1.0-alpha.11, the upstreams that opt in with [`search: true`](discovery.md). Results are filtered by access policy. Pass `browse=true` to page through hosted packages with no search term. |
+| `GET` | `/-/org/{scope}/package` | Packages of one organization, on registries that enable discovery. Added in v0.1.0-alpha.11. |
 | `GET` | `/-/tarballs/sha512/{digest}` | Immutable artifact by its base64url SHA-512 digest, added in v0.1.0-alpha.8. See [Registry revisions](/registry-revisions). |
 
 If the client sends `Accept: application/vnd.npm.install-v1+json`, pnpr
@@ -171,7 +205,7 @@ a hosted registry.
 | --- | --- | --- |
 | `PUT` | `/{name}` | Publish an unscoped package. Body is the npm publish document with `_attachments`. Requires `publish`. |
 | `PUT` | `/@scope/{name}` | Publish a scoped package. Body is the npm publish document with `_attachments`. Requires `publish`. |
-| `PUT` | `/-/pnpm/v1/publish` | pnpm batch publish. Body is `{"packages":[<publish document>, ...]}`. The batch is all-or-nothing and each package requires `publish`. |
+| `PUT` | `/-/pnpm/v1/publish` | pnpm batch publish. Body is `{"packages":[<publish document>, ...]}`. The batch is all-or-nothing and each package requires `publish`. For a release that spans ecosystems, use [`PUT /-/pnpr/v0/publish`](ecosystems.md#one-publish-for-a-workspace-that-spans-ecosystems) instead. |
 | `PUT` | `/{package}/-rev/{rev}` | Replace a packument, used by partial unpublish. Requires both `publish` and `unpublish`. Use a percent-encoded scoped package name, for example `@scope%2Fname`. |
 | `DELETE` | `/{package}/-rev/{rev}` | Remove an entire package, used by force unpublish. Requires `unpublish`. Use a percent-encoded scoped package name for scoped packages. |
 | `DELETE` | `/{name}/-/{filename}/-rev/{rev}` | Remove an unscoped tarball. Requires `unpublish`. |

--- a/pnpr-docs/install-acceleration.md
+++ b/pnpr-docs/install-acceleration.md
@@ -62,6 +62,24 @@ For frozen restores with an already-fresh lockfile, pnpm can use
 `POST /-/pnpr/v0/verify-lockfile` to get only the server-side trust verdict
 instead of resolving again.
 
+## Cargo and Python
+
+Added in: v0.1.0-alpha.11
+
+`POST /-/pnpr/v0/resolve` takes an `ecosystem` field, so the same endpoint
+resolves [Cargo and Python](ecosystems.md) dependency graphs as well. Both are
+latency-bound in the same way npm is, and each has its own extra cost the server
+removes:
+
+- For **Cargo**, the client no longer fetches one sparse-index file per crate in
+  the graph.
+- For **Python**, the client no longer downloads a wheel to find out what it
+  requires.
+
+A `cargo.enabled` or `python.enabled` workspace with `pnprServer` set offloads
+those resolutions automatically. When the server does not serve an ecosystem's
+resolution, pnpm resolves it locally instead of failing.
+
 Since pnpr v0.1.0-alpha.9, `pnpm install --fix-lockfile` is forwarded as a
 repair request, including during filtered installs. The server regenerates
 broken lockfile metadata while retaining locked versions that remain

--- a/pnpr-docs/introduction.md
+++ b/pnpr-docs/introduction.md
@@ -4,11 +4,18 @@ title: Introduction
 slug: /
 ---
 
-**pnpr** is a pnpm-compatible npm registry server, written in Rust. It speaks the
+**pnpr** is a pnpm-compatible registry server, written in Rust. It speaks the
 npm registry protocol, so any npm-compatible client (pnpm, npm, yarn) can talk to
 it. It hosts your own packages and proxies upstream registries such as
 `registry.npmjs.org`, with its own authentication and access controls — roughly
 the role [verdaccio](https://verdaccio.org/) plays in the JavaScript ecosystem.
+
+Since v0.1.0-alpha.11, one instance can serve more than npm. It also speaks the
+Cargo and Python protocols and the [OCI distribution
+API](container-images.md), so a workspace that ships a package, a crate, a
+Python distribution, and an image can [publish all four in one
+transaction](ecosystems.md#one-publish-for-a-workspace-that-spans-ecosystems).
+Users can sign in through [OpenID Connect](oidc.md).
 
 Every registry origin pnpr serves is a declared
 [registry](configuration.md#registries-and-defaultregistry) that claims the
@@ -36,8 +43,14 @@ configuration, and APIs may change between releases.
   fan it out to a whole team through pnpr's own authentication, so clients
   never handle the upstream credential.
 - **An install accelerator** — resolve a project's dependency graph server-side
-  and hand pnpm a ready-to-use lockfile. See
-  [Install acceleration](install-acceleration.md).
+  and hand pnpm a ready-to-use lockfile, for npm, Cargo, and Python
+  dependencies alike. See [Install acceleration](install-acceleration.md).
+- **A container image registry** — push and pull with `docker`, `podman`, or
+  `skopeo`, and cache pulls from Docker Hub and GHCR. See
+  [Container images](container-images.md).
+- **A build cache** — share a [Cargo compilation cache](compiler-cache.md)
+  between CI and developer machines, and keep the
+  [run records](pipeline-runs.md) of `pnpm pipeline`.
 
 ## How it relates to pnpm
 

--- a/pnpr-docs/oidc.md
+++ b/pnpr-docs/oidc.md
@@ -1,0 +1,172 @@
+---
+id: oidc
+title: OpenID Connect
+---
+
+Added in: v0.1.0-alpha.11
+
+pnpr supports OIDC browser sign-in and keyless npm publishing from workloads
+such as GitHub Actions. Both use discovery and signed ID tokens from explicitly
+configured issuers. Local password authentication keeps working alongside them.
+
+## Browser sign-in
+
+Register a web application with your identity provider. Set its callback to
+`https://registry.example/-/oidc/company/callback`, replacing the hostname and
+`company` with your pnpr provider name, and enable the authorization code flow.
+Start pnpr with `--public-url https://registry.example`, its HTTPS origin
+without a path prefix.
+
+```yaml
+auth:
+  oidc:
+    - name: company
+      issuer: https://accounts.google.com
+      audience: your-client-id
+      login:
+        clientSecret: ${OIDC_CLIENT_SECRET}
+        users:
+          - subject: 'the-users-stable-sub-claim'
+            username: alice
+            claims:
+              hd: example.com
+```
+
+`audience` is the application's client ID. `clientSecret` can be omitted for
+providers that support public clients with PKCE. `subject` is the exact `sub`
+claim issued to this application, not an email address. Each binding maps that
+subject to a pnpr username, and the registry's existing access rules and teams
+then apply. Extra `claims` are exact string matches and all of them must match.
+There is no automatic account creation, and no linking by email.
+
+Use the issuer your provider publishes:
+
+| Provider | Issuer |
+| --- | --- |
+| Google Workspace | `https://accounts.google.com` |
+| Microsoft Entra ID | `https://login.microsoftonline.com/<tenant-id>/v2.0` |
+| Okta org authorization server | `https://<your-org>.okta.com` |
+| Okta custom authorization server | `https://<your-org>.okta.com/oauth2/<authorization-server-id>` |
+
+Use a tenant-specific Entra issuer. For Google Workspace, require the `hd` claim
+for your organization's domain, as shown above. See the provider documentation
+for [Google](https://developers.google.com/identity/openid-connect/reference),
+[Entra](https://learn.microsoft.com/en-us/entra/identity-platform/v2-protocols-oidc),
+and [Okta](https://developer.okta.com/docs/concepts/auth-servers/).
+
+Open `https://registry.example/-/oidc/company/login` in a browser. After
+sign-in, pnpr displays a token to put in the registry's `_authToken` setting,
+for example in your private user `.npmrc`:
+
+```ini
+//registry.example/:_authToken=THE_DISPLAYED_TOKEN
+```
+
+The browser session expires at the earlier of one hour or the ID token's expiry,
+and `npm logout` revokes it. Sessions live in memory and disappear on restart,
+so a multi-replica deployment needs affinity for both the login flow and the
+authenticated requests that follow. They do not appear in `npm token list`. This
+sign-in URL is separate from the npm CLI's `npm login` web protocol. An OIDC
+session cannot yet be exchanged for an [OCI scoped bearer token](container-images.md#authentication).
+
+## GitHub Actions keyless publishing
+
+Configure a dedicated workload username, a named hosted npm registry, and exact
+package names. The package's normal `publish` rule must grant that username
+access too.
+
+```yaml
+registries:
+  private:
+    type: hosted
+    packages:
+      '@example/widget':
+        publish: [release-ci]
+auth:
+  oidc:
+    - name: github
+      issuer: https://token.actions.githubusercontent.com
+      audience: https://registry.example
+      workloads:
+        - identity:
+            subject: repo:example/widgets:ref:refs/heads/main
+            username: release-ci
+            claims:
+              repository_id: '123456789'
+              repository_owner_id: '987654321'
+              workflow_ref: example/widgets/.github/workflows/release.yml@refs/heads/main
+          registry: private
+          packages: ['@example/widget']
+```
+
+Use immutable repository and owner IDs so trust does not transfer when names are
+reused. For reusable workflows, also require `job_workflow_ref` to pin the
+workflow that performs the publication. A job using a GitHub environment has an
+environment-based subject, such as
+`repo:example/widgets:environment:production`. Configure the exact subject and
+the additional claims you intend to trust. See
+[GitHub's OIDC reference](https://docs.github.com/en/actions/reference/security/oidc).
+
+The publishing job needs `id-token: write`. Request an ID token with pnpr's
+configured audience and prefix it with `pnpr_workload_` as the registry token.
+No pnpr password, persistent API key, or token exchange is involved:
+
+```yaml
+permissions:
+  contents: read
+  id-token: write
+steps:
+  # Check out, install dependencies, and build before requesting the token.
+  - name: Publish to pnpr
+    shell: bash
+    run: |
+      response=$(curl --fail --silent --show-error \
+        -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+        "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=https%3A%2F%2Fregistry.example")
+      token=$(jq -er '.value' <<< "$response")
+      echo "::add-mask::$token"
+      export NODE_AUTH_TOKEN="pnpr_workload_${token}"
+      npm publish --registry=https://registry.example/~private/
+```
+
+The project's `.npmrc` holds only the environment reference:
+
+```ini
+//registry.example/~private/:_authToken=${NODE_AUTH_TOKEN}
+```
+
+On a server with more than one ecosystem, use `/npm/~private/` in both places.
+
+The credential permits ordinary `PUT` publications to the configured packages
+through that named registry and nothing else. It cannot read packages, unpublish,
+change dist-tags separately, manage accounts, publish batches, or reach other
+pnpr services. Request the token after building so it stays valid through the
+publish request; its issuer's expiry applies to every request.
+
+## Validation and operations
+
+pnpr accepts RS256 and ES256 signatures and verifies the issuer, audience,
+authorized party where present, expiry, issue time, and not-before claims.
+Browser login also verifies a browser-bound state, a nonce, and S256 PKCE.
+Unmapped and ambiguous identities are rejected, and user subjects must be unique
+within a provider, its workload bindings included.
+
+The `pnpr_oidc_` and `pnpr_workload_` credential prefixes are reserved for OIDC,
+and workload credentials bypass the persistent token backend.
+
+Discovery and JWKS use HTTPS with redirects disabled and bounded response sizes
+and deadlines. Literal and DNS-resolved destinations must be public IP addresses,
+and OIDC requests ignore environment-configured HTTP proxies. Metadata is cached
+for five minutes, and a verification failure can trigger a refresh at most once
+every 30 seconds per provider, so an unavailable provider can never turn an
+invalid credential into anonymous access.
+
+Login state lives in a signed HttpOnly cookie for five minutes. Anonymous login
+starts reserve no server-side entries. Successful login replays and browser
+sessions are each capped at 1,024 per process, and a separate 1,024-entry
+callback-attempt history rejects recent failed and concurrent replays before
+token exchange, evicting the oldest attempt when full. At most 16 browser
+callbacks perform network operations concurrently.
+
+pnpr omits OIDC callback query strings from its request logs. Configure reverse
+proxies to omit them too.

--- a/pnpr-docs/pipeline-runs.md
+++ b/pnpr-docs/pipeline-runs.md
@@ -1,0 +1,58 @@
+---
+id: pipeline-runs
+title: Pipeline run records
+---
+
+Added in: v0.1.0-alpha.11
+
+pnpr can store the reports [`pnpm pipeline`](/cli/pipeline) produces, so a
+team's CI runs are listed and served from one place instead of living in the
+scrollback of whichever machine ran them.
+
+```yaml
+pipeline:
+  enabled: true
+  workspaces:
+    acme-app:
+      access: [team:platform]
+      publish: ci-builder
+```
+
+`access` decides who may list and read a workspace's runs, `publish` who may
+submit one. A workspace nobody may access is invisible rather than forbidden: a
+listing filters to what the caller can see, and a read of an unreadable
+workspace answers `404`.
+
+The workspace key is the identity `pnpm pipeline` derives from the workspace
+root directory. Run the command once with `--report` and read the name back from
+the listing.
+
+Records live with the hosted packages, so a run submitted through one replica is
+listed and served by every other.
+
+## Submitting a run
+
+```sh
+pnpm pipeline --report
+pnpm pipeline --report-to https://runs.example.com
+```
+
+`--report` submits to the server named by
+[`pnprServer`](install-acceleration.md#enabling-it), which also drives install
+offloading. `--report-to` names a different server, which is the better spelling
+when the server that stores runs is not the one that accelerates installs. A
+failed run is submitted before the command exits non-zero.
+
+Each submission carries a summary document and the run's event stream.
+
+## Reading runs back
+
+| Method | Path | Description |
+| --- | --- | --- |
+| `PUT` | `/-/pnpr/v0/pipeline/runs` | Record one run. Requires `publish` on the run's workspace. |
+| `GET` | `/-/pnpr/v0/pipeline/runs` | The most recent run summaries, newest first. Accepts `workspace` and `limit`. |
+| `GET` | `/-/pnpr/v0/pipeline/runs/{workspace}/{run_id}` | One run's full record, event stream included. |
+| `GET` | `/-/pnpr/v0/pipeline` | A self-contained web viewer over the two read endpoints. |
+
+The viewer is static HTML with no data of its own. The reads it issues carry the
+token the visitor pastes, so the page itself needs no authentication.

--- a/sidebars-pnpr.json
+++ b/sidebars-pnpr.json
@@ -10,11 +10,17 @@
       "items": [
         "configuration",
         "storage",
-        "auth-backends"
+        "auth-backends",
+        "oidc"
       ]
     },
+    "ecosystems",
+    "container-images",
+    "discovery",
     "install-acceleration",
     "shared-side-effects-cache",
+    "compiler-cache",
+    "pipeline-runs",
     "endpoints",
     "license"
   ]

--- a/sidebars.json
+++ b/sidebars.json
@@ -63,6 +63,7 @@
         "label": "Run scripts",
         "items": [
           "cli/run",
+          "cli/pipeline",
           "cli/test",
           "cli/exec",
           "cli/pnx",
@@ -185,6 +186,8 @@
       "registry-revisions",
       "workspaces",
       "workspace-task-orchestration",
+      "cargo",
+      "python",
       "catalogs",
       "config-dependencies",
       "aliases",

--- a/versioned_docs/version-11.x/catalogs.md
+++ b/versioned_docs/version-11.x/catalogs.md
@@ -132,6 +132,28 @@ catalogs:
     react-dom: ^18.2.0
 ```
 
+### Workspace dependencies in a catalog
+
+Added in: v11.26.0
+
+A catalog entry may hold a [`workspace:` range](./workspaces.md#workspace-protocol-workspace), so the version a workspace dependency is linked by is written once too:
+
+```yaml title="pnpm-workspace.yaml"
+catalog:
+  '@example/utils': workspace:^
+```
+
+```json title="packages/example-app/package.json"
+{
+  "name": "@example/app",
+  "dependencies": {
+    "@example/utils": "catalog:"
+  }
+}
+```
+
+pnpm expands the `catalog:` reference to `workspace:^` and then links the workspace project, exactly as if the `package.json` had declared `workspace:^` itself. On publish both protocols are replaced, so the example above ships as `"^1.4.0"` when `@example/utils` is at 1.4.0.
+
 ## Publishing
 
 The `catalog:` protocol is removed when running `pnpm publish` or `pnpm pack`. This is similar to the [`workspace:` protocol](./workspaces.md#workspace-protocol-workspace), which is [also replaced on publish](./workspaces.md#publishing-workspace-packages).

--- a/versioned_docs/version-11.x/cli/add.md
+++ b/versioned_docs/version-11.x/cli/add.md
@@ -104,6 +104,14 @@ pnpm --allow-build=esbuild add my-bundler
 
 This will run `esbuild`'s postinstall script and also add it to the `allowBuilds` field of `pnpm-workspace.yaml`. So, `esbuild` will always be allowed to run its scripts in the future.
 
+Since v11.26.0, prefixing a name with `!` denies the build instead:
+
+```
+pnpm add --allow-build=!core-js my-bundler
+```
+
+writes `allowBuilds: { core-js: false }`, so the package is never asked about again. Global installs (`pnpm add -g`) record the denial too.
+
 ### --filter &lt;package_selector\>
 
 [Read more about filtering.](../filtering.md)

--- a/versioned_docs/version-11.x/cli/approve-builds.md
+++ b/versioned_docs/version-11.x/cli/approve-builds.md
@@ -21,6 +21,8 @@ pnpm approve-builds esbuild fsevents !core-js
 
 Prefix a package name with `!` to deny it. Only mentioned packages are affected; the rest are left untouched.
 
+Since v11.26.0, a decision is saved even when nothing is awaiting approval, so a policy can be written before the package is installed. A named package that is not awaiting approval is reported with a warning rather than an error, and is not rebuilt: it may not be installed yet, and rebuilding it would need a lockfile the project may not have. An argument that names no package at all is rejected before anything is written.
+
 During install, packages with ignored builds that are not yet listed in `allowBuilds` are automatically added to `pnpm-workspace.yaml` with a placeholder value, so you can manually set them to `true` or `false`.
 
 Since v11.23.0, writing `allowBuilds` also removes `onlyBuiltDependencies`, `onlyBuiltDependenciesFile`, `neverBuiltDependencies`, and `ignoredBuiltDependencies` from `pnpm-workspace.yaml`. `allowBuilds` replaced those settings in pnpm 11 and they have been ignored since, so a workspace migrated from pnpm 10 kept them around looking active.

--- a/versioned_docs/version-11.x/cli/audit.md
+++ b/versioned_docs/version-11.x/cli/audit.md
@@ -131,6 +131,10 @@ audit:
     - GHSA-vh95-rmgr-6w4m
 ```
 
+Since v11.26.0, ignored advisories are left out of the vulnerability
+total and the per-severity counts, and reported separately. When every advisory
+found is ignored, the summary says so rather than reporting a clean audit.
+
 ### audit.ignorePrune
 
 Added in: v11.25.0

--- a/versioned_docs/version-11.x/cli/change.md
+++ b/versioned_docs/version-11.x/cli/change.md
@@ -10,6 +10,7 @@ Records a change intent: which packages a change affects, the bump type for each
 ```sh
 pnpm change [--bump <type>] [--summary <text>] [<pkg>...]
 pnpm change status
+pnpm change check
 ```
 
 Change intents are consumed later by [`pnpm version -r`](./version.md#recursive-releases). See [Release management](../versioning.md) for the whole workflow.
@@ -67,6 +68,18 @@ Release plan:
 ```
 
 The cause of each bump is one of `intent` (a change intent named the package), `dependencies` (a dependent was pulled in by propagation), `fixed` (a [fixed group](../versioning.md#fixed-groups) companion), or `epic` (an [epic](../versioning.md#epics) re-base).
+
+### check
+
+Added in: v11.26.0
+
+Validate the versions committed in the workspace against the [epic](../versioning.md#epics) bands and [fixed group](../versioning.md#fixed-groups) lockstep declared in `pnpm-workspace.yaml`.
+
+```sh
+pnpm change check
+```
+
+Unlike `pnpm change status`, which reports the release the pending intents produce, `check` looks only at the versions already in the manifests. It reads no intents, so it is the step to run on every pull request: a package whose version drifted out of its epic's band, or out of step with its fixed group, fails the command. Every violation is listed, including ones in packages the current release does not touch.
 
 ## Options
 

--- a/versioned_docs/version-11.x/cli/deploy.md
+++ b/versioned_docs/version-11.x/cli/deploy.md
@@ -7,7 +7,11 @@ Deploy a package from a workspace. During deployment, the files of the deployed 
 
 :::note
 
-By default, the deploy command only works with workspaces that have the `inject-workspace-packages` setting set to `true`. If you want to use deploy without "injected dependencies", use the `--legacy` flag or set `force-legacy-deploy` to `true`.
+Since v11.26.0, `pnpm deploy` no longer requires [`injectWorkspacePackages`](../workspaces.md#injectworkspacepackages). A linked workspace dependency is rewritten to a `file:` dependency in the dedicated deploy lockfile, and the peer dependencies it declares are bound to the deployed graph's own resolution.
+
+Where a peer resolves to more than one version in that graph, the binding is ambiguous, and the deploy fails with `ERR_PNPM_DEPLOY_AMBIGUOUS_PEER` naming the package, the peer, and the competing versions. Pin the peer to one version with an [`overrides`](../settings/dependency-resolution.md#overrides) entry, or turn `injectWorkspacePackages` on, which is the setting that decides between the candidates.
+
+Before v11.26.0 the command refused every non-injected workspace up front. `--legacy`, or `forceLegacyDeploy: true`, still selects the older implementation.
 
 :::
 

--- a/versioned_docs/version-11.x/cli/remove.md
+++ b/versioned_docs/version-11.x/cli/remove.md
@@ -33,6 +33,20 @@ Only remove the dependency from `optionalDependencies`.
 
 Only remove the dependency from `dependencies`.
 
+### --unsafe-perm
+
+Added in: v11.26.0
+
+Accepted for compatibility with `pnpm install`; see [`unsafePerm`](../settings/build.md#unsafeperm).
+
+### Supply-chain policy flags
+
+Added in: v11.26.0
+
+`pnpm remove` accepts the same policy overrides as `pnpm install` and `pnpm add`: `--trust-lockfile`, `--no-trust-lockfile`, [`--trust-policy`](../settings/dependency-resolution.md#trustpolicy), [`--trust-policy-exclude`](../settings/dependency-resolution.md#trustpolicyexclude), and [`--trust-policy-ignore-after`](../settings/dependency-resolution.md#trustpolicyignoreafter).
+
+Removing a package rewrites the lockfile, so `pnpm remove` verifies the whole lockfile against the active policies the way `pnpm install` does, not only the entries of the package being removed. [`--trust-lockfile`](../settings/dependency-resolution.md#trustlockfile) skips that pass entirely.
+
 ### --filter &lt;package_selector\>
 
 [Read more about filtering.](../filtering.md)

--- a/versioned_docs/version-11.x/cli/update.md
+++ b/versioned_docs/version-11.x/cli/update.md
@@ -63,6 +63,10 @@ Updated actions are pinned to exact commit hashes, with their release tags prese
 - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 ```
 
+Local actions are followed rather than looked up: a `./`-relative reference, and
+since v11.26.0 GitHub's self-repository spelling
+(`uses: $/.github/actions/setup`), resolve inside the repository.
+
 Checking for updates runs `git ls-remote` against every referenced repository. Actions whose refs cannot be read — for example, an action in a private repository — are skipped with a warning. If the actions are hosted on a different GitHub server (such as a GitHub Enterprise Server), set [`update.githubActionsServer`](../settings/dependency-resolution.md#updategithubactionsserver) (added in v11.17.0).
 
 ## Options
@@ -162,6 +166,12 @@ Set [`update.changeset`](../settings/dependency-resolution.md#updatechangeset) t
 Added in: v11.16.0
 
 Also update the GitHub Actions referenced by the repository's workflow files. See [Updating GitHub Actions](#updating-github-actions).
+
+### Supply-chain policy flags
+
+Added in: v11.26.0
+
+`pnpm update` accepts the same policy overrides as `pnpm install` and `pnpm add`: `--trust-lockfile`, `--no-trust-lockfile`, [`--trust-policy`](../settings/dependency-resolution.md#trustpolicy), [`--trust-policy-exclude`](../settings/dependency-resolution.md#trustpolicyexclude), and [`--trust-policy-ignore-after`](../settings/dependency-resolution.md#trustpolicyignoreafter), so a policy can be relaxed or tightened for a single run without editing `pnpm-workspace.yaml`.
 
 ### --filter &lt;package_selector\>
 

--- a/versioned_docs/version-11.x/settings/_catalogMode.mdx
+++ b/versioned_docs/version-11.x/settings/_catalogMode.mdx
@@ -11,3 +11,4 @@ Controls if and how dependencies are added to the default catalog, when running 
 - **prefer** - prefers catalog versions, but will fall back to direct dependencies if no compatible version is found.
 - **manual** (default) - does not automatically add dependencies to the catalog.
 
+Since v11.26.0, a specifier that names a location rather than a version is never moved into a catalog: local paths, local tarballs, tarball URLs, and `workspace:<path>` ranges stay in the `package.json` that declares them. Such a specifier is resolved relative to its own project, so one catalog entry could not mean the same directory for every project that references it.

--- a/versioned_docs/version-11.x/settings/_scriptShell.mdx
+++ b/versioned_docs/version-11.x/settings/_scriptShell.mdx
@@ -11,3 +11,4 @@ For instance, to force usage of Git Bash on Windows:
 pnpm config set scriptShell "C:\\Program Files\\git\\bin\\bash.exe"
 ```
 
+Since v11.26.0, a relative path in `pnpm-workspace.yaml` resolves from the workspace root, including for scripts that run in a nested package. A bare command name such as `bash` is still looked up on `PATH`.

--- a/versioned_docs/version-11.x/settings/build.md
+++ b/versioned_docs/version-11.x/settings/build.md
@@ -66,6 +66,11 @@ the setting meant before it grew a remote tier. Writing without reading
 (`read: false, write: true`) populates a cache the run never consumes, which is
 what a job that warms one for others wants.
 
+Since v11.26.0, the `--side-effects-cache` and `--no-side-effects-cache` flags, and
+`PNPM_CONFIG_SIDE_EFFECTS_CACHE`, toggle the **local** cache only. A remote tier
+declared under `sideEffectsCache.remote` is left in place, so a run can turn the
+local cache off without losing the shared one.
+
 ### sideEffectsCacheReadonly
 
 * Default: **false**

--- a/versioned_docs/version-11.x/settings/cli.md
+++ b/versioned_docs/version-11.x/settings/cli.md
@@ -162,3 +162,7 @@ nodeDownloadMirrors:
   rc: https://npmmirror.com/mirrors/node-rc/
   nightly: https://npmmirror.com/mirrors/node-nightly/
 ```
+
+Since v11.26.0, downloads from a mirror carry the npm registry credentials
+configured for that URL, including bearer tokens, basic auth, and `tokenHelper`,
+so a mirror behind an authenticating proxy works without a separate credential.

--- a/versioned_docs/version-11.x/versioning.md
+++ b/versioned_docs/version-11.x/versioning.md
@@ -102,6 +102,10 @@ With the lead on `11.x`, members occupy majors `1100`–`1199`. Members move ind
 
 Membership is matched with pnpm's package selectors: name globs, `./`-prefixed directory globs, and `!`-prefixed negations. Selectors are evaluated in order and the last one to match decides, so a later include can re-admit a package an earlier negation excluded. The lead is never a member of its own band.
 
+## Checking committed versions
+
+[`pnpm change check`](./cli/change.md#check) validates the versions already committed in the workspace against the `versioning.epics` bands and the `versioning.fixed` groups, without reading any change intent. Run it in CI, next to the lint and test steps, so a version that drifted out of its band is caught on the pull request that introduced it rather than at release time.
+
 ## Changelogs
 
 By default (`versioning.changelog.storage: registry`) no `CHANGELOG.md` is committed. Each release's section is composed at publish time and packed into the published tarball on top of the previously published version's changelog. Consumed change intents are garbage-collected by a later `pnpm version -r` only once the registry confirms the version was published with its section.

--- a/versioned_sidebars/version-12.x-sidebars.json
+++ b/versioned_sidebars/version-12.x-sidebars.json
@@ -63,6 +63,7 @@
         "label": "Run scripts",
         "items": [
           "cli/run",
+          "cli/pipeline",
           "cli/test",
           "cli/exec",
           "cli/pnx",
@@ -185,6 +186,8 @@
       "registry-revisions",
       "workspaces",
       "workspace-task-orchestration",
+      "cargo",
+      "python",
       "catalogs",
       "config-dependencies",
       "aliases",


### PR DESCRIPTION
Documents everything released since the 11.25 / 12.1 docs pass: pnpm 11.26, 12.2, 12.3, 12.4 (and the 12.4.1 patch), plus pnpr 0.1.0-alpha.10 and 0.1.0-alpha.11. pnpr's docs were current only to alpha.9.

Facts come from the composed release pages in the pnpm repo (`.changeset/changelogs/` at each tag), with the source checked for the settings, flags, and paths documented.

## Release posts

- `blog/releases/11.26.md`
- `blog/releases/12.2-12.3.md` — combined. They landed a day apart and are mostly one catch-up story; precedent is `11.21-11.22.md`.
- `blog/releases/12.4.md` — also covers 12.4.1 and pnpr alpha.11, so it is dated at those releases rather than at 12.4.0.

## New pages

| Page | Covers |
| --- | --- |
| `docs/cargo.md` | Cargo dependencies, `cargo.enabled` / `cargo.indexUrl`, vendoring, git-sourced crates |
| `docs/python.md` | Python dependencies, the managed `.venv`, `python.*` settings |
| `docs/cli/pipeline.md` | `pnpm pipeline`, task caching (`outputs`/`inputs`/`env`/`cache`/`cargoTargetDir`), `pipelines` / `pipelineBase` |
| `pnpr-docs/ecosystems.md` | Cargo and Python registries, ecosystem prefixes and groups, cross-ecosystem publish |
| `pnpr-docs/container-images.md` | The OCI surface, `oci-gc`, pull-through caching |
| `pnpr-docs/oidc.md` | Browser sign-in and GitHub Actions keyless publishing |
| `pnpr-docs/compiler-cache.md` | The sccache Cargo compilation cache |
| `pnpr-docs/pipeline-runs.md` | `pnpm pipeline` run records |
| `pnpr-docs/discovery.md` | Browser UIs, `browse=true`, the registry directory |

## Edits to existing pages

The behaviour changes, not the fix list: `workspace:` ranges in catalogs, the trust flags on `remove` and `update`, `pnpm change check`, `crate:`/`pypi:` selectors, `--allow-build=!pkg`, patched packages needing build approval, `fetchTimeout` as an inactivity timeout, registry metadata keyed by the full URL, native project-aware shims, deploy without `injectWorkspacePackages`, `linkWorkspacePackages` depth, the `packageConfigs` scope, what the `updateConfig` hook receives, the glob rules for `packages` and `--filter`, explicit values on boolean flags, and a supported-platforms table.

## Two things worth a look

- `versioned_sidebars/version-12.x-sidebars.json` is a hand-maintained copy of `sidebars.json`, and since `includeCurrentVersion` is `false` it is the one actually served. The new pages would be unreachable without syncing it, so this PR does.
- The pnpr surfaces heading now covers the pipeline surface too. It carries an explicit `{#registry-resolver-and-artifact-surfaces}` anchor so the link from the 12.1 post keeps resolving.

`pnpm build` is clean. The one broken link it reports, `/cli/pn` from `blog/releases/11.0`, predates this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HMFNHGe6AEth8RkxRhDTd8
